### PR TITLE
Fix CORS preflight 401s on cross-origin function calls

### DIFF
--- a/netlify/functions/health-watchdog.mjs
+++ b/netlify/functions/health-watchdog.mjs
@@ -256,6 +256,18 @@ function buildAlertEmail(results, timestamp) {
 // ── Main handler ──
 
 export default async function handler(req, context) {
+  // CORS preflight must short-circuit BEFORE auth — preflights are unauthenticated.
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      },
+    });
+  }
+
   // Allow Netlify scheduler OR authenticated superadmin only.
   const auth = await requireScheduledOrAuth(req, context);
   if (!auth.ok) return auth.response;

--- a/netlify/functions/pacer-health.mjs
+++ b/netlify/functions/pacer-health.mjs
@@ -48,7 +48,18 @@ async function checkEndpoint(path, toolName) {
   }
 }
 
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Content-Type': 'application/json',
+};
+
 export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
   const auth = await requireAuth(event);
   if (!auth.ok) return auth.response;
 

--- a/netlify/functions/sf-fix-numbers.mjs
+++ b/netlify/functions/sf-fix-numbers.mjs
@@ -6,7 +6,18 @@
 import { sfRequest } from './sf-helpers.mjs';
 import { requireAuth } from './lib/auth.mjs';
 
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Content-Type': 'application/json',
+};
+
 export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
   const auth = await requireAuth(event);
   if (!auth.ok) return auth.response;
 

--- a/netlify/functions/sf-token-debug.mjs
+++ b/netlify/functions/sf-token-debug.mjs
@@ -2,7 +2,18 @@
 import { getStore } from '@netlify/blobs';
 import { requireAuth } from './lib/auth.mjs';
 
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Content-Type': 'application/json',
+};
+
 export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
   const auth = await requireAuth(event);
   if (!auth.ok) return auth.response;
 


### PR DESCRIPTION
## Summary
Fixes 401 errors on cross-origin requests from `control.html` (and any other page hitting absolute `apbg-billing.netlify.app/.netlify/functions/...` URLs) by moving the `OPTIONS` preflight short-circuit ahead of the auth gate.

## Root cause
PR #10's `requireAuth` / `requireScheduledOrAuth` calls were placed at the very top of four function handlers — before the `OPTIONS` check. Browsers do an unauthenticated CORS preflight before any cross-origin request that has a non-simple header (like `Authorization: Bearer ...`). The preflight has no auth header, so it failed with 401, which the browser interpreted as a CORS preflight failure and blocked the actual request.

## Fixed in
- `pacer-health.mjs` — no OPTIONS handler at all, added one
- `sf-fix-numbers.mjs` — no OPTIONS handler at all, added one
- `sf-token-debug.mjs` — no OPTIONS handler at all, added one
- `health-watchdog.mjs` — OPTIONS existed but ran AFTER auth, moved to top

`resq-sf-sync-background.mjs` deliberately not changed — it's server-to-server only (the dispatcher fetches it from inside another function), no browser preflight.

## Test plan
- [ ] Deploys
- [ ] Open `alamedapointbg.com/billing/control.html` (logged in as superadmin) → health badges populate (no more 401s in console)
- [ ] OPTIONS preflight to any of these endpoints returns 204 with `Access-Control-Allow-Headers: Content-Type, Authorization`
- [ ] Actual authenticated GET still works
- [ ] Unauthenticated GET still returns 401 (auth gate intact)

https://claude.ai/code/session_01F2SHfYP1w9MCa9v6Dq4Z6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2SHfYP1w9MCa9v6Dq4Z6e)_