### PR TITLE
fix(sync): photo notice is a step + Clear Errors button/endpoint

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -233,7 +233,9 @@ async function processNewWO(wo, mapping, sfCustomerNames) {
   // Catches: prior crashed runs, parallel sync races, and SF returning a job
   // creation success that our code mis-handled.
   try {
-    const existing = await findSfJobsByPoNumber(resqRef);
+    const allMatches = await findSfJobsByPoNumber(resqRef);
+    // Ignore Cancelled jobs — they're already handled and shouldn't be linked to or counted as duplicates.
+    const existing = allMatches.filter(j => !isSfCancelled(j.status));
     if (existing.length > 0) {
       const best = pickBestSfJob(existing, null);
 
@@ -328,7 +330,9 @@ async function syncBidirectional(session, resqWO, mapEntry) {
     if (!mapEntry.reconciled) {
       try {
         const resqRef = resqWO.code.startsWith('R') ? resqWO.code : `R${resqWO.code}`;
-        const matches = await findSfJobsByPoNumber(resqRef);
+        const allMatches = await findSfJobsByPoNumber(resqRef);
+        // Skip Cancelled jobs — already handled, not duplicates.
+        const matches = allMatches.filter(j => !isSfCancelled(j.status));
         if (matches.length > 1) {
           const best = pickBestSfJob(matches, mapEntry.sfJobId);
           if (best) {
@@ -362,10 +366,9 @@ async function syncBidirectional(session, resqWO, mapEntry) {
               sfJobs: matches.map(j => ({ id: j.id, number: j.number || j.job_number || null, status: j.status, created_at: j.created_at || null })),
             });
           }
-        } else if (matches.length === 0 && mapEntry.sfJobId) {
-          // We had a mapping but SF returned no jobs with this po_number.
-          // The job may have been deleted manually, OR (more concerning) the
-          // mapping is stale.
+        } else if (allMatches.length === 0 && mapEntry.sfJobId) {
+          // No SF job at all has this po_number. Mapping points to a job that's
+          // been deleted, or the po_number was changed manually.
           result.report?.push({
             resqCode: resqWO.code,
             reason: 'no_sf_match',
@@ -562,6 +565,13 @@ async function findSfJobsByPoNumber(poNumber) {
 
 function isSfUnscheduled(status) {
   return (status || '').toLowerCase().includes('unschedul');
+}
+
+// Cancelled jobs are treated as "already handled" — never re-flagged as
+// duplicates and never re-linked to. This means cancelling a duplicate via
+// the UI immediately removes it from the next sync's report.
+function isSfCancelled(status) {
+  return (status || '').toLowerCase().includes('cancel');
 }
 
 // Whitelist of statuses that mean "actively progressed" — only these qualify

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -45,12 +45,27 @@ const RESQ_TO_SF_STATUS = {
   'CLOSED': 'Invoiced',
 };
 
+// Sync lock — prevents overlapping sync runs from creating duplicate SF jobs.
+// Cron fires every 5min; manual POST can also fire; lock TTL must cover a normal run.
+const SYNC_LOCK_KEY = 'sync-lock';
+const SYNC_LOCK_TTL_MS = 10 * 60 * 1000; // 10 min
+
 export async function handler(event) {
   const log = { started: new Date().toISOString(), steps: [], errors: [], created: 0, updated: 0 };
 
   const saveProgress = async () => {
     try { await saveBlob('last-sync', JSON.stringify(log)); } catch (x) {}
   };
+
+  // Acquire global sync lock to prevent overlapping runs from racing on SF job creation.
+  const lockAcquired = await acquireSyncLock();
+  if (!lockAcquired) {
+    log.steps.push('Skipped: another sync run is in progress (lock held)');
+    log.completed = new Date().toISOString();
+    log.skipped = true;
+    try { await saveBlob('last-sync', JSON.stringify(log)); } catch (x) {}
+    return { statusCode: 200, body: JSON.stringify({ ok: true, skipped: true }) };
+  }
 
   try {
     // 1. Connect to ResQ
@@ -118,6 +133,11 @@ export async function handler(event) {
         log.errors.push(`WO ${wo.code} failed: ${e.message}`);
       }
 
+      // Persist mapping after every WO so concurrent runs (and crash recovery)
+      // see fresh entries — closes the race window where two runs could both
+      // see a missing entry and create duplicate SF jobs.
+      await saveMapping(mapping);
+
       // Save progress every 4 WOs
       if ((i + 1) % 4 === 0) await saveProgress();
     }
@@ -139,9 +159,36 @@ export async function handler(event) {
     log.completed = new Date().toISOString();
     try { await saveBlob('last-sync', JSON.stringify(log)); } catch (x) {}
     console.error('[SYNC] Failed:', e.message);
+  } finally {
+    await releaseSyncLock();
   }
 
   return { statusCode: 200, body: JSON.stringify({ ok: true }) };
+}
+
+// --- Sync lock ---
+async function acquireSyncLock() {
+  const store = await getStore();
+  if (!store) return true; // best-effort: proceed if blobs unavailable
+  try {
+    const raw = await store.get(SYNC_LOCK_KEY);
+    if (raw) {
+      const lock = JSON.parse(raw);
+      if (lock && lock.ts && (Date.now() - lock.ts) < SYNC_LOCK_TTL_MS) {
+        return false;
+      }
+    }
+    await store.set(SYNC_LOCK_KEY, JSON.stringify({ ts: Date.now() }));
+    return true;
+  } catch (e) {
+    return true;
+  }
+}
+
+async function releaseSyncLock() {
+  const store = await getStore();
+  if (!store) return;
+  try { await store.delete(SYNC_LOCK_KEY); } catch (e) {}
 }
 
 // --- Timeout wrapper ---
@@ -169,6 +216,45 @@ async function processNewWO(wo, mapping, sfCustomerNames) {
 
   const resqRef = wo.code.startsWith('R') ? wo.code : `R${wo.code}`;
 
+  // Safety net: before creating, check SF for any existing job with this po_number.
+  // Catches: prior crashed runs, parallel sync races, and SF returning a job
+  // creation success that our code mis-handled.
+  try {
+    const existing = await findSfJobsByPoNumber(resqRef);
+    if (existing.length > 0) {
+      const best = pickBestSfJob(existing, null);
+      const hasNonUnsched = existing.some(j => !isSfUnscheduled(j.status));
+
+      // If a non-Unscheduled match exists, cancel any Unscheduled duplicates.
+      if (hasNonUnsched) {
+        for (const j of existing) {
+          if (String(j.id) === String(best.id)) continue;
+          if (isSfUnscheduled(j.status)) {
+            const c = await cancelSfJob(j.id);
+            if (c.ok) result.steps.push(`🧹 Cancelled duplicate Unscheduled SF #${j.id} for ${wo.code}`);
+            else result.errors.push(`Cancel SF #${j.id} for ${wo.code}: ${c.error}`);
+          }
+        }
+      }
+
+      mapping[wo.id] = {
+        sfJobId: best.id,
+        sfJobNumber: best.number || best.job_number || best.id,
+        resqCode: wo.code, resqStatus: wo.status,
+        sfStatus: best.status || 'Unscheduled',
+        facility: wo.facility, customer: sfCustomerKey, title: wo.title,
+        createdAt: new Date().toISOString(), lastSyncAt: new Date().toISOString(),
+        linkedExisting: true, reconciled: true,
+      };
+      result.steps.push(`🔗 Linked existing SF #${best.id} for ${wo.code} (skipped create, ${existing.length} match${existing.length === 1 ? '' : 'es'})`);
+      return result;
+    }
+  } catch (e) {
+    // Lookup failure is non-fatal — log and proceed to create. Better to risk a
+    // duplicate than skip the WO entirely.
+    result.steps.push(`po_number lookup failed for ${wo.code}: ${e.message.substring(0, 150)}`);
+  }
+
   // Create new SF job
   try {
     const sfJob = await createSfJob(wo, customerName);
@@ -183,6 +269,7 @@ async function processNewWO(wo, mapping, sfCustomerNames) {
       resqCode: wo.code, resqStatus: wo.status, sfStatus: targetSfStatus,
       facility: wo.facility, customer: sfCustomerKey, title: wo.title,
       createdAt: new Date().toISOString(), lastSyncAt: new Date().toISOString(),
+      reconciled: true,
     };
     result.created++;
     result.steps.push(`✓ Created SF #${sfJob.id} (${resqRef}) for ${wo.code} (${wo.facility})`);
@@ -197,6 +284,44 @@ async function syncBidirectional(session, resqWO, mapEntry) {
   const result = { steps: [], errors: [], updated: 0 };
 
   try {
+    // One-shot duplicate reconciliation for entries created before the
+    // duplicate-prevention fix. Runs once per WO (gated by mapEntry.reconciled).
+    if (!mapEntry.reconciled) {
+      try {
+        const resqRef = resqWO.code.startsWith('R') ? resqWO.code : `R${resqWO.code}`;
+        const matches = await findSfJobsByPoNumber(resqRef);
+        if (matches.length > 1) {
+          const hasNonUnsched = matches.some(j => !isSfUnscheduled(j.status));
+          // Per spec: only act when there's a progressed (non-Unscheduled) match.
+          // If all matches are Unscheduled, treat as "the only job" — leave alone.
+          if (hasNonUnsched) {
+            const best = pickBestSfJob(matches, mapEntry.sfJobId);
+            // Re-link mapping to the progressed job if needed.
+            if (String(best.id) !== String(mapEntry.sfJobId)) {
+              result.steps.push(`🔗 Re-linked ${resqWO.code}: SF #${mapEntry.sfJobId} → SF #${best.id} (${best.status})`);
+              mapEntry.replacedSfJobId = mapEntry.sfJobId;
+              mapEntry.sfJobId = best.id;
+              mapEntry.sfJobNumber = best.number || best.job_number || best.id;
+              mapEntry.sfStatus = best.status;
+              mapEntry.relinkedAt = new Date().toISOString();
+            }
+            // Cancel every other Unscheduled match (only Unscheduled — never touch progressed jobs).
+            for (const j of matches) {
+              if (String(j.id) === String(best.id)) continue;
+              if (isSfUnscheduled(j.status)) {
+                const c = await cancelSfJob(j.id);
+                if (c.ok) result.steps.push(`🧹 Cancelled duplicate Unscheduled SF #${j.id} for ${resqWO.code}`);
+                else result.errors.push(`Cancel duplicate SF #${j.id} for ${resqWO.code}: ${c.error}`);
+              }
+            }
+          }
+        }
+        mapEntry.reconciled = true;
+      } catch (e) {
+        result.errors.push(`Reconcile ${resqWO.code}: ${e.message.substring(0, 200)}`);
+      }
+    }
+
     // Fetch current SF job status
     let sfJob;
     try {
@@ -342,6 +467,85 @@ async function fetchSyncableWOs(session) {
         equipment: n.equipment?.name || '',
       };
     });
+}
+
+// --- SF Duplicate-prevention Helpers ---
+
+// Find all SF jobs whose po_number matches the ResQ ref. Used to:
+//   1. Avoid creating a 2nd SF job when one already exists (race-safety)
+//   2. Reconcile pre-existing duplicates: re-link mapping to the progressed
+//      job and cancel the unscheduled one(s).
+async function findSfJobsByPoNumber(poNumber) {
+  if (!poNumber) return [];
+  // Try filter first (cheaper). Fall back to scanning recent jobs if filter unsupported.
+  try {
+    const res = await sfRequest('GET', `/jobs?filters[po_number]=${encodeURIComponent(poNumber)}&per-page=50`);
+    const items = res.items || res.data || [];
+    if (items.length) {
+      // Some SF deployments ignore the filter and return all jobs; double-check po_number client-side.
+      const exact = items.filter(j => String(j.po_number || '').trim() === String(poNumber).trim());
+      if (exact.length) return exact;
+    }
+  } catch (e) { /* fall through to scan */ }
+
+  // Fallback: scan a few pages of recent jobs and match po_number client-side.
+  const matches = [];
+  for (let page = 1; page <= 3; page++) {
+    try {
+      const res = await sfRequest('GET', `/jobs?per-page=100&sort=-created_at&page=${page}`);
+      const jobs = res.items || res.data || [];
+      if (jobs.length === 0) break;
+      for (const j of jobs) {
+        if (String(j.po_number || '').trim() === String(poNumber).trim()) matches.push(j);
+      }
+    } catch (e) { break; }
+  }
+  return matches;
+}
+
+function isSfUnscheduled(status) {
+  return (status || '').toLowerCase().includes('unschedul');
+}
+
+// Pick which SF job a duplicate set should collapse to.
+// Preference order: invoiced > completed > scheduled/assigned > anything-non-unscheduled
+//   > the currently-linked one > the oldest unscheduled (last resort).
+function pickBestSfJob(jobs, currentLinkedId) {
+  if (!jobs.length) return null;
+  if (jobs.length === 1) return jobs[0];
+
+  const nonUnsched = jobs.filter(j => !isSfUnscheduled(j.status));
+  if (nonUnsched.length > 0) {
+    // Prefer the currently-linked job if it's already non-unscheduled.
+    if (currentLinkedId) {
+      const cur = nonUnsched.find(j => String(j.id) === String(currentLinkedId));
+      if (cur) return cur;
+    }
+    const order = ['invoic', 'complet', 'schedul', 'assign'];
+    for (const stage of order) {
+      const m = nonUnsched.find(j => (j.status || '').toLowerCase().includes(stage));
+      if (m) return m;
+    }
+    return nonUnsched[0];
+  }
+
+  // All unscheduled. Per spec: don't treat as duplicates — keep currently-linked or oldest.
+  if (currentLinkedId) {
+    const cur = jobs.find(j => String(j.id) === String(currentLinkedId));
+    if (cur) return cur;
+  }
+  // Oldest first (smallest id is typically oldest in SF).
+  return jobs.slice().sort((a, b) => Number(a.id) - Number(b.id))[0];
+}
+
+// Cancel an SF job (soft — set status to Cancelled, preserve history).
+async function cancelSfJob(jobId) {
+  try {
+    await sfRequest('PUT', `/jobs/${jobId}`, { status: 'Cancelled' });
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: (e.message || '').substring(0, 200) };
+  }
 }
 
 // --- SF Helpers ---

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -52,6 +52,7 @@ const SYNC_LOCK_TTL_MS = 10 * 60 * 1000; // 10 min
 
 export async function handler(event) {
   const log = { started: new Date().toISOString(), steps: [], errors: [], created: 0, updated: 0 };
+  const dedupeReport = [];
 
   const saveProgress = async () => {
     try { await saveBlob('last-sync', JSON.stringify(log)); } catch (x) {}
@@ -115,6 +116,7 @@ export async function handler(event) {
           const r = await withTimeout(syncBidirectional(session, wo, mapping[wo.id]), 30000, `sync ${wo.code}`);
           if (r.steps.length) log.steps.push(...r.steps);
           if (r.errors.length) log.errors.push(...r.errors);
+          if (r.report?.length) dedupeReport.push(...r.report);
           log.updated += r.updated || 0;
         } else {
           // New WO — skip if already done (awaiting payment, closed, etc.)
@@ -127,6 +129,7 @@ export async function handler(event) {
           const r = await withTimeout(processNewWO(wo, mapping, sfCustomerNames), 15000, `process ${wo.code}`);
           if (r.steps.length) log.steps.push(...r.steps);
           if (r.errors.length) log.errors.push(...r.errors);
+          if (r.report?.length) dedupeReport.push(...r.report);
           log.created += r.created || 0;
         }
       } catch (e) {
@@ -146,13 +149,23 @@ export async function handler(event) {
     log.completed = new Date().toISOString();
     log.mappingCount = Object.keys(mapping).length;
     log.errors = log.errors.map(e => typeof e === 'string' && e.length > 300 ? e.substring(0, 300) + '...' : e);
+    log.dedupeReportCount = dedupeReport.length;
+
+    const reportBlob = {
+      generated: new Date().toISOString(),
+      totalIssues: dedupeReport.length,
+      byReason: dedupeReport.reduce((acc, r) => { acc[r.reason] = (acc[r.reason] || 0) + 1; return acc; }, {}),
+      items: dedupeReport,
+    };
+
     await Promise.all([
       saveMapping(mapping),
       saveBlob('last-sync', JSON.stringify(log)),
       log.errors.length ? saveBlob('last-errors', JSON.stringify(log.errors)) : saveBlob('last-errors', '[]'),
+      saveBlob('dedupe-report', JSON.stringify(reportBlob)),
     ]);
 
-    console.log(`[SYNC] Done: ${log.created} created, ${log.updated} updated, ${log.errors.length} errors`);
+    console.log(`[SYNC] Done: ${log.created} created, ${log.updated} updated, ${log.errors.length} errors, ${dedupeReport.length} review items`);
 
   } catch (e) {
     log.errors.push(e.message);
@@ -201,7 +214,7 @@ function withTimeout(promise, ms, label) {
 
 // --- Process new unmapped WO ---
 async function processNewWO(wo, mapping, sfCustomerNames) {
-  const result = { steps: [], errors: [], created: 0 };
+  const result = { steps: [], errors: [], created: 0, report: [] };
   const sfCustomerKey = classifyFacility(wo.facility);
   if (!sfCustomerKey) {
     result.steps.push(`Skip ${wo.code}: "${wo.facility}" not Starbird/Melt`);
@@ -223,30 +236,56 @@ async function processNewWO(wo, mapping, sfCustomerNames) {
     const existing = await findSfJobsByPoNumber(resqRef);
     if (existing.length > 0) {
       const best = pickBestSfJob(existing, null);
-      const hasNonUnsched = existing.some(j => !isSfUnscheduled(j.status));
 
-      // If a non-Unscheduled match exists, cancel any Unscheduled duplicates.
-      if (hasNonUnsched) {
+      if (best) {
+        // A progressed match exists — link to it and cancel Unscheduled duplicates.
         for (const j of existing) {
           if (String(j.id) === String(best.id)) continue;
           if (isSfUnscheduled(j.status)) {
             const c = await cancelSfJob(j.id);
             if (c.ok) result.steps.push(`🧹 Cancelled duplicate Unscheduled SF #${j.id} for ${wo.code}`);
-            else result.errors.push(`Cancel SF #${j.id} for ${wo.code}: ${c.error}`);
+            else {
+              result.errors.push(`Cancel SF #${j.id} for ${wo.code}: ${c.error}`);
+              result.report?.push({ resqCode: wo.code, reason: 'cancel_failed', sfJobId: j.id, status: j.status, error: c.error });
+            }
           }
         }
+        mapping[wo.id] = {
+          sfJobId: best.id,
+          sfJobNumber: best.number || best.job_number || best.id,
+          resqCode: wo.code, resqStatus: wo.status,
+          sfStatus: best.status || 'Unscheduled',
+          facility: wo.facility, customer: sfCustomerKey, title: wo.title,
+          createdAt: new Date().toISOString(), lastSyncAt: new Date().toISOString(),
+          linkedExisting: true, reconciled: true,
+        };
+        result.steps.push(`🔗 Linked existing progressed SF #${best.id} (${best.status}) for ${wo.code}`);
+        return result;
       }
 
+      // No progressed match. Pick one of the existing jobs to link to (so we
+      // don't create yet another), but flag for manual review if there are
+      // multiple matches or a non-trivial status mix.
+      const fallback = existing.find(j => isSfUnscheduled(j.status)) || existing[0];
       mapping[wo.id] = {
-        sfJobId: best.id,
-        sfJobNumber: best.number || best.job_number || best.id,
+        sfJobId: fallback.id,
+        sfJobNumber: fallback.number || fallback.job_number || fallback.id,
         resqCode: wo.code, resqStatus: wo.status,
-        sfStatus: best.status || 'Unscheduled',
+        sfStatus: fallback.status || 'Unscheduled',
         facility: wo.facility, customer: sfCustomerKey, title: wo.title,
         createdAt: new Date().toISOString(), lastSyncAt: new Date().toISOString(),
         linkedExisting: true, reconciled: true,
       };
-      result.steps.push(`🔗 Linked existing SF #${best.id} for ${wo.code} (skipped create, ${existing.length} match${existing.length === 1 ? '' : 'es'})`);
+      result.steps.push(`🔗 Linked existing SF #${fallback.id} (${fallback.status}) for ${wo.code} (no progressed match)`);
+      if (existing.length > 1) {
+        result.report?.push({
+          resqCode: wo.code,
+          reason: 'duplicates_no_progressed',
+          message: `${existing.length} SF jobs match po_number=${resqRef}, none in a progressed status. Manual review needed to consolidate.`,
+          linkedTo: fallback.id,
+          sfJobs: existing.map(j => ({ id: j.id, number: j.number || j.job_number || null, status: j.status, created_at: j.created_at || null })),
+        });
+      }
       return result;
     }
   } catch (e) {
@@ -281,7 +320,7 @@ async function processNewWO(wo, mapping, sfCustomerNames) {
 
 // --- Bidirectional Status Sync ---
 async function syncBidirectional(session, resqWO, mapEntry) {
-  const result = { steps: [], errors: [], updated: 0 };
+  const result = { steps: [], errors: [], updated: 0, report: [] };
 
   try {
     // One-shot duplicate reconciliation for entries created before the
@@ -291,12 +330,9 @@ async function syncBidirectional(session, resqWO, mapEntry) {
         const resqRef = resqWO.code.startsWith('R') ? resqWO.code : `R${resqWO.code}`;
         const matches = await findSfJobsByPoNumber(resqRef);
         if (matches.length > 1) {
-          const hasNonUnsched = matches.some(j => !isSfUnscheduled(j.status));
-          // Per spec: only act when there's a progressed (non-Unscheduled) match.
-          // If all matches are Unscheduled, treat as "the only job" — leave alone.
-          if (hasNonUnsched) {
-            const best = pickBestSfJob(matches, mapEntry.sfJobId);
-            // Re-link mapping to the progressed job if needed.
+          const best = pickBestSfJob(matches, mapEntry.sfJobId);
+          if (best) {
+            // Progressed match exists — re-link mapping to it and cancel any Unscheduled duplicates.
             if (String(best.id) !== String(mapEntry.sfJobId)) {
               result.steps.push(`🔗 Re-linked ${resqWO.code}: SF #${mapEntry.sfJobId} → SF #${best.id} (${best.status})`);
               mapEntry.replacedSfJobId = mapEntry.sfJobId;
@@ -305,16 +341,37 @@ async function syncBidirectional(session, resqWO, mapEntry) {
               mapEntry.sfStatus = best.status;
               mapEntry.relinkedAt = new Date().toISOString();
             }
-            // Cancel every other Unscheduled match (only Unscheduled — never touch progressed jobs).
             for (const j of matches) {
               if (String(j.id) === String(best.id)) continue;
               if (isSfUnscheduled(j.status)) {
                 const c = await cancelSfJob(j.id);
                 if (c.ok) result.steps.push(`🧹 Cancelled duplicate Unscheduled SF #${j.id} for ${resqWO.code}`);
-                else result.errors.push(`Cancel duplicate SF #${j.id} for ${resqWO.code}: ${c.error}`);
+                else {
+                  result.errors.push(`Cancel duplicate SF #${j.id} for ${resqWO.code}: ${c.error}`);
+                  result.report?.push({ resqCode: resqWO.code, reason: 'cancel_failed', sfJobId: j.id, status: j.status, error: c.error });
+                }
               }
             }
+          } else {
+            // Multiple matches but none progressed — flag for manual review.
+            result.report?.push({
+              resqCode: resqWO.code,
+              reason: 'duplicates_no_progressed',
+              message: `${matches.length} SF jobs match po_number=${resqRef}, none in a progressed status. Manual review needed.`,
+              currentlyLinked: mapEntry.sfJobId,
+              sfJobs: matches.map(j => ({ id: j.id, number: j.number || j.job_number || null, status: j.status, created_at: j.created_at || null })),
+            });
           }
+        } else if (matches.length === 0 && mapEntry.sfJobId) {
+          // We had a mapping but SF returned no jobs with this po_number.
+          // The job may have been deleted manually, OR (more concerning) the
+          // mapping is stale.
+          result.report?.push({
+            resqCode: resqWO.code,
+            reason: 'no_sf_match',
+            message: `Mapping points to SF #${mapEntry.sfJobId} but no SF job has po_number=${resqRef}. Possibly deleted or never created.`,
+            currentlyLinked: mapEntry.sfJobId,
+          });
         }
         mapEntry.reconciled = true;
       } catch (e) {
@@ -507,35 +564,45 @@ function isSfUnscheduled(status) {
   return (status || '').toLowerCase().includes('unschedul');
 }
 
+// Whitelist of statuses that mean "actively progressed" — only these qualify
+// as a re-link target, and only their presence justifies cancelling an
+// Unscheduled duplicate. Cancelled / On Hold / unknown statuses are treated
+// like Unscheduled: never linked to, and never trigger auto-cancel.
+function isSfProgressed(status) {
+  const s = (status || '').toLowerCase().trim();
+  if (!s) return false;
+  if (s.includes('unschedul')) return false;
+  if (s.includes('cancel')) return false;
+  if (s.includes('hold')) return false;
+  return s.includes('schedul') ||   // Scheduled- Service / Re-scheduled / etc.
+         s.includes('assign') ||    // Assigned / Re-assigned
+         s.includes('dispatch') ||  // Dispatched
+         s.includes('progress') ||  // In Progress
+         s.includes('site') ||      // On Site
+         s.includes('complet') ||   // Completed- Service
+         s.includes('invoic');      // Invoiced
+}
+
 // Pick which SF job a duplicate set should collapse to.
-// Preference order: invoiced > completed > scheduled/assigned > anything-non-unscheduled
-//   > the currently-linked one > the oldest unscheduled (last resort).
+// Only ever returns a *progressed* job. Returns null when no progressed match
+// exists, signalling "leave alone — needs manual review".
 function pickBestSfJob(jobs, currentLinkedId) {
   if (!jobs.length) return null;
-  if (jobs.length === 1) return jobs[0];
+  const progressed = jobs.filter(j => isSfProgressed(j.status));
+  if (progressed.length === 0) return null;
+  if (progressed.length === 1) return progressed[0];
 
-  const nonUnsched = jobs.filter(j => !isSfUnscheduled(j.status));
-  if (nonUnsched.length > 0) {
-    // Prefer the currently-linked job if it's already non-unscheduled.
-    if (currentLinkedId) {
-      const cur = nonUnsched.find(j => String(j.id) === String(currentLinkedId));
-      if (cur) return cur;
-    }
-    const order = ['invoic', 'complet', 'schedul', 'assign'];
-    for (const stage of order) {
-      const m = nonUnsched.find(j => (j.status || '').toLowerCase().includes(stage));
-      if (m) return m;
-    }
-    return nonUnsched[0];
-  }
-
-  // All unscheduled. Per spec: don't treat as duplicates — keep currently-linked or oldest.
+  // Prefer the currently-linked job if it's already progressed.
   if (currentLinkedId) {
-    const cur = jobs.find(j => String(j.id) === String(currentLinkedId));
+    const cur = progressed.find(j => String(j.id) === String(currentLinkedId));
     if (cur) return cur;
   }
-  // Oldest first (smallest id is typically oldest in SF).
-  return jobs.slice().sort((a, b) => Number(a.id) - Number(b.id))[0];
+  const order = ['invoic', 'complet', 'progress', 'site', 'dispatch', 'assign', 'schedul'];
+  for (const stage of order) {
+    const m = progressed.find(j => (j.status || '').toLowerCase().includes(stage));
+    if (m) return m;
+  }
+  return progressed[0];
 }
 
 // Cancel an SF job (soft — set status to Cancelled, preserve history).

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -451,9 +451,11 @@ async function syncBidirectional(session, resqWO, mapEntry) {
           mapEntry.photosSent = true;
           result.updated++;
         } else if (photoResult.errors.length) {
-          // Photos exist but couldn't be auto-downloaded — don't mark as sent
-          result.steps.push(`📸 ${resqWO.code}: manual upload needed via sync.html`);
-          result.errors.push(...photoResult.errors);
+          // Photos exist but couldn't be auto-downloaded — don't mark as sent.
+          // Surface as a step (informational), NOT an error: SF doesn't expose
+          // photo download endpoints, so this is a known limitation, not a
+          // sync failure. The user uploads via the dashboard.
+          result.steps.push(`📸 ${resqWO.code}: manual upload needed via sync.html (${photoResult.errors[0]})`);
         } else {
           // No photos on the SF job at all
           result.steps.push(`No photos on SF job for ${resqWO.code}`);

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -18,6 +18,7 @@ export async function handler(event) {
   if (qs.cancelSfJob) return handleCancelSfJob(qs.cancelSfJob, qs.resqCode);
   if (qs.relink) return handleRelink(qs.relink, qs.toSfJobId);
   if (qs.dismissIssue) return handleDismissIssue(qs.dismissIssue);
+  if (qs.clearErrors) return handleClearErrors();
   if (event.httpMethod === 'GET') return handleGet();
   if (event.httpMethod === 'POST') return handlePost();
   return { statusCode: 405, body: 'GET or POST only' };
@@ -513,6 +514,39 @@ async function handleRelink(resqCode, toSfJobId) {
     } catch (e) { /* non-fatal */ }
 
     return json({ ok: true, resqCode, sfJobId: toSfJobId });
+  } catch (e) {
+    return json({ error: e.message }, 500);
+  }
+}
+
+// --- Clear errors: wipe last-errors and remove errors from the last sync log ---
+async function handleClearErrors() {
+  try {
+    const store = await getStore();
+    if (!store) return json({ error: 'Blob store not available' }, 500);
+    let cleared = 0;
+
+    // Reset last-errors to empty.
+    try {
+      const before = await store.get('last-errors').catch(() => null);
+      if (before) cleared += JSON.parse(before).length || 0;
+      await store.set('last-errors', '[]');
+    } catch (e) {}
+
+    // Strip errors out of the last-sync log so the dashboard log stops showing them.
+    try {
+      const raw = await store.get('last-sync');
+      if (raw) {
+        const log = JSON.parse(raw);
+        if (Array.isArray(log.errors)) {
+          cleared += log.errors.length;
+          log.errors = [];
+        }
+        await store.set('last-sync', JSON.stringify(log));
+      }
+    } catch (e) {}
+
+    return json({ ok: true, cleared });
   } catch (e) {
     return json({ error: e.message }, 500);
   }

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -15,6 +15,9 @@ export async function handler(event) {
   if (qs.visitPhotos) return handleVisitPhotos(event, qs.visitPhotos);
   if (qs.introspect) return handleIntrospect(qs.introspect);
   if (qs.dedupeReport) return handleDedupeReport();
+  if (qs.cancelSfJob) return handleCancelSfJob(qs.cancelSfJob, qs.resqCode);
+  if (qs.relink) return handleRelink(qs.relink, qs.toSfJobId);
+  if (qs.dismissIssue) return handleDismissIssue(qs.dismissIssue);
   if (event.httpMethod === 'GET') return handleGet();
   if (event.httpMethod === 'POST') return handlePost();
   return { statusCode: 405, body: 'GET or POST only' };
@@ -408,13 +411,13 @@ async function handleGet() {
     ]);
 
     const mapping = mappingRaw ? JSON.parse(mappingRaw) : {};
-    const dedupe = dedupeRaw ? JSON.parse(dedupeRaw) : null;
+    const dedupe = dedupeRaw ? JSON.parse(dedupeRaw) : { totalIssues: 0, items: [] };
     return json({
       lastSync: lastRunRaw ? JSON.parse(lastRunRaw) : null,
       lastErrors: lastErrorsRaw ? JSON.parse(lastErrorsRaw) : [],
       mappingCount: Object.keys(mapping).length,
       mappings: mapping,
-      dedupeReportSummary: dedupe ? { generated: dedupe.generated, totalIssues: dedupe.totalIssues, byReason: dedupe.byReason } : null,
+      dedupeReport: dedupe,
     });
   } catch (e) {
     return json({ error: e.message }, 500);
@@ -429,6 +432,123 @@ async function handleDedupeReport() {
     const raw = await store.get('dedupe-report').catch(() => null);
     if (!raw) return json({ generated: null, totalIssues: 0, items: [] });
     return json(JSON.parse(raw));
+  } catch (e) {
+    return json({ error: e.message }, 500);
+  }
+}
+
+// --- Cancel SF Job: PUT /jobs/{id} with status=Cancelled ---
+async function handleCancelSfJob(jobId, resqCode) {
+  if (!jobId) return json({ error: 'jobId required' }, 400);
+  try {
+    const { sfRequest } = await import('./sf-helpers.mjs');
+    await sfRequest('PUT', `/jobs/${jobId}`, { status: 'Cancelled' });
+
+    // Drop the cancelled job from the dedupe report so it disappears from the UI immediately.
+    const store = await getStore();
+    if (store) {
+      try {
+        const raw = await store.get('dedupe-report');
+        if (raw) {
+          const r = JSON.parse(raw);
+          for (const item of (r.items || [])) {
+            if (item.sfJobs) item.sfJobs = item.sfJobs.filter(j => String(j.id) !== String(jobId));
+          }
+          // Remove items that lose their last SF job, OR whose duplicate set drops below 2.
+          r.items = (r.items || []).filter(i => {
+            if (i.reason === 'duplicates_no_progressed') {
+              return (i.sfJobs?.length || 0) > 1;
+            }
+            if (i.reason === 'cancel_failed' && String(i.sfJobId) === String(jobId)) {
+              return false;
+            }
+            return true;
+          });
+          r.totalIssues = r.items.length;
+          r.byReason = r.items.reduce((acc, x) => { acc[x.reason] = (acc[x.reason] || 0) + 1; return acc; }, {});
+          await store.set('dedupe-report', JSON.stringify(r));
+        }
+      } catch (e) { /* non-fatal */ }
+    }
+
+    return json({ ok: true, jobId, status: 'Cancelled', resqCode });
+  } catch (e) {
+    return json({ error: e.message }, 500);
+  }
+}
+
+// --- Relink: point a mapping at a different SF job ---
+async function handleRelink(resqCode, toSfJobId) {
+  if (!resqCode || !toSfJobId) return json({ error: 'resqCode and toSfJobId required' }, 400);
+  try {
+    const store = await getStore();
+    if (!store) return json({ error: 'Blob store not available' }, 500);
+    const raw = await store.get('wo-mapping');
+    const mapping = raw ? JSON.parse(raw) : {};
+    let found = null;
+    for (const [k, v] of Object.entries(mapping)) {
+      if (v.resqCode === resqCode || k === resqCode) {
+        v.replacedSfJobId = v.sfJobId;
+        v.sfJobId = toSfJobId;
+        v.relinkedAt = new Date().toISOString();
+        v.lastSyncAt = new Date().toISOString();
+        v.reconciled = true;
+        delete v.sfDeleted;
+        found = v;
+      }
+    }
+    if (!found) return json({ error: 'No mapping found for ' + resqCode }, 404);
+    await store.set('wo-mapping', JSON.stringify(mapping));
+
+    // Drop this WO from the dedupe report — user has resolved it.
+    try {
+      const reportRaw = await store.get('dedupe-report');
+      if (reportRaw) {
+        const r = JSON.parse(reportRaw);
+        r.items = (r.items || []).filter(i => i.resqCode !== resqCode);
+        r.totalIssues = r.items.length;
+        r.byReason = r.items.reduce((acc, x) => { acc[x.reason] = (acc[x.reason] || 0) + 1; return acc; }, {});
+        await store.set('dedupe-report', JSON.stringify(r));
+      }
+    } catch (e) { /* non-fatal */ }
+
+    return json({ ok: true, resqCode, sfJobId: toSfJobId });
+  } catch (e) {
+    return json({ error: e.message }, 500);
+  }
+}
+
+// --- Dismiss: remove a WO from the report without taking action ---
+async function handleDismissIssue(resqCode) {
+  if (!resqCode) return json({ error: 'resqCode required' }, 400);
+  try {
+    const store = await getStore();
+    if (!store) return json({ error: 'Blob store not available' }, 500);
+    const raw = await store.get('dedupe-report').catch(() => null);
+    if (!raw) return json({ ok: true, dismissed: 0 });
+    const r = JSON.parse(raw);
+    const before = (r.items || []).length;
+    r.items = (r.items || []).filter(i => i.resqCode !== resqCode);
+    r.totalIssues = r.items.length;
+    r.byReason = r.items.reduce((acc, x) => { acc[x.reason] = (acc[x.reason] || 0) + 1; return acc; }, {});
+    await store.set('dedupe-report', JSON.stringify(r));
+
+    // Also mark the mapping as reconciled so the next sync doesn't re-flag it.
+    try {
+      const mappingRaw = await store.get('wo-mapping');
+      if (mappingRaw) {
+        const mapping = JSON.parse(mappingRaw);
+        for (const [k, v] of Object.entries(mapping)) {
+          if (v.resqCode === resqCode) {
+            v.reconciled = true;
+            v.dismissedAt = new Date().toISOString();
+          }
+        }
+        await store.set('wo-mapping', JSON.stringify(mapping));
+      }
+    } catch (e) { /* non-fatal */ }
+
+    return json({ ok: true, dismissed: before - r.totalIssues });
   } catch (e) {
     return json({ error: e.message }, 500);
   }

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -14,6 +14,7 @@ export async function handler(event) {
   if (qs.uploadPhoto) return handleUploadPhoto(event, qs.uploadPhoto);
   if (qs.visitPhotos) return handleVisitPhotos(event, qs.visitPhotos);
   if (qs.introspect) return handleIntrospect(qs.introspect);
+  if (qs.dedupeReport) return handleDedupeReport();
   if (event.httpMethod === 'GET') return handleGet();
   if (event.httpMethod === 'POST') return handlePost();
   return { statusCode: 405, body: 'GET or POST only' };
@@ -399,19 +400,35 @@ async function handleGet() {
     const store = await getStore();
     if (!store) return json({ error: 'Blob store not available' }, 500);
 
-    const [mappingRaw, lastRunRaw, lastErrorsRaw] = await Promise.all([
+    const [mappingRaw, lastRunRaw, lastErrorsRaw, dedupeRaw] = await Promise.all([
       store.get('wo-mapping').catch(() => null),
       store.get('last-sync').catch(() => null),
       store.get('last-errors').catch(() => null),
+      store.get('dedupe-report').catch(() => null),
     ]);
 
     const mapping = mappingRaw ? JSON.parse(mappingRaw) : {};
+    const dedupe = dedupeRaw ? JSON.parse(dedupeRaw) : null;
     return json({
       lastSync: lastRunRaw ? JSON.parse(lastRunRaw) : null,
       lastErrors: lastErrorsRaw ? JSON.parse(lastErrorsRaw) : [],
       mappingCount: Object.keys(mapping).length,
       mappings: mapping,
+      dedupeReportSummary: dedupe ? { generated: dedupe.generated, totalIssues: dedupe.totalIssues, byReason: dedupe.byReason } : null,
     });
+  } catch (e) {
+    return json({ error: e.message }, 500);
+  }
+}
+
+// --- Dedupe Report: full list of WOs that need manual review ---
+async function handleDedupeReport() {
+  try {
+    const store = await getStore();
+    if (!store) return json({ error: 'Blob store not available' }, 500);
+    const raw = await store.get('dedupe-report').catch(() => null);
+    if (!raw) return json({ generated: null, totalIssues: 0, items: [] });
+    return json(JSON.parse(raw));
   } catch (e) {
     return json({ error: e.message }, 500);
   }

--- a/public/sync.html
+++ b/public/sync.html
@@ -109,6 +109,36 @@ tr:hover td{background:#F9FAFB}
 .scan-result.ok{background:#D1FAE5;color:#065F46}
 .scan-result.err{background:#FEE2E2;color:#991B1B}
 .scan-result.pending{background:#FEF3C7;color:#92400E}
+
+/* Needs Manual Review */
+.review-section h2{display:flex;align-items:center;gap:8px}
+.review-count{display:inline-block;background:#DC2626;color:#fff;font-size:0.7rem;font-weight:700;padding:2px 8px;border-radius:10px;margin-left:auto}
+.review-count.zero{background:#10B981}
+.review-item{padding:14px 20px;border-top:1px solid #F3F4F6;display:flex;flex-direction:column;gap:8px}
+.review-item:first-child{border-top:0}
+.review-head{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+.review-head .code{font-weight:700;color:#1F2937;font-family:'JetBrains Mono',monospace}
+.review-reason{display:inline-block;padding:2px 8px;border-radius:4px;font-size:0.7rem;font-weight:600;text-transform:uppercase}
+.review-reason.dup{background:#FEF3C7;color:#92400E}
+.review-reason.no_sf_match{background:#FEE2E2;color:#991B1B}
+.review-reason.cancel_failed{background:#FEE2E2;color:#991B1B}
+.review-msg{font-size:0.82rem;color:#6B7280}
+.review-jobs{margin-top:6px;border:1px solid #E5E7EB;border-radius:6px;overflow:hidden}
+.review-job{display:flex;align-items:center;gap:10px;padding:8px 12px;font-size:0.8rem;border-top:1px solid #F3F4F6}
+.review-job:first-child{border-top:0}
+.review-job .meta{flex:1}
+.review-job .meta strong{font-family:'JetBrains Mono',monospace}
+.review-job .actions{display:flex;gap:6px}
+.review-job .linked-pill{font-size:0.65rem;background:#1F4E79;color:#fff;padding:2px 6px;border-radius:3px;font-weight:600;margin-left:6px}
+.review-btn{padding:4px 10px;font-size:0.72rem;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid;background:#fff}
+.review-btn.cancel{border-color:#FCA5A5;color:#991B1B}
+.review-btn.cancel:hover{background:#FEE2E2}
+.review-btn.link{border-color:#A7C3E8;color:#1F4E79}
+.review-btn.link:hover{background:#EFF6FF}
+.review-btn.dismiss{border-color:#D1D5DB;color:#6B7280}
+.review-btn.dismiss:hover{background:#F3F4F6}
+.review-btn:disabled{opacity:0.5;cursor:wait}
+.review-actions-row{display:flex;justify-content:flex-end;margin-top:4px}
 .scan-detail{margin-top:8px;font-size:0.78rem;color:#374151}
 .scan-detail table{width:100%;border-collapse:collapse;margin-top:6px}
 .scan-detail td,.scan-detail th{padding:4px 8px;border:1px solid #E5E7EB;font-size:0.75rem}
@@ -182,6 +212,12 @@ tr:hover td{background:#F9FAFB}
       <div id="mappingTable">
         <div class="empty">Loading...</div>
       </div>
+    </div>
+
+    <!-- Needs Manual Review -->
+    <div class="section review-section" id="reviewSection" style="display:none">
+      <h2>⚠️ Needs Manual Review <span class="review-count" id="reviewCount">0</span></h2>
+      <div id="reviewList"></div>
     </div>
 
     <!-- Sync Log -->
@@ -292,6 +328,9 @@ async function loadStatus() {
 
     // Mapping table
     renderMappings(data.mappings || {});
+
+    // Needs Manual Review
+    renderReview(data.dedupeReport || { items: [] });
 
     // Health checks (async, non-blocking)
     loadHealth();
@@ -462,6 +501,122 @@ function renderMappings(mappings) {
 
   html += '</tbody></table>';
   document.getElementById('mappingTable').innerHTML = html;
+}
+
+function renderReview(report) {
+  const items = (report && report.items) || [];
+  const section = document.getElementById('reviewSection');
+  const list = document.getElementById('reviewList');
+  const count = document.getElementById('reviewCount');
+
+  if (items.length === 0) {
+    section.style.display = 'none';
+    return;
+  }
+
+  section.style.display = 'block';
+  count.textContent = items.length;
+  count.className = 'review-count' + (items.length === 0 ? ' zero' : '');
+
+  const reasonLabel = {
+    duplicates_no_progressed: 'Duplicates',
+    no_sf_match: 'Missing SF Job',
+    cancel_failed: 'Cancel Failed',
+  };
+  const reasonClass = {
+    duplicates_no_progressed: 'dup',
+    no_sf_match: 'no_sf_match',
+    cancel_failed: 'cancel_failed',
+  };
+
+  list.innerHTML = items.map(item => {
+    const code = (item.resqCode || '').replace(/'/g, '');
+    const linkedId = item.currentlyLinked || item.linkedTo;
+    const jobsHtml = (item.sfJobs || []).map(j => {
+      const isLinked = linkedId && String(j.id) === String(linkedId);
+      const status = j.status || '—';
+      const num = j.number || j.id;
+      return `<div class="review-job">
+        <div class="meta">
+          <strong>SF #${j.id}</strong> ${num !== j.id ? `(${num})` : ''} —
+          ${statusBadge(status)}
+          ${j.created_at ? `<span style="color:#9CA3AF;font-size:0.72rem;margin-left:6px">created ${new Date(j.created_at).toLocaleDateString()}</span>` : ''}
+          ${isLinked ? '<span class="linked-pill">CURRENTLY LINKED</span>' : ''}
+        </div>
+        <div class="actions">
+          ${!isLinked ? `<button class="review-btn link" onclick="relinkTo('${code}', '${j.id}', this)">🔗 Link to this</button>` : ''}
+          <button class="review-btn cancel" onclick="cancelSfJobUI('${j.id}', '${code}', this)">🗑 Cancel SF #${j.id}</button>
+        </div>
+      </div>`;
+    }).join('');
+
+    // For cancel_failed, the item has sfJobId not sfJobs
+    const cancelFailedHtml = item.reason === 'cancel_failed'
+      ? `<div class="review-job">
+          <div class="meta">
+            <strong>SF #${item.sfJobId}</strong> — ${statusBadge(item.status || 'Unscheduled')}
+            <span style="color:#991B1B;font-size:0.72rem;margin-left:6px">last error: ${(item.error || '').substring(0, 80)}</span>
+          </div>
+          <div class="actions">
+            <button class="review-btn cancel" onclick="cancelSfJobUI('${item.sfJobId}', '${code}', this)">🗑 Retry Cancel</button>
+          </div>
+        </div>`
+      : '';
+
+    return `<div class="review-item">
+      <div class="review-head">
+        <span class="code">${item.resqCode || '—'}</span>
+        <span class="review-reason ${reasonClass[item.reason] || 'dup'}">${reasonLabel[item.reason] || item.reason}</span>
+      </div>
+      <div class="review-msg">${item.message || ''}</div>
+      <div class="review-jobs">${jobsHtml}${cancelFailedHtml}</div>
+      <div class="review-actions-row">
+        <button class="review-btn dismiss" onclick="dismissReview('${code}', this)">Dismiss (no action)</button>
+      </div>
+    </div>`;
+  }).join('');
+}
+
+async function cancelSfJobUI(jobId, resqCode, btn) {
+  if (!confirm(`Cancel SF Job #${jobId}?\n\nThis sets the SF job's status to Cancelled. The job stays in SF for history.`)) return;
+  if (btn) { btn.disabled = true; btn.textContent = '...'; }
+  try {
+    const res = await fetch(`${API_BASE}/resq-sf-sync?cancelSfJob=${encodeURIComponent(jobId)}&resqCode=${encodeURIComponent(resqCode || '')}`);
+    const data = await res.json();
+    if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+    await loadStatus();
+  } catch (e) {
+    alert(`Cancel failed: ${e.message}`);
+    if (btn) { btn.disabled = false; btn.textContent = `🗑 Cancel SF #${jobId}`; }
+  }
+}
+
+async function relinkTo(resqCode, sfJobId, btn) {
+  if (!confirm(`Re-link mapping for ${resqCode} to SF Job #${sfJobId}?\n\nFuture syncs will update this SF job instead of the current one.`)) return;
+  if (btn) { btn.disabled = true; btn.textContent = '...'; }
+  try {
+    const res = await fetch(`${API_BASE}/resq-sf-sync?relink=${encodeURIComponent(resqCode)}&toSfJobId=${encodeURIComponent(sfJobId)}`);
+    const data = await res.json();
+    if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+    await loadStatus();
+  } catch (e) {
+    alert(`Relink failed: ${e.message}`);
+    if (btn) { btn.disabled = false; btn.textContent = '🔗 Link to this'; }
+  }
+}
+
+async function dismissReview(resqCode, btn) {
+  if (!confirm(`Dismiss ${resqCode} from the review list?\n\nThis hides it from the report. The SF jobs are not changed.`)) return;
+  if (btn) { btn.disabled = true; btn.textContent = '...'; }
+  try {
+    const res = await fetch(`${API_BASE}/resq-sf-sync?dismissIssue=${encodeURIComponent(resqCode)}`);
+    const data = await res.json();
+    if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+    await loadStatus();
+  } catch (e) {
+    alert(`Dismiss failed: ${e.message}`);
+    if (btn) { btn.disabled = false; btn.textContent = 'Dismiss (no action)'; }
+  }
 }
 
 function renderLog(data) {

--- a/public/sync.html
+++ b/public/sync.html
@@ -111,9 +111,14 @@ tr:hover td{background:#F9FAFB}
 .scan-result.pending{background:#FEF3C7;color:#92400E}
 
 /* Needs Manual Review */
-.review-section h2{display:flex;align-items:center;gap:8px}
-.review-count{display:inline-block;background:#DC2626;color:#fff;font-size:0.7rem;font-weight:700;padding:2px 8px;border-radius:10px;margin-left:auto}
-.review-count.zero{background:#10B981}
+.review-section{border:2px solid #DC2626 !important}
+.review-section h2{display:flex;align-items:center;gap:8px;background:#DC2626;color:#fff;font-size:1rem;padding:14px 20px;margin:0;font-weight:700}
+.review-section.zero{border-color:#10B981 !important}
+.review-section.zero h2{background:#10B981}
+.review-stripe{height:6px;background:repeating-linear-gradient(45deg,#DC2626,#DC2626 10px,#FEE2E2 10px,#FEE2E2 20px)}
+.review-section.zero .review-stripe{background:repeating-linear-gradient(45deg,#10B981,#10B981 10px,#D1FAE5 10px,#D1FAE5 20px)}
+.review-count{display:inline-block;background:#fff;color:#DC2626;font-size:0.8rem;font-weight:700;padding:2px 10px;border-radius:10px;margin-left:auto}
+.review-section.zero .review-count{color:#065F46}
 .review-item{padding:14px 20px;border-top:1px solid #F3F4F6;display:flex;flex-direction:column;gap:8px}
 .review-item:first-child{border-top:0}
 .review-head{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
@@ -214,10 +219,11 @@ tr:hover td{background:#F9FAFB}
       </div>
     </div>
 
-    <!-- Needs Manual Review -->
-    <div class="section review-section" id="reviewSection" style="display:none">
-      <h2>⚠️ Needs Manual Review <span class="review-count" id="reviewCount">0</span></h2>
-      <div id="reviewList"></div>
+    <!-- Jobs with Sync Issues -->
+    <div class="section review-section" id="reviewSection">
+      <h2>⚠️ Jobs with Sync Issues: <span class="review-count" id="reviewCount">0</span></h2>
+      <div class="review-stripe"></div>
+      <div id="reviewList"><div class="empty" style="padding:20px;color:#9CA3AF">Loading...</div></div>
     </div>
 
     <!-- Sync Log -->
@@ -509,13 +515,13 @@ function renderReview(report) {
   const list = document.getElementById('reviewList');
   const count = document.getElementById('reviewCount');
 
-  // Always visible so users can confirm the section loaded and see the all-clear state.
+  // Always visible. Red border + stripe when there are issues, green when clear.
   section.style.display = 'block';
+  section.className = 'section review-section' + (items.length === 0 ? ' zero' : '');
   count.textContent = items.length;
-  count.className = 'review-count' + (items.length === 0 ? ' zero' : '');
 
   if (items.length === 0) {
-    list.innerHTML = `<div class="empty" style="padding:20px;color:#059669">
+    list.innerHTML = `<div class="empty" style="padding:20px;color:#059669;font-weight:600">
       ✓ All clear — no work orders need manual review.
     </div>`;
     return;

--- a/public/sync.html
+++ b/public/sync.html
@@ -209,6 +209,7 @@ tr:hover td{background:#F9FAFB}
     <div class="actions">
       <button class="primary" id="syncBtn" onclick="runSync()">▶ Run Sync Now</button>
       <button class="secondary" onclick="loadStatus()">↻ Refresh Status</button>
+      <button class="secondary" id="clearErrBtn" onclick="clearErrors()">🧹 Clear Errors</button>
     </div>
 
     <!-- Mapping Table -->
@@ -428,6 +429,24 @@ async function runSync() {
     btn.disabled = false;
     btn.innerHTML = '▶ Run Sync Now';
   }
+}
+
+// --- Clear stored errors (last-errors blob + errors in last-sync log) ---
+async function clearErrors() {
+  if (!confirm('Clear all stored sync errors? This wipes the error log without changing any sync data — new errors will reappear on the next sync if they recur.')) return;
+  const btn = document.getElementById('clearErrBtn');
+  btn.disabled = true;
+  btn.innerHTML = '<span class="spinner"></span>Clearing...';
+  try {
+    const res = await fetch(`${API_BASE}/resq-sf-sync?clearErrors=1`);
+    const data = await res.json();
+    if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+    await loadStatus();
+  } catch (e) {
+    alert(`Clear failed: ${e.message}`);
+  }
+  btn.disabled = false;
+  btn.innerHTML = '🧹 Clear Errors';
 }
 
 // --- Clear (delete) a mapping entry ---

--- a/public/sync.html
+++ b/public/sync.html
@@ -509,14 +509,17 @@ function renderReview(report) {
   const list = document.getElementById('reviewList');
   const count = document.getElementById('reviewCount');
 
-  if (items.length === 0) {
-    section.style.display = 'none';
-    return;
-  }
-
+  // Always visible so users can confirm the section loaded and see the all-clear state.
   section.style.display = 'block';
   count.textContent = items.length;
   count.className = 'review-count' + (items.length === 0 ? ' zero' : '');
+
+  if (items.length === 0) {
+    list.innerHTML = `<div class="empty" style="padding:20px;color:#059669">
+      ✓ All clear — no work orders need manual review.
+    </div>`;
+    return;
+  }
 
   const reasonLabel = {
     duplicates_no_progressed: 'Duplicates',


### PR DESCRIPTION
## Summary

Reduces error noise on the sync dashboard and adds a way to wipe stored errors on demand.

- **Photo "manual upload needed" is no longer an error.** SF doesn't expose photo download endpoints, so requiring manual upload via `sync.html` is a known design limitation, not a sync failure. Reclassified from `errors.push` to `steps.push`. Detail is preserved.
- **New `?clearErrors=1` endpoint** — wipes `last-errors` blob and strips errors out of the `last-sync` log.
- **New 🧹 Clear Errors button** in the action bar (next to Run Sync / Refresh).

## Not included (need diagnosis)

- `Save ROW R0951419/R0931634: ResQ GQL ValidationError` — real ResQ API rejection on `saveRecordOfWork`. Truncated message — need full validation error to know which field's wrong.
- `Create SF job for R0929414: 422 customer_name not found` — the SF customer name in `SF_CUSTOMERS` (`STARBIRD CHICKEN: RESQ`, `THE MELT RESQ`, `BRIX BEVERAGE: RESQ`) doesn't match what's in SF anymore. Will need to update the mapping once we know the new name.

https://claude.ai/code/session_015tNiKZoMrY6uhLVHRM56Fp

---
_Generated by [Claude Code](https://claude.ai/code/session_015tNiKZoMrY6uhLVHRM56Fp)_