### PR TITLE
Make ResQ codes and SF Job #s clickable on sync page

### DIFF
--- a/public/sync.html
+++ b/public/sync.html
@@ -45,6 +45,8 @@ table{width:100%;border-collapse:collapse;font-size:0.82rem}
 th{background:#F9FAFB;text-align:left;padding:10px 16px;font-weight:600;color:#6B7280;text-transform:uppercase;font-size:0.7rem;letter-spacing:0.5px}
 td{padding:10px 16px;border-top:1px solid #F3F4F6}
 tr:hover td{background:#F9FAFB}
+td a,.review-head .code a,.review-job .meta a{color:#1F4E79;text-decoration:none;border-bottom:1px dotted #1F4E79}
+td a:hover,.review-head .code a:hover,.review-job .meta a:hover{color:#2E75B6;border-bottom-color:#2E75B6}
 
 .badge{display:inline-block;padding:2px 8px;border-radius:4px;font-size:0.7rem;font-weight:600;text-transform:uppercase}
 .badge.unscheduled{background:#FEF3C7;color:#92400E}
@@ -510,11 +512,13 @@ function renderMappings(mappings) {
       ? `<button class="expense-btn" onclick="openExpense('${sfJob}','${m.resqCode || ''}')">💰 Bill</button>`
       : '—';
 
+    const resqLink = resqLinkHtml(resqId, m.resqCode);
+    const sfLink = sfLinkHtml(m.sfJobId, m.sfJobNumber);
     html += `<tr>
-      <td><strong>${m.resqCode || '—'}</strong></td>
+      <td>${resqLink}</td>
       <td>${(m.title || '').substring(0, 50)}</td>
       <td>${m.facility || '—'}</td>
-      <td>${m.sfJobNumber || m.sfJobId || '—'}</td>
+      <td>${sfLink}</td>
       <td>${resqBadge}</td>
       <td>${sfBadge}</td>
       <td>${photoBtn}</td>
@@ -565,9 +569,10 @@ function renderReview(report) {
       const isLinked = linkedId && String(j.id) === String(linkedId);
       const status = j.status || '—';
       const num = j.number || j.id;
+      const sfHref = `https://admin.servicefusion.com/jobs/view/${encodeURIComponent(j.id)}`;
       return `<div class="review-job">
         <div class="meta">
-          <strong>SF #${j.id}</strong> ${num !== j.id ? `(${num})` : ''} —
+          <a href="${sfHref}" target="_blank" rel="noopener" title="Open in Service Fusion"><strong>SF #${j.id}</strong></a> ${num !== j.id ? `(${num})` : ''} —
           ${statusBadge(status)}
           ${j.created_at ? `<span style="color:#9CA3AF;font-size:0.72rem;margin-left:6px">created ${new Date(j.created_at).toLocaleDateString()}</span>` : ''}
           ${isLinked ? '<span class="linked-pill">CURRENTLY LINKED</span>' : ''}
@@ -580,10 +585,11 @@ function renderReview(report) {
     }).join('');
 
     // For cancel_failed, the item has sfJobId not sfJobs
+    const cancelFailedHref = item.sfJobId ? `https://admin.servicefusion.com/jobs/view/${encodeURIComponent(item.sfJobId)}` : '';
     const cancelFailedHtml = item.reason === 'cancel_failed'
       ? `<div class="review-job">
           <div class="meta">
-            <strong>SF #${item.sfJobId}</strong> — ${statusBadge(item.status || 'Unscheduled')}
+            <a href="${cancelFailedHref}" target="_blank" rel="noopener" title="Open in Service Fusion"><strong>SF #${item.sfJobId}</strong></a> — ${statusBadge(item.status || 'Unscheduled')}
             <span style="color:#991B1B;font-size:0.72rem;margin-left:6px">last error: ${(item.error || '').substring(0, 80)}</span>
           </div>
           <div class="actions">
@@ -592,9 +598,12 @@ function renderReview(report) {
         </div>`
       : '';
 
+    const resqHref = item.resqCode || item.resqId
+      ? `https://app.getresq.com/work-orders/${encodeURIComponent(item.resqId || item.resqCode)}`
+      : '';
     return `<div class="review-item">
       <div class="review-head">
-        <span class="code">${item.resqCode || '—'}</span>
+        <span class="code">${resqHref ? `<a href="${resqHref}" target="_blank" rel="noopener" title="Open in ResQ">${item.resqCode || '—'}</a>` : (item.resqCode || '—')}</span>
         <span class="review-reason ${reasonClass[item.reason] || 'dup'}">${reasonLabel[item.reason] || item.reason}</span>
       </div>
       <div class="review-msg">${item.message || ''}</div>
@@ -659,6 +668,21 @@ function renderLog(data) {
   }
   html += `<span class="info">Completed: ${data.completed || '?'} | Created: ${data.created || 0} | Updated: ${data.updated || 0}</span>`;
   document.getElementById('syncLog').innerHTML = html;
+}
+
+// External deep links to ResQ + Service Fusion ticket detail pages
+function resqLinkHtml(resqId, resqCode) {
+  const label = resqCode || '—';
+  if (!resqId && !resqCode) return `<strong>—</strong>`;
+  const target = resqId || resqCode;
+  const url = `https://app.getresq.com/work-orders/${encodeURIComponent(target)}`;
+  return `<a href="${url}" target="_blank" rel="noopener" title="Open in ResQ"><strong>${label}</strong></a>`;
+}
+function sfLinkHtml(sfJobId, sfJobNumber) {
+  const label = sfJobNumber || sfJobId || '—';
+  if (!sfJobId) return label;
+  const url = `https://admin.servicefusion.com/jobs/view/${encodeURIComponent(sfJobId)}`;
+  return `<a href="${url}" target="_blank" rel="noopener" title="Open in Service Fusion">${label}</a>`;
 }
 
 function statusBadge(status) {


### PR DESCRIPTION
## Summary
- ResQ Code column on the sync dashboard now links to `https://app.getresq.com/work-orders/{id}` (new tab)
- SF Job # column links to `https://admin.servicefusion.com/jobs/view/{id}` (new tab)
- Same links applied in the "Jobs with Sync Issues" review section so each duplicate / candidate SF job is one click away

## Heads-up on URL formats
The ResQ web app uses `app.getresq.com` and Service Fusion uses `admin.servicefusion.com` (both confirmed from existing code in `resq-helpers.mjs` and `sf-oauth-callback.mjs`). The path segments (`/work-orders/{id}` and `/jobs/view/{id}`) are best-guess based on the typical URL patterns for those products — please click through one or two and confirm they land on the right ticket. If either pattern is wrong, it's a one-line tweak in `resqLinkHtml` / `sfLinkHtml` near the top of the script block in `public/sync.html`.

## Test plan
- [ ] Open the sync dashboard, verify the ResQ code in the mapping table is now a link
- [ ] Click a ResQ code — should open the work order in ResQ in a new tab
- [ ] Click an SF Job # — should open the job in Service Fusion in a new tab
- [ ] Confirm the same links work in the "Jobs with Sync Issues" red box

https://claude.ai/code/session_01F2SHfYP1w9MCa9v6Dq4Z6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2SHfYP1w9MCa9v6Dq4Z6e)_