### PR TITLE
Require Supabase JWT + superadmin role on Netlify functions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -33,4 +33,4 @@
   [headers.values]
     Access-Control-Allow-Origin = "*"
     Access-Control-Allow-Methods = "GET, POST, OPTIONS"
-    Access-Control-Allow-Headers = "Content-Type"
+    Access-Control-Allow-Headers = "Content-Type, Authorization"

--- a/netlify/functions/approve-bill.mjs
+++ b/netlify/functions/approve-bill.mjs
@@ -1,5 +1,6 @@
 import { qboRequest, qboQuery, corsHeaders } from './qbo-helpers.mjs';
 import { sendEmail, confirmationEmailHtml, APPROVAL_EMAIL } from './email-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
@@ -9,6 +10,9 @@ export async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, headers: corsHeaders(), body: JSON.stringify({ error: 'POST only' }) };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
 
   try {
     const payload = JSON.parse(event.body);

--- a/netlify/functions/create-invoice.mjs
+++ b/netlify/functions/create-invoice.mjs
@@ -1,4 +1,5 @@
 import { qboRequest, corsHeaders } from './qbo-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
@@ -8,6 +9,9 @@ export async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, headers: corsHeaders(), body: JSON.stringify({ error: 'POST only' }) };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
 
   try {
     const payload = JSON.parse(event.body);

--- a/netlify/functions/create-vendor.mjs
+++ b/netlify/functions/create-vendor.mjs
@@ -1,4 +1,5 @@
 import { qboRequest, corsHeaders } from './qbo-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
@@ -8,6 +9,9 @@ export async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, headers: corsHeaders(), body: JSON.stringify({ error: 'POST only' }) };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
 
   try {
     const { displayName, companyName, email, phone } = JSON.parse(event.body);

--- a/netlify/functions/expense-to-bill.mjs
+++ b/netlify/functions/expense-to-bill.mjs
@@ -11,6 +11,7 @@
 
 import { sfRequest } from './sf-helpers.mjs';
 import { qboRequest, qboQuery, corsHeaders } from './qbo-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 const ACCOUNT_MAP = {
   equipment: { id: '42', name: 'Equipment Sales COGS' },
@@ -31,6 +32,9 @@ export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 200, headers: corsHeaders(), body: '' };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
 
   const qs = event.queryStringParameters || {};
 

--- a/netlify/functions/get-customers.mjs
+++ b/netlify/functions/get-customers.mjs
@@ -1,9 +1,14 @@
 import { qboQuery, corsHeaders } from './qbo-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 200, headers: corsHeaders(), body: '' };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
   try {
     let all = [];
     let start = 1;

--- a/netlify/functions/get-departments.mjs
+++ b/netlify/functions/get-departments.mjs
@@ -1,9 +1,14 @@
 import { qboQuery, corsHeaders } from './qbo-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 200, headers: corsHeaders(), body: '' };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
   try {
     const result = await qboQuery(
       `SELECT Id, Name FROM Department WHERE Active = true ORDERBY Name MAXRESULTS 200`

--- a/netlify/functions/get-vendors.mjs
+++ b/netlify/functions/get-vendors.mjs
@@ -1,9 +1,13 @@
 import { qboQuery, corsHeaders } from './qbo-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 200, headers: corsHeaders(), body: '' };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
 
   try {
     const result = await qboQuery(

--- a/netlify/functions/health-watchdog.mjs
+++ b/netlify/functions/health-watchdog.mjs
@@ -3,6 +3,7 @@
 // Sends alert email only when something is wrong
 
 import { qboQuery } from './qbo-helpers.mjs';
+import { requireScheduledOrAuth } from './lib/auth.mjs';
 import { sfRequest } from './sf-helpers.mjs';
 import { resqLogin, resqGql } from './resq-helpers.mjs';
 import { sendEmail, APPROVAL_EMAIL } from './email-helpers.mjs';
@@ -254,7 +255,11 @@ function buildAlertEmail(results, timestamp) {
 
 // ── Main handler ──
 
-export default async function handler(req) {
+export default async function handler(req, context) {
+  // Allow Netlify scheduler OR authenticated superadmin only.
+  const auth = await requireScheduledOrAuth(req, context);
+  if (!auth.ok) return auth.response;
+
   // Handle GET requests — return last health check result (or live with ?refresh=1)
   if (req.method === 'GET') {
     const url = new URL(req.url);
@@ -297,7 +302,7 @@ export default async function handler(req) {
       headers: {
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'GET, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
       },
     });
   }

--- a/netlify/functions/lib/auth.mjs
+++ b/netlify/functions/lib/auth.mjs
@@ -1,0 +1,142 @@
+// Auth helpers for Netlify functions.
+//
+// Verifies the Supabase JWT from Authorization: Bearer <token> and rejects
+// requests without a valid superadmin role. Reads role from app_metadata.role
+// (server-controlled, not user-tamperable).
+//
+// Two handler styles are supported:
+//   - v1 legacy:  export async function handler(event) { ... }   (event.headers is plain object)
+//   - v2 modern:  export default async (req, context) => { ... } (req.headers is Headers instance)
+//
+// Usage (v1):
+//   const auth = await requireAuth(event);
+//   if (!auth.ok) return auth.response;
+//
+// Usage (v2):
+//   const auth = await requireAuth(req);
+//   if (!auth.ok) return auth.response;
+//
+// Both return { ok, response?, user?, role?, jwt? }.
+
+const SUPABASE_URL =
+  process.env.SUPABASE_URL || 'https://gfsdpwiqzshhexkofiif.supabase.co';
+const SUPABASE_ANON_KEY =
+  process.env.SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdmc2Rwd2lxenNoaGV4a29maWlmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU1OTUyMzcsImV4cCI6MjA5MTE3MTIzN30.AygnPJwQ5NfIeKwPtkO6tgVYmkV3MAxL1lMFwN9HPnY';
+
+const DEFAULT_ROLES = ['superadmin'];
+
+const ERR_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+
+function isV2(reqOrEvent) {
+  return typeof reqOrEvent?.headers?.get === 'function';
+}
+
+function getAuthHeader(reqOrEvent) {
+  if (isV2(reqOrEvent)) return reqOrEvent.headers.get('authorization') || '';
+  const h = reqOrEvent?.headers || {};
+  return h.authorization || h.Authorization || '';
+}
+
+function makeError(reqOrEvent, status, message) {
+  const body = JSON.stringify({ error: message });
+  if (isV2(reqOrEvent)) {
+    return new Response(body, { status, headers: ERR_HEADERS });
+  }
+  return { statusCode: status, headers: ERR_HEADERS, body };
+}
+
+export async function requireAuth(reqOrEvent, allowedRoles = DEFAULT_ROLES) {
+  // Internal-cron bypass: cron functions invoke handlers in-process with this flag.
+  // Synthetic-event field; not settable from an external HTTP request.
+  if (reqOrEvent && reqOrEvent._internalCron === true) {
+    return { ok: true, user: null, role: 'cron', jwt: null, scheduled: true };
+  }
+
+  const authHeader = getAuthHeader(reqOrEvent);
+  const m = /^Bearer\s+(.+)$/i.exec(String(authHeader).trim());
+  if (!m) {
+    return {
+      ok: false,
+      response: makeError(reqOrEvent, 401, 'Missing Authorization bearer token'),
+    };
+  }
+  const jwt = m[1];
+
+  let user;
+  try {
+    const res = await fetch(`${SUPABASE_URL}/auth/v1/user`, {
+      headers: {
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${jwt}`,
+      },
+    });
+    if (!res.ok) {
+      return {
+        ok: false,
+        response: makeError(reqOrEvent, 401, 'Invalid or expired token'),
+      };
+    }
+    user = await res.json();
+  } catch (e) {
+    return {
+      ok: false,
+      response: makeError(reqOrEvent, 503, 'Auth service unavailable'),
+    };
+  }
+
+  if (!user || !user.id) {
+    return { ok: false, response: makeError(reqOrEvent, 401, 'Invalid token') };
+  }
+
+  const role = user.app_metadata?.role || null;
+  if (allowedRoles && !allowedRoles.includes(role)) {
+    return {
+      ok: false,
+      response: makeError(
+        reqOrEvent,
+        403,
+        `Forbidden — role "${role || 'none'}" not allowed`
+      ),
+    };
+  }
+
+  return { ok: true, user, role, jwt };
+}
+
+// Cron-only gate. Use in scheduled functions to reject manual HTTP hits.
+// Netlify v2 runtime sets context.next_run / context.scheduled_time for scheduled invocations.
+export function requireScheduled(_req, context) {
+  const isScheduled = !!(
+    context?.next_run ||
+    context?.scheduledTime ||
+    context?.scheduled_time
+  );
+  if (isScheduled) return { ok: true, scheduled: true };
+  return {
+    ok: false,
+    response: new Response(
+      JSON.stringify({ error: 'Forbidden — cron-only endpoint' }),
+      { status: 403, headers: ERR_HEADERS }
+    ),
+  };
+}
+
+// Either scheduled invocation (Netlify cron) or authenticated superadmin.
+export async function requireScheduledOrAuth(
+  req,
+  context,
+  allowedRoles = DEFAULT_ROLES
+) {
+  const isScheduled = !!(
+    context?.next_run ||
+    context?.scheduledTime ||
+    context?.scheduled_time
+  );
+  if (isScheduled) return { ok: true, scheduled: true };
+  return requireAuth(req, allowedRoles);
+}

--- a/netlify/functions/master-health-cron.mjs
+++ b/netlify/functions/master-health-cron.mjs
@@ -3,8 +3,13 @@
 // Sends alert email if any site is failing
 
 import { runMasterHealthChecks } from './lib/master-health-core.mjs';
+import { requireScheduled } from './lib/auth.mjs';
 
-export default async function handler() {
+export default async function handler(req, context) {
+  // Reject manual HTTP hits — only the Netlify scheduler may invoke.
+  const gate = requireScheduled(req, context);
+  if (!gate.ok) return gate.response;
+
   console.log('[master-health-cron] Running scheduled cross-site health check');
   const payload = await runMasterHealthChecks();
   return new Response(JSON.stringify(payload), {

--- a/netlify/functions/master-health.mjs
+++ b/netlify/functions/master-health.mjs
@@ -2,11 +2,12 @@
 // Returns cached results or runs live cross-site health checks
 
 import { runMasterHealthChecks } from './lib/master-health-core.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 const CORS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
   'Content-Type': 'application/json',
 };
 
@@ -32,6 +33,9 @@ export default async function handler(req) {
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: CORS });
   }
+
+  const auth = await requireAuth(req);
+  if (!auth.ok) return auth.response;
 
   // Try cached result first (unless ?refresh=1)
   const url = new URL(req.url);

--- a/netlify/functions/onboard-customer.mjs
+++ b/netlify/functions/onboard-customer.mjs
@@ -2,6 +2,11 @@ import { corsHeaders } from './qbo-helpers.mjs';
 import { createToken } from './token-helpers.mjs';
 import { sendEmail, SITE_URL } from './email-helpers.mjs';
 
+// SECURITY TODO: this endpoint is hit by an external QuestionScout webhook,
+// so Supabase user auth doesn't apply. It still needs HMAC signature verification
+// against a shared secret to prevent unauthenticated callers from forging
+// onboarding requests (which create QBO customers and send approval emails).
+
 // Approval recipients for customer/vendor onboarding
 const ONBOARD_EMAILS = ['service@brixbev.com', 'invoicing@brixbev.com'];
 

--- a/netlify/functions/pacer-health.mjs
+++ b/netlify/functions/pacer-health.mjs
@@ -2,6 +2,8 @@
 // Tests QBO and Zoho MCP endpoints server-side (no CORS issues)
 // Called by control dashboard frontend
 
+import { requireAuth } from './lib/auth.mjs';
+
 const MCP_KEY = process.env.MCP_API_KEY || process.env.QBO_PROXY_KEY;
 const PACER_BASE = 'https://pacerfinance.netlify.app';
 
@@ -47,6 +49,9 @@ async function checkEndpoint(path, toolName) {
 }
 
 export async function handler(event) {
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
   const results = {
     qbo: await checkEndpoint('/qbo', 'QuickBooks'),
     zoho: await checkEndpoint('/zoho', 'Zoho'),

--- a/netlify/functions/process-inbound.mjs
+++ b/netlify/functions/process-inbound.mjs
@@ -2,6 +2,11 @@ import { corsHeaders } from './qbo-helpers.mjs';
 import { createToken } from './token-helpers.mjs';
 import { sendEmail, approvalEmailHtml, APPROVAL_EMAIL, SITE_URL } from './email-helpers.mjs';
 
+// SECURITY TODO: this endpoint is hit by an external email-forwarding webhook,
+// so Supabase user auth doesn't apply. It still needs HMAC signature verification
+// against a shared secret to prevent unauthenticated callers from forging inbound
+// emails (which trigger approval emails and create signed bill-approval tokens).
+
 // This function receives inbound emails via webhook from your email service
 // (SendGrid Inbound Parse, Mailgun Routes, or custom forwarding)
 //

--- a/netlify/functions/qbo-helpers.mjs
+++ b/netlify/functions/qbo-helpers.mjs
@@ -186,7 +186,7 @@ export function corsHeaders() {
   return {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     'Content-Type': 'application/json',
   };
 }

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -17,6 +17,7 @@
 
 import { resqLogin, resqGql } from './resq-helpers.mjs';
 import { sfRequest } from './sf-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 const BRIX_VENDOR_KEYWORDS = ['brix'];
 
@@ -51,6 +52,9 @@ const SYNC_LOCK_KEY = 'sync-lock';
 const SYNC_LOCK_TTL_MS = 10 * 60 * 1000; // 10 min
 
 export async function handler(event) {
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
   const log = { started: new Date().toISOString(), steps: [], errors: [], created: 0, updated: 0 };
   const dedupeReport = [];
 

--- a/netlify/functions/resq-sf-sync-cron.mjs
+++ b/netlify/functions/resq-sf-sync-cron.mjs
@@ -2,12 +2,17 @@
 // Calls the background worker directly (same process, no HTTP)
 
 import { handler as bgHandler } from './resq-sf-sync-background.mjs';
+import { requireScheduled } from './lib/auth.mjs';
 
-export default async (req) => {
+export default async (req, context) => {
+  // Reject manual HTTP hits to this URL — only the Netlify scheduler may invoke.
+  const gate = requireScheduled(req, context);
+  if (!gate.ok) return gate.response;
+
   console.log('[CRON] ResQ↔SF sync starting...');
 
   try {
-    await bgHandler({ httpMethod: 'POST' });
+    await bgHandler({ httpMethod: 'POST', _internalCron: true });
     console.log('[CRON] Sync complete');
     return new Response(JSON.stringify({ ok: true }), {
       status: 200,

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -2,10 +2,15 @@
 // GET  → returns sync status/mapping from blobs (fast)
 // POST → kicks off background function, returns 202 immediately
 
+import { requireAuth } from './lib/auth.mjs';
+
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 204, headers: corsHeaders() };
   }
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+  event._authJwt = auth.jwt;
   const qs = event.queryStringParameters || {};
   if (qs.lookup) return handleLookup(qs.lookup);
   if (qs.sfPhotos) return handleSfPhotos(qs.sfPhotos);
@@ -20,7 +25,7 @@ export async function handler(event) {
   if (qs.dismissIssue) return handleDismissIssue(qs.dismissIssue);
   if (qs.clearErrors) return handleClearErrors();
   if (event.httpMethod === 'GET') return handleGet();
-  if (event.httpMethod === 'POST') return handlePost();
+  if (event.httpMethod === 'POST') return handlePost(event);
   return { statusCode: 405, body: 'GET or POST only' };
 }
 
@@ -589,7 +594,7 @@ async function handleDismissIssue(resqCode) {
 }
 
 // --- POST: Write "running" marker, invoke background function ---
-async function handlePost() {
+async function handlePost(event) {
   try {
     // Write a "running" marker so the dashboard shows sync in progress
     const store = await getStore();
@@ -610,11 +615,13 @@ async function handlePost() {
     // and continue running for up to 15 minutes
     const siteUrl = process.env.URL || 'https://apbg-billing.netlify.app';
     const bgUrl = `${siteUrl}/.netlify/functions/resq-sf-sync-background`;
+    const bgHeaders = { 'Content-Type': 'application/json' };
+    if (event?._authJwt) bgHeaders.Authorization = `Bearer ${event._authJwt}`;
     let bgStatus = 'unknown';
     try {
       const bgRes = await fetch(bgUrl, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: bgHeaders,
         body: JSON.stringify({ trigger: 'manual', ts: Date.now() }),
       });
       bgStatus = `${bgRes.status}`;
@@ -654,7 +661,7 @@ function corsHeaders() {
   return {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
   };
 }
 

--- a/netlify/functions/sf-fix-numbers.mjs
+++ b/netlify/functions/sf-fix-numbers.mjs
@@ -4,8 +4,12 @@
 // GET ?action=link  — link found matches to ResQ mapping + remove duplicates
 
 import { sfRequest } from './sf-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
   const qs = event.queryStringParameters || {};
 
   // Quick lookup

--- a/netlify/functions/sf-token-debug.mjs
+++ b/netlify/functions/sf-token-debug.mjs
@@ -1,7 +1,11 @@
 // Diagnostic: check SF token blob state + test blob read/write
 import { getStore } from '@netlify/blobs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
   const results = {};
 
   // 1. Check blob store


### PR DESCRIPTION
## Summary
Adds server-side Supabase JWT + role auth to every state-changing Netlify function. Closes the external-attacker hole where unauthenticated callers could hit `/.netlify/functions/...` URLs directly and create QBO bills, cancel SF jobs, delete mappings, etc.

## What changed
**New `netlify/functions/lib/auth.mjs`:**
- `requireAuth(reqOrEvent)` — verifies `Authorization: Bearer <jwt>` against Supabase `/auth/v1/user`, requires `app_metadata.role === 'superadmin'` (the secure metadata field, not user-tamperable `user_metadata`)
- `requireScheduled(req, context)` — only allows Netlify scheduler invocations
- `requireScheduledOrAuth(req, context)` — for endpoints that are both scheduled and user-callable
- Internal-cron bypass via synthetic `event._internalCron` flag for in-process cron→bg calls

**Wrapped (require superadmin JWT):** `resq-sf-sync`, `resq-sf-sync-background`, `expense-to-bill`, `approve-bill`, `create-invoice`, `create-vendor`, `get-customers`, `get-departments`, `get-vendors`, `pacer-health`, `sf-fix-numbers`, `sf-token-debug`, `health-watchdog`, `master-health`

**Cron-only (reject manual HTTP hits):** `resq-sf-sync-cron`, `master-health-cron`

**Left public (intentionally):** `oauth-callback`, `sf-oauth-callback` (OAuth redirect targets), `approve-customer`, `decode-token` (already token-gated via signed tokens)

**Flagged with SECURITY TODO (separate PR):** `onboard-customer`, `process-inbound` — these are external webhooks (QuestionScout / email forwarder) so Supabase user auth doesn't apply. They need HMAC signature verification against a shared secret.

**CORS:** added `Authorization` to `Access-Control-Allow-Headers` in `netlify.toml`, `qbo-helpers.corsHeaders`, `resq-sf-sync.corsHeaders`, `master-health`, and `health-watchdog`.

**Dispatcher → bg JWT forwarding:** `resq-sf-sync.handlePost` forwards the caller's JWT to the background function HTTP call so the bg's own auth check passes.

## ⚠️ Breaking change
This PR by itself **breaks the dashboard UIs** (`sync.html`, `control.html`, `approve.html`, `setup.html`) — they don't send `Authorization` headers yet, so all API calls will return 401. That's the follow-up PR (PR B), which replaces the client-side password gates with real Supabase Auth and wires the bearer header into every `fetch()`.

**Two options for landing:**
- (a) Hold this as draft, build PR B, merge both together (zero downtime)
- (b) Merge this immediately to lock down the security hole, accept that admin UIs are broken until PR B lands (probably ~hours, not days)

Recommendation: (a) unless you want the security boundary up _right now_.

## Background context
Earlier in this session I migrated `auth.users` so every account now has `app_metadata.role` populated (was previously only in `user_metadata`, which is user-modifiable via `auth.updateUser()`). That migration is what makes this PR's authz check secure.

## Test plan
- [ ] Deploy preview builds without errors
- [ ] Once PR B is in: `curl -X POST .../resq-sf-sync` without auth → 401
- [ ] `curl` with valid superadmin JWT → 200 + sync runs
- [ ] `curl` with valid `user`-role JWT → 403
- [ ] `curl /resq-sf-sync-cron` (no auth, no schedule) → 403
- [ ] Netlify scheduler still triggers cron syncs successfully

https://claude.ai/code/session_01F2SHfYP1w9MCa9v6Dq4Z6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2SHfYP1w9MCa9v6Dq4Z6e)_