### PR TITLE
Wire dashboards to Supabase Auth + send bearer on every API call

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -33,4 +33,4 @@
   [headers.values]
     Access-Control-Allow-Origin = "*"
     Access-Control-Allow-Methods = "GET, POST, OPTIONS"
-    Access-Control-Allow-Headers = "Content-Type"
+    Access-Control-Allow-Headers = "Content-Type, Authorization"

--- a/netlify/functions/approve-bill.mjs
+++ b/netlify/functions/approve-bill.mjs
@@ -1,5 +1,6 @@
 import { qboRequest, qboQuery, corsHeaders } from './qbo-helpers.mjs';
 import { sendEmail, confirmationEmailHtml, APPROVAL_EMAIL } from './email-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
@@ -9,6 +10,9 @@ export async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, headers: corsHeaders(), body: JSON.stringify({ error: 'POST only' }) };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
 
   try {
     const payload = JSON.parse(event.body);

--- a/netlify/functions/create-invoice.mjs
+++ b/netlify/functions/create-invoice.mjs
@@ -1,4 +1,5 @@
 import { qboRequest, corsHeaders } from './qbo-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
@@ -8,6 +9,9 @@ export async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, headers: corsHeaders(), body: JSON.stringify({ error: 'POST only' }) };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
 
   try {
     const payload = JSON.parse(event.body);

--- a/netlify/functions/create-vendor.mjs
+++ b/netlify/functions/create-vendor.mjs
@@ -1,4 +1,5 @@
 import { qboRequest, corsHeaders } from './qbo-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
@@ -8,6 +9,9 @@ export async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, headers: corsHeaders(), body: JSON.stringify({ error: 'POST only' }) };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
 
   try {
     const { displayName, companyName, email, phone } = JSON.parse(event.body);

--- a/netlify/functions/expense-to-bill.mjs
+++ b/netlify/functions/expense-to-bill.mjs
@@ -11,6 +11,7 @@
 
 import { sfRequest } from './sf-helpers.mjs';
 import { qboRequest, qboQuery, corsHeaders } from './qbo-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 const ACCOUNT_MAP = {
   equipment: { id: '42', name: 'Equipment Sales COGS' },
@@ -31,6 +32,9 @@ export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 200, headers: corsHeaders(), body: '' };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
 
   const qs = event.queryStringParameters || {};
 

--- a/netlify/functions/get-customers.mjs
+++ b/netlify/functions/get-customers.mjs
@@ -1,9 +1,14 @@
 import { qboQuery, corsHeaders } from './qbo-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 200, headers: corsHeaders(), body: '' };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
   try {
     let all = [];
     let start = 1;

--- a/netlify/functions/get-departments.mjs
+++ b/netlify/functions/get-departments.mjs
@@ -1,9 +1,14 @@
 import { qboQuery, corsHeaders } from './qbo-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 200, headers: corsHeaders(), body: '' };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
   try {
     const result = await qboQuery(
       `SELECT Id, Name FROM Department WHERE Active = true ORDERBY Name MAXRESULTS 200`

--- a/netlify/functions/get-vendors.mjs
+++ b/netlify/functions/get-vendors.mjs
@@ -1,9 +1,13 @@
 import { qboQuery, corsHeaders } from './qbo-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 200, headers: corsHeaders(), body: '' };
   }
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
 
   try {
     const result = await qboQuery(

--- a/netlify/functions/health-watchdog.mjs
+++ b/netlify/functions/health-watchdog.mjs
@@ -3,6 +3,7 @@
 // Sends alert email only when something is wrong
 
 import { qboQuery } from './qbo-helpers.mjs';
+import { requireScheduledOrAuth } from './lib/auth.mjs';
 import { sfRequest } from './sf-helpers.mjs';
 import { resqLogin, resqGql } from './resq-helpers.mjs';
 import { sendEmail, APPROVAL_EMAIL } from './email-helpers.mjs';
@@ -254,7 +255,11 @@ function buildAlertEmail(results, timestamp) {
 
 // ── Main handler ──
 
-export default async function handler(req) {
+export default async function handler(req, context) {
+  // Allow Netlify scheduler OR authenticated superadmin only.
+  const auth = await requireScheduledOrAuth(req, context);
+  if (!auth.ok) return auth.response;
+
   // Handle GET requests — return last health check result (or live with ?refresh=1)
   if (req.method === 'GET') {
     const url = new URL(req.url);
@@ -297,7 +302,7 @@ export default async function handler(req) {
       headers: {
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'GET, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
       },
     });
   }

--- a/netlify/functions/lib/auth.mjs
+++ b/netlify/functions/lib/auth.mjs
@@ -1,0 +1,142 @@
+// Auth helpers for Netlify functions.
+//
+// Verifies the Supabase JWT from Authorization: Bearer <token> and rejects
+// requests without a valid superadmin role. Reads role from app_metadata.role
+// (server-controlled, not user-tamperable).
+//
+// Two handler styles are supported:
+//   - v1 legacy:  export async function handler(event) { ... }   (event.headers is plain object)
+//   - v2 modern:  export default async (req, context) => { ... } (req.headers is Headers instance)
+//
+// Usage (v1):
+//   const auth = await requireAuth(event);
+//   if (!auth.ok) return auth.response;
+//
+// Usage (v2):
+//   const auth = await requireAuth(req);
+//   if (!auth.ok) return auth.response;
+//
+// Both return { ok, response?, user?, role?, jwt? }.
+
+const SUPABASE_URL =
+  process.env.SUPABASE_URL || 'https://gfsdpwiqzshhexkofiif.supabase.co';
+const SUPABASE_ANON_KEY =
+  process.env.SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdmc2Rwd2lxenNoaGV4a29maWlmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU1OTUyMzcsImV4cCI6MjA5MTE3MTIzN30.AygnPJwQ5NfIeKwPtkO6tgVYmkV3MAxL1lMFwN9HPnY';
+
+const DEFAULT_ROLES = ['superadmin'];
+
+const ERR_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+
+function isV2(reqOrEvent) {
+  return typeof reqOrEvent?.headers?.get === 'function';
+}
+
+function getAuthHeader(reqOrEvent) {
+  if (isV2(reqOrEvent)) return reqOrEvent.headers.get('authorization') || '';
+  const h = reqOrEvent?.headers || {};
+  return h.authorization || h.Authorization || '';
+}
+
+function makeError(reqOrEvent, status, message) {
+  const body = JSON.stringify({ error: message });
+  if (isV2(reqOrEvent)) {
+    return new Response(body, { status, headers: ERR_HEADERS });
+  }
+  return { statusCode: status, headers: ERR_HEADERS, body };
+}
+
+export async function requireAuth(reqOrEvent, allowedRoles = DEFAULT_ROLES) {
+  // Internal-cron bypass: cron functions invoke handlers in-process with this flag.
+  // Synthetic-event field; not settable from an external HTTP request.
+  if (reqOrEvent && reqOrEvent._internalCron === true) {
+    return { ok: true, user: null, role: 'cron', jwt: null, scheduled: true };
+  }
+
+  const authHeader = getAuthHeader(reqOrEvent);
+  const m = /^Bearer\s+(.+)$/i.exec(String(authHeader).trim());
+  if (!m) {
+    return {
+      ok: false,
+      response: makeError(reqOrEvent, 401, 'Missing Authorization bearer token'),
+    };
+  }
+  const jwt = m[1];
+
+  let user;
+  try {
+    const res = await fetch(`${SUPABASE_URL}/auth/v1/user`, {
+      headers: {
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${jwt}`,
+      },
+    });
+    if (!res.ok) {
+      return {
+        ok: false,
+        response: makeError(reqOrEvent, 401, 'Invalid or expired token'),
+      };
+    }
+    user = await res.json();
+  } catch (e) {
+    return {
+      ok: false,
+      response: makeError(reqOrEvent, 503, 'Auth service unavailable'),
+    };
+  }
+
+  if (!user || !user.id) {
+    return { ok: false, response: makeError(reqOrEvent, 401, 'Invalid token') };
+  }
+
+  const role = user.app_metadata?.role || null;
+  if (allowedRoles && !allowedRoles.includes(role)) {
+    return {
+      ok: false,
+      response: makeError(
+        reqOrEvent,
+        403,
+        `Forbidden — role "${role || 'none'}" not allowed`
+      ),
+    };
+  }
+
+  return { ok: true, user, role, jwt };
+}
+
+// Cron-only gate. Use in scheduled functions to reject manual HTTP hits.
+// Netlify v2 runtime sets context.next_run / context.scheduled_time for scheduled invocations.
+export function requireScheduled(_req, context) {
+  const isScheduled = !!(
+    context?.next_run ||
+    context?.scheduledTime ||
+    context?.scheduled_time
+  );
+  if (isScheduled) return { ok: true, scheduled: true };
+  return {
+    ok: false,
+    response: new Response(
+      JSON.stringify({ error: 'Forbidden — cron-only endpoint' }),
+      { status: 403, headers: ERR_HEADERS }
+    ),
+  };
+}
+
+// Either scheduled invocation (Netlify cron) or authenticated superadmin.
+export async function requireScheduledOrAuth(
+  req,
+  context,
+  allowedRoles = DEFAULT_ROLES
+) {
+  const isScheduled = !!(
+    context?.next_run ||
+    context?.scheduledTime ||
+    context?.scheduled_time
+  );
+  if (isScheduled) return { ok: true, scheduled: true };
+  return requireAuth(req, allowedRoles);
+}

--- a/netlify/functions/master-health-cron.mjs
+++ b/netlify/functions/master-health-cron.mjs
@@ -3,8 +3,13 @@
 // Sends alert email if any site is failing
 
 import { runMasterHealthChecks } from './lib/master-health-core.mjs';
+import { requireScheduled } from './lib/auth.mjs';
 
-export default async function handler() {
+export default async function handler(req, context) {
+  // Reject manual HTTP hits — only the Netlify scheduler may invoke.
+  const gate = requireScheduled(req, context);
+  if (!gate.ok) return gate.response;
+
   console.log('[master-health-cron] Running scheduled cross-site health check');
   const payload = await runMasterHealthChecks();
   return new Response(JSON.stringify(payload), {

--- a/netlify/functions/master-health.mjs
+++ b/netlify/functions/master-health.mjs
@@ -2,11 +2,12 @@
 // Returns cached results or runs live cross-site health checks
 
 import { runMasterHealthChecks } from './lib/master-health-core.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 const CORS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
   'Content-Type': 'application/json',
 };
 
@@ -32,6 +33,9 @@ export default async function handler(req) {
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: CORS });
   }
+
+  const auth = await requireAuth(req);
+  if (!auth.ok) return auth.response;
 
   // Try cached result first (unless ?refresh=1)
   const url = new URL(req.url);

--- a/netlify/functions/onboard-customer.mjs
+++ b/netlify/functions/onboard-customer.mjs
@@ -2,6 +2,11 @@ import { corsHeaders } from './qbo-helpers.mjs';
 import { createToken } from './token-helpers.mjs';
 import { sendEmail, SITE_URL } from './email-helpers.mjs';
 
+// SECURITY TODO: this endpoint is hit by an external QuestionScout webhook,
+// so Supabase user auth doesn't apply. It still needs HMAC signature verification
+// against a shared secret to prevent unauthenticated callers from forging
+// onboarding requests (which create QBO customers and send approval emails).
+
 // Approval recipients for customer/vendor onboarding
 const ONBOARD_EMAILS = ['service@brixbev.com', 'invoicing@brixbev.com'];
 

--- a/netlify/functions/pacer-health.mjs
+++ b/netlify/functions/pacer-health.mjs
@@ -2,6 +2,8 @@
 // Tests QBO and Zoho MCP endpoints server-side (no CORS issues)
 // Called by control dashboard frontend
 
+import { requireAuth } from './lib/auth.mjs';
+
 const MCP_KEY = process.env.MCP_API_KEY || process.env.QBO_PROXY_KEY;
 const PACER_BASE = 'https://pacerfinance.netlify.app';
 
@@ -47,6 +49,9 @@ async function checkEndpoint(path, toolName) {
 }
 
 export async function handler(event) {
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
   const results = {
     qbo: await checkEndpoint('/qbo', 'QuickBooks'),
     zoho: await checkEndpoint('/zoho', 'Zoho'),

--- a/netlify/functions/process-inbound.mjs
+++ b/netlify/functions/process-inbound.mjs
@@ -2,6 +2,11 @@ import { corsHeaders } from './qbo-helpers.mjs';
 import { createToken } from './token-helpers.mjs';
 import { sendEmail, approvalEmailHtml, APPROVAL_EMAIL, SITE_URL } from './email-helpers.mjs';
 
+// SECURITY TODO: this endpoint is hit by an external email-forwarding webhook,
+// so Supabase user auth doesn't apply. It still needs HMAC signature verification
+// against a shared secret to prevent unauthenticated callers from forging inbound
+// emails (which trigger approval emails and create signed bill-approval tokens).
+
 // This function receives inbound emails via webhook from your email service
 // (SendGrid Inbound Parse, Mailgun Routes, or custom forwarding)
 //

--- a/netlify/functions/qbo-helpers.mjs
+++ b/netlify/functions/qbo-helpers.mjs
@@ -186,7 +186,7 @@ export function corsHeaders() {
   return {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     'Content-Type': 'application/json',
   };
 }

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -17,6 +17,7 @@
 
 import { resqLogin, resqGql } from './resq-helpers.mjs';
 import { sfRequest } from './sf-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 const BRIX_VENDOR_KEYWORDS = ['brix'];
 
@@ -51,6 +52,9 @@ const SYNC_LOCK_KEY = 'sync-lock';
 const SYNC_LOCK_TTL_MS = 10 * 60 * 1000; // 10 min
 
 export async function handler(event) {
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
   const log = { started: new Date().toISOString(), steps: [], errors: [], created: 0, updated: 0 };
   const dedupeReport = [];
 

--- a/netlify/functions/resq-sf-sync-cron.mjs
+++ b/netlify/functions/resq-sf-sync-cron.mjs
@@ -2,12 +2,17 @@
 // Calls the background worker directly (same process, no HTTP)
 
 import { handler as bgHandler } from './resq-sf-sync-background.mjs';
+import { requireScheduled } from './lib/auth.mjs';
 
-export default async (req) => {
+export default async (req, context) => {
+  // Reject manual HTTP hits to this URL — only the Netlify scheduler may invoke.
+  const gate = requireScheduled(req, context);
+  if (!gate.ok) return gate.response;
+
   console.log('[CRON] ResQ↔SF sync starting...');
 
   try {
-    await bgHandler({ httpMethod: 'POST' });
+    await bgHandler({ httpMethod: 'POST', _internalCron: true });
     console.log('[CRON] Sync complete');
     return new Response(JSON.stringify({ ok: true }), {
       status: 200,

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -2,10 +2,15 @@
 // GET  → returns sync status/mapping from blobs (fast)
 // POST → kicks off background function, returns 202 immediately
 
+import { requireAuth } from './lib/auth.mjs';
+
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 204, headers: corsHeaders() };
   }
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+  event._authJwt = auth.jwt;
   const qs = event.queryStringParameters || {};
   if (qs.lookup) return handleLookup(qs.lookup);
   if (qs.sfPhotos) return handleSfPhotos(qs.sfPhotos);
@@ -20,7 +25,7 @@ export async function handler(event) {
   if (qs.dismissIssue) return handleDismissIssue(qs.dismissIssue);
   if (qs.clearErrors) return handleClearErrors();
   if (event.httpMethod === 'GET') return handleGet();
-  if (event.httpMethod === 'POST') return handlePost();
+  if (event.httpMethod === 'POST') return handlePost(event);
   return { statusCode: 405, body: 'GET or POST only' };
 }
 
@@ -589,7 +594,7 @@ async function handleDismissIssue(resqCode) {
 }
 
 // --- POST: Write "running" marker, invoke background function ---
-async function handlePost() {
+async function handlePost(event) {
   try {
     // Write a "running" marker so the dashboard shows sync in progress
     const store = await getStore();
@@ -610,11 +615,13 @@ async function handlePost() {
     // and continue running for up to 15 minutes
     const siteUrl = process.env.URL || 'https://apbg-billing.netlify.app';
     const bgUrl = `${siteUrl}/.netlify/functions/resq-sf-sync-background`;
+    const bgHeaders = { 'Content-Type': 'application/json' };
+    if (event?._authJwt) bgHeaders.Authorization = `Bearer ${event._authJwt}`;
     let bgStatus = 'unknown';
     try {
       const bgRes = await fetch(bgUrl, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: bgHeaders,
         body: JSON.stringify({ trigger: 'manual', ts: Date.now() }),
       });
       bgStatus = `${bgRes.status}`;
@@ -654,7 +661,7 @@ function corsHeaders() {
   return {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
   };
 }
 

--- a/netlify/functions/sf-fix-numbers.mjs
+++ b/netlify/functions/sf-fix-numbers.mjs
@@ -4,8 +4,12 @@
 // GET ?action=link  — link found matches to ResQ mapping + remove duplicates
 
 import { sfRequest } from './sf-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
   const qs = event.queryStringParameters || {};
 
   // Quick lookup

--- a/netlify/functions/sf-token-debug.mjs
+++ b/netlify/functions/sf-token-debug.mjs
@@ -1,7 +1,11 @@
 // Diagnostic: check SF token blob state + test blob read/write
 import { getStore } from '@netlify/blobs';
+import { requireAuth } from './lib/auth.mjs';
 
 export async function handler(event) {
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
   const results = {};
 
   // 1. Check blob store

--- a/public/approve.html
+++ b/public/approve.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script>if(location.hostname.endsWith('.netlify.app'))location.replace('https://alamedapointbg.com/billing/approve.html'+location.search);</script>
   <title>APBG 3rd Party Billing Loader — Review</title>
+  <script src="https://unpkg.com/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+  <script src="/billing/auth.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <style>
     *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
@@ -178,9 +180,11 @@
 <script>
 // ── ALL API CALLS GO TO PACERFINANCE (where QBO auth works) ──
 const API='/billing/.netlify/functions';
+const fetch = (...args) => APBG.auth.authedFetch(...args);
 let vendors=[],customers=[],lineCount=0;
 
 document.addEventListener('DOMContentLoaded',async()=>{
+  await APBG.auth.requireSuperadmin();
   const params=new URLSearchParams(window.location.search);
   const token=params.get('token');
 

--- a/public/auth.js
+++ b/public/auth.js
@@ -1,0 +1,111 @@
+// Shared Supabase Auth gate for APBG admin pages.
+//
+// Usage in any admin HTML page:
+//   <script src="https://unpkg.com/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+//   <script src="/billing/auth.js"></script>
+//   <script>
+//     APBG.auth.requireSuperadmin().then(({ supabase, session }) => {
+//       // ... page init runs only after auth check passes
+//     });
+//   </script>
+//
+// All API calls to /billing/.netlify/functions/* should go through
+// APBG.auth.authedFetch(...) instead of plain fetch() so the bearer token
+// is attached automatically.
+
+(function () {
+  var SUPABASE_URL = 'https://gfsdpwiqzshhexkofiif.supabase.co';
+  var SUPABASE_ANON_KEY =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdmc2Rwd2lxenNoaGV4a29maWlmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU1OTUyMzcsImV4cCI6MjA5MTE3MTIzN30.AygnPJwQ5NfIeKwPtkO6tgVYmkV3MAxL1lMFwN9HPnY';
+  var GATEWAY_URL = 'https://alamedapointbg.com/';
+  var ALLOWED_ROLES = ['superadmin'];
+
+  function getSb() {
+    if (window.__apbgSb) return window.__apbgSb;
+    if (!window.supabase || !window.supabase.createClient) {
+      throw new Error(
+        'Supabase JS SDK not loaded — include the @supabase/supabase-js script before /billing/auth.js'
+      );
+    }
+    window.__apbgSb = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+    return window.__apbgSb;
+  }
+
+  function redirectToLogin() {
+    var next = location.pathname + location.search;
+    location.href = GATEWAY_URL + '?next=' + encodeURIComponent(next);
+  }
+
+  function showAccessDenied(role) {
+    document.body.innerHTML = '';
+    var card = document.createElement('div');
+    card.style.cssText =
+      'font-family:system-ui,sans-serif;max-width:480px;margin:80px auto;padding:32px;text-align:center;border:1px solid #FCA5A5;border-radius:8px;background:#FEF2F2';
+    var h1 = document.createElement('h1');
+    h1.style.cssText = 'color:#991B1B;font-size:1.2rem;margin-bottom:8px';
+    h1.textContent = 'Access denied';
+    var p = document.createElement('p');
+    p.style.cssText = 'color:#7F1D1D;font-size:0.9rem';
+    p.textContent =
+      'Your role (' +
+      (role || 'none') +
+      ') does not have access to this page. This page requires superadmin.';
+    var link = document.createElement('a');
+    link.href = GATEWAY_URL;
+    link.style.cssText = 'color:#1F4E79;display:inline-block;margin-top:16px';
+    link.textContent = '← Back to gateway';
+    card.appendChild(h1);
+    card.appendChild(p);
+    card.appendChild(link);
+    document.body.appendChild(card);
+  }
+
+  async function requireSuperadmin() {
+    var sb = getSb();
+    var sessionResult = await sb.auth.getSession();
+    var session = sessionResult.data && sessionResult.data.session;
+    if (!session || !session.user) {
+      redirectToLogin();
+      return new Promise(function () {}); // never resolves; page is redirecting
+    }
+    var role =
+      session.user.app_metadata && session.user.app_metadata.role
+        ? session.user.app_metadata.role
+        : null;
+    if (ALLOWED_ROLES.indexOf(role) === -1) {
+      showAccessDenied(role);
+      return new Promise(function () {}); // never resolves; access denied
+    }
+    sb.auth.onAuthStateChange(function (event, newSession) {
+      if (event === 'SIGNED_OUT' || !newSession) {
+        redirectToLogin();
+      }
+    });
+    return { supabase: sb, session: session, user: session.user, role: role };
+  }
+
+  async function authedFetch(input, init) {
+    init = init || {};
+    var sb = getSb();
+    var sessionResult = await sb.auth.getSession();
+    var session = sessionResult.data && sessionResult.data.session;
+    if (!session) {
+      redirectToLogin();
+      throw new Error('Not authenticated');
+    }
+    var headers = new Headers(init.headers || {});
+    headers.set('Authorization', 'Bearer ' + session.access_token);
+    var nextInit = {};
+    for (var k in init) if (Object.prototype.hasOwnProperty.call(init, k)) nextInit[k] = init[k];
+    nextInit.headers = headers;
+    return fetch(input, nextInit);
+  }
+
+  window.APBG = window.APBG || {};
+  window.APBG.auth = {
+    requireSuperadmin: requireSuperadmin,
+    authedFetch: authedFetch,
+    getSupabase: getSb,
+    GATEWAY_URL: GATEWAY_URL,
+  };
+})();

--- a/public/control.html
+++ b/public/control.html
@@ -4,6 +4,8 @@
 <meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <script>if(location.hostname.endsWith('.netlify.app'))location.replace('https://alamedapointbg.com/control'+location.search);</script>
 <title>Master Control — APBG Systems</title>
+<script src="https://unpkg.com/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+<script src="/billing/auth.js"></script>
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:'DM Sans',system-ui,sans-serif;background:#0F172A;color:#E2E8F0;min-height:100vh}
@@ -84,15 +86,8 @@ header .links a:hover{color:#fff}
 </head>
 <body>
 
-<!-- PIN Gate -->
-<div id="gate" class="gate">
-<div class="gate-card">
-  <h1>Master Control</h1>
-  <p>Enter PIN to access the system dashboard</p>
-  <input type="password" id="pin" placeholder="PIN" maxlength="8" autofocus>
-  <div class="err" id="pinErr">Invalid PIN</div>
-</div>
-</div>
+<!-- Loading state while auth check runs -->
+<div id="authLoading" class="gate"><div class="gate-card"><h1>Master Control</h1><p>Checking access…</p></div></div>
 
 <!-- Dashboard -->
 <div id="app" style="display:none">
@@ -192,18 +187,13 @@ function renderLog() {
   el.innerHTML = logLines.map(l => `<span class="${l.cls}">[${l.ts}] ${l.msg}</span>`).join('\n');
 }
 
-// ═══ PIN GATE ═══
-document.getElementById('pin').addEventListener('keydown', function(e) {
-  if (e.key === 'Enter') {
-    if (this.value === '2026' || this.value === 'brix2026') {
-      document.getElementById('gate').style.display = 'none';
-      document.getElementById('app').style.display = 'block';
-      refreshAll();
-      setInterval(refreshAll, 60000); // auto-refresh every 60s
-    } else {
-      document.getElementById('pinErr').style.display = 'block';
-    }
-  }
+// ═══ AUTH GATE ═══
+const fetch = (...args) => APBG.auth.authedFetch(...args);
+APBG.auth.requireSuperadmin().then(() => {
+  document.getElementById('authLoading').style.display = 'none';
+  document.getElementById('app').style.display = 'block';
+  refreshAll();
+  setInterval(refreshAll, 60000); // auto-refresh every 60s
 });
 
 // ═══ HEALTH FETCHER ═══

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -6,6 +6,7 @@
 <title>PACER Ops Dashboard</title>
 <script src="https://cdn.tailwindcss.com"></script>
 <script src="https://unpkg.com/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+<script src="/billing/auth.js"></script>
 <style>
   body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f172a; color: #e2e8f0; }
   .card { background: #1e293b; border-radius: 12px; padding: 20px; border: 1px solid #334155; }
@@ -402,7 +403,7 @@ window.switchTab = function(tab) {
   render();
 };
 
-render();
+APBG.auth.requireSuperadmin().then(() => render());
 </script>
 </body>
 </html>

--- a/public/ops/index.html
+++ b/public/ops/index.html
@@ -7,6 +7,8 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.9/babel.min.js"></script>
+<script src="https://unpkg.com/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+<script src="/billing/auth.js"></script>
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 :root{--bg:#0a0e17;--sf:#111827;--sf2:#1a2235;--bd:#1e2d4a;--ac:#22d3ee;--ac2:#818cf8;--gn:#34d399;--rd:#f87171;--am:#fbbf24;--tx:#e2e8f0;--mt:#64748b}
@@ -364,7 +366,9 @@ function App() {
   )
 }
 
-ReactDOM.render(React.createElement(App), document.getElementById('root'));
+APBG.auth.requireSuperadmin().then(function() {
+  ReactDOM.render(React.createElement(App), document.getElementById('root'));
+});
 </script>
 </body>
 </html>

--- a/public/setup.html
+++ b/public/setup.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>APBG Billing — Connect Services</title>
+<script src="https://unpkg.com/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+<script src="/billing/auth.js"></script>
 <style>
 body{font-family:'DM Sans',sans-serif;background:#F4F6F9;display:flex;align-items:center;justify-content:center;min-height:100vh;padding:24px}
 .card{background:#fff;border-radius:12px;border:1px solid #E2E6ED;padding:48px 40px;max-width:480px;width:100%;text-align:center;box-shadow:0 4px 24px rgba(0,0,0,0.04)}
@@ -19,7 +21,8 @@ a.sf:hover{background:#2E75B6}
 </style>
 </head>
 <body>
-<div class="card">
+<div class="card" id="authLoading"><h1>APBG Billing — Connect Services</h1><p>Checking access…</p></div>
+<div class="card" id="mainCard" style="display:none">
 <h1>APBG Billing — Connect Services</h1>
 <p>Authorize connections to QuickBooks and Service Fusion. One-time setup for each.</p>
 
@@ -34,6 +37,11 @@ a.sf:hover{background:#2E75B6}
 <p style="margin-top:32px;font-size:0.75rem;color:#ccc;">After connecting, return to <a href="/billing/" style="color:#1F4E79">the billing loader</a></p>
 </div>
 <script>
+APBG.auth.requireSuperadmin().then(() => {
+  document.getElementById('authLoading').style.display = 'none';
+  document.getElementById('mainCard').style.display = 'block';
+});
+
 // QBO OAuth URL — hardcoded redirect to prevent mismatch
 const qboClientId = 'ABCV3BJbXv0jfZln6eny4GqiGmojgwwqu9Eq2Fjbg8AoCN3nuK';
 const qboRedirect = encodeURIComponent('https://apbg-billing.netlify.app/.netlify/functions/oauth-callback');

--- a/public/sync.html
+++ b/public/sync.html
@@ -4,6 +4,8 @@
 <meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <script>if(location.hostname.endsWith('.netlify.app'))location.replace('https://alamedapointbg.com/billing/sync.html'+location.search);</script>
 <title>APBG — ResQ ↔ SF Sync</title>
+<script src="https://unpkg.com/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+<script src="/billing/auth.js"></script>
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:'DM Sans',system-ui,sans-serif;background:#F4F6F9;color:#1F2937;min-height:100vh}
@@ -160,13 +162,11 @@ tr:hover td{background:#F9FAFB}
 </head>
 <body>
 
-<!-- Login Gate -->
-<div class="gate" id="gateScreen">
-  <div class="gate-card">
-    <h1>🔄 ResQ ↔ SF Sync</h1>
-    <p>Enter admin code to access the sync dashboard</p>
-    <input type="password" id="gateInput" placeholder="Admin code" autocomplete="off">
-    <div class="err" id="gateErr">Invalid code</div>
+<!-- Loading state while auth check runs -->
+<div id="authLoading" style="display:flex;align-items:center;justify-content:center;min-height:100vh;font-family:'DM Sans',system-ui,sans-serif;color:#6B7280">
+  <div style="text-align:center">
+    <div class="spinner" style="display:inline-block;width:32px;height:32px;border:3px solid #E2E6ED;border-top-color:#1F4E79;border-radius:50%;animation:spin 0.6s linear infinite;margin-bottom:12px"></div>
+    <div>Checking access…</div>
   </div>
 </div>
 
@@ -283,21 +283,14 @@ tr:hover td{background:#F9FAFB}
 </div>
 
 <script>
-const GATE_CODE = 'pacer2026';
 const API_BASE = '/billing/.netlify/functions';
+const fetch = (...args) => APBG.auth.authedFetch(...args);
 
-// --- Gate ---
-const gateInput = document.getElementById('gateInput');
-gateInput.addEventListener('keyup', (e) => {
-  if (gateInput.value === GATE_CODE) {
-    document.getElementById('gateScreen').style.display = 'none';
-    document.getElementById('mainApp').style.display = 'block';
-    loadStatus();
-  } else if (gateInput.value.length >= GATE_CODE.length) {
-    document.getElementById('gateErr').style.display = 'block';
-    setTimeout(() => { document.getElementById('gateErr').style.display = 'none'; }, 2000);
-    gateInput.value = '';
-  }
+// --- Auth gate ---
+APBG.auth.requireSuperadmin().then(() => {
+  document.getElementById('authLoading').style.display = 'none';
+  document.getElementById('mainApp').style.display = 'block';
+  loadStatus();
 });
 
 // --- Load Status ---


### PR DESCRIPTION
## Summary
Replaces the client-side password/PIN gates on admin pages with real Supabase Auth, sharing the session from the alamedapointbg.com gateway login. Pairs with PR #10 (server-side `requireAuth` on Netlify functions).

## How it works
1. User logs in at `alamedapointbg.com/` — the existing gateway. Supabase JS persists the session in localStorage under the apex domain.
2. When the user navigates to `/billing/sync.html` (or any other admin page), the new `public/auth.js` reads that session.
3. If no session → redirect to `https://alamedapointbg.com/?next=<current_path>` so the gateway can return them after login.
4. If session exists but role ≠ `superadmin` → render an "access denied" message in place of the page.
5. If session is good → page runs as normal, and every internal API call carries `Authorization: Bearer <access_token>`.

## What changed
**New `public/auth.js`** (shared helper, served from `/billing/auth.js`):
- `APBG.auth.requireSuperadmin()` — the gate. Returns `{ supabase, session, user, role }` or never resolves (so `.then(...)` page-init code is safe).
- `APBG.auth.authedFetch(input, init)` — fetch wrapper that injects the bearer token.
- `onAuthStateChange` listener triggers redirect-to-login on sign-out / token-refresh failure.

**Per-page edits:**
- **`sync.html`** — dropped `pacer2026` password gate. Used `const fetch = APBG.auth.authedFetch` to shadow the global `fetch`, so all existing `fetch(...)` calls route through auth without per-call rewrites.
- **`control.html`** — dropped hardcoded `2026 / brix2026` PIN. Same fetch-shadow pattern.
- **`approve.html`** — added gate at the top of `DOMContentLoaded`.
- **`setup.html`** — added gate (no API calls; just guards the OAuth-connect UI from non-admins).
- **`dashboard.html`** — gate before initial `render()`.
- **`ops/index.html`** — gate before `ReactDOM.render()`.

## Intentionally NOT changed
- **`index.html`** (billing loader): only calls `process-inbound`, which is a webhook endpoint flagged with `SECURITY TODO` for HMAC-signature verification (separate PR). Adding Supabase auth here would break the webhook path — the dual-auth model is its own piece of work.
- **`customer-approve.html`**: already secured via the signed URL token from approval emails.

## Merge order
This PR depends on **PR #10**. Recommended sequence:
1. Land PR #10 (server-side gate)
2. Land this PR (client-side gate)
3. Brief moment between merges where admin UIs return 401 — pick a low-traffic time, or merge in fast succession.

Or merge both in a queue. Either way, deploying PR #10 alone breaks UIs; deploying this PR alone is harmless (auth.js works regardless of server state) but doesn't actually secure anything until PR #10 ships.

## Test plan
- [ ] Sign out in the gateway → visit `/billing/sync.html` → redirected to gateway with `?next=/billing/sync.html`
- [ ] Sign in as `superadmin` → visit sync.html → loads, sync runs work
- [ ] Sign in as `user` (non-superadmin) → visit sync.html → "access denied" card
- [ ] Open DevTools network → confirm every `fetch` to `/billing/.netlify/functions/*` carries `Authorization: Bearer ...`
- [ ] Open `/billing/control.html`, `/billing/approve.html?token=...`, `/billing/setup.html`, `/billing/dashboard.html`, `/billing/ops/` — all gate the same way
- [ ] `/billing/customer-approve.html?token=...` (signed link from email) still works without login
- [ ] `/billing/` (index.html) still works without login (drops a vendor PDF, scans it)

## Gateway prerequisite
Confirm the gateway sets `?next=` returns are honored (i.e. after login, redirects back to `next` param). If the gateway ignores `next`, users land on the gateway home and have to navigate manually. Functional but suboptimal UX.

https://claude.ai/code/session_01F2SHfYP1w9MCa9v6Dq4Z6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2SHfYP1w9MCa9v6Dq4Z6e)_