### PR TITLE
Fix authedFetch infinite recursion (capture native fetch)

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -165,6 +165,12 @@
     };
   }
 
+  // Capture native fetch at module-load time. Classic <script>s share their
+  // top-level let/const scope, so a `const fetch = APBG.auth.authedFetch` in
+  // an admin page would otherwise shadow the bare `fetch` identifier here
+  // and cause infinite recursion ("Maximum call stack size exceeded").
+  var nativeFetch = window.fetch.bind(window);
+
   async function authedFetch(input, init) {
     init = init || {};
     var session = readSession();
@@ -177,7 +183,7 @@
     var nextInit = {};
     for (var k in init) if (Object.prototype.hasOwnProperty.call(init, k)) nextInit[k] = init[k];
     nextInit.headers = headers;
-    return fetch(input, nextInit);
+    return nativeFetch(input, nextInit);
   }
 
   function getSupabase() {


### PR DESCRIPTION
## Summary
One-line fix for "Maximum call stack size exceeded" on every authenticated API call after login.

## Root cause
Classic `<script>` tags **share** their top-level `let`/`const` scope (it's a single "script scope" across all classic scripts on a page). The admin pages do:

```js
const fetch = (...args) => APBG.auth.authedFetch(...args);
```

to shadow the global `fetch`. That const is also visible inside `auth.js`'s IIFE. So when `authedFetch` did `return fetch(input, ...)`, it resolved to the page's shadowed `fetch`, which called `authedFetch`, which called `fetch`, ad infinitum.

## Fix
Capture `window.fetch.bind(window)` at module load time and call it as `nativeFetch`. Bypasses the shared script scope.

https://claude.ai/code/session_01F2SHfYP1w9MCa9v6Dq4Z6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2SHfYP1w9MCa9v6Dq4Z6e)_