### PR TITLE
Hotfix: stop redirect loop, dump apbg_session for diagnosis

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -116,6 +116,20 @@
     }
     var session = sessionResult && sessionResult.data && sessionResult.data.session;
     if (!session || !session.user) {
+      // Loop-breaker: if the gateway uses its own custom session storage
+      // ('apbg_session'), don't bounce back to the gateway — that creates
+      // an infinite cycle. Instead show what's stored so we can wire it up.
+      var apbgRaw = null;
+      try { apbgRaw = localStorage.getItem('apbg_session'); } catch (e) {}
+      if (apbgRaw) {
+        var pretty = apbgRaw;
+        try { pretty = JSON.stringify(JSON.parse(apbgRaw), null, 2); } catch (e) {}
+        showError(
+          'Gateway session detected but its format is not recognized by Supabase JS. Share the structure below with the dev so the storage adapter can be wired up — DO NOT post the access_token publicly.',
+          'localStorage.apbg_session:\n' + pretty
+        );
+        return new Promise(function () {});
+      }
       redirectToLogin();
       return new Promise(function () {}); // never resolves; page is redirecting
     }


### PR DESCRIPTION
## Summary
Hotfix: stops the redirect loop on `/billing/sync.html` and reveals the gateway's session format.

## Context
The gateway at `alamedapointbg.com` stores its Supabase session in localStorage under a custom key `apbg_session`, not the default `sb-<project-ref>-auth-token`. The Supabase JS client we use in our admin pages doesn't see it → no session → redirect to gateway → gateway honors `?next=` → bounce back → loop.

## Fix
Before redirecting, check for `localStorage.apbg_session`. If present, render an error card showing the value (parsed if JSON) so we can see the structure. Tells the user not to post the access_token publicly.

Once we know the format, the follow-up PR will wire a custom Supabase JS storage adapter that reads/writes `apbg_session`, restoring single-sign-on between gateway and `/billing/...` pages.

## Note
There's a separate problem visible in the same console: the gateway's own homepage calls `apbg-billing.netlify.app/.netlify/functions/health-watchdog` and `pacer-health` directly. PR #10 gated those, so the gateway's panel now shows 401s. Same root cause (gateway can't speak Supabase JWT to apbg-billing). The follow-up adapter PR fixes both.

https://claude.ai/code/session_01F2SHfYP1w9MCa9v6Dq4Z6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2SHfYP1w9MCa9v6Dq4Z6e)_