### PR TITLE
feat(sql): revoke anon SELECT on ops.qbo_customers (§12 #6 PR B2)

### DIFF
--- a/supabase/migrations/20260505c_qbo_customers_revoke_anon.sql
+++ b/supabase/migrations/20260505c_qbo_customers_revoke_anon.sql
@@ -1,0 +1,43 @@
+-- §12 #6 PR B2 — destructive half: revoke direct anon SELECT on ops.qbo_customers.
+--
+-- The PII gate's additive half landed in 20260505b_customer_directory.sql:
+-- ops.v_customer_directory (safe-column view) and ops.fn_customer_directory()
+-- (SECURITY DEFINER RPC) are now live and the Margin Minder consumers in
+-- public/sales/index.html have been migrated to use the RPC.
+--
+-- Apbg-ops audit (2026-05-05) reports zero direct reads of ops.qbo_customers
+-- from its codebase — apbg-ops gets customer signal from denormalized
+-- customer_name columns on qbo_invoices / delivery_stops / service_jobs,
+-- and from SECURITY DEFINER RPCs (fn_customer_detail, fn_customer_health,
+-- etc.) for full-row reads.
+--
+-- This migration shuts the PII door on ops.qbo_customers itself. After
+-- this lands, the table is unreadable via the anon key. SECURITY DEFINER
+-- RPCs continue to work (they bypass RLS by design); authenticated users
+-- with a valid bearer token retain SELECT.
+--
+-- Roles list on the new policy: 'admin', 'superadmin', 'margin-minder-user',
+-- 'ops-user'. Adjust to match the gateway's actual role-claim minting once
+-- it deploys (joint architecture doc §5 roadmap).
+
+-- Tighten the SELECT policy: was USING (true) for {public}; now requires
+-- an authenticated session whose JWT carries an authorized role claim.
+DROP POLICY IF EXISTS qbo_customers_read ON ops.qbo_customers;
+
+CREATE POLICY qbo_customers_read ON ops.qbo_customers
+  FOR SELECT
+  TO authenticated
+  USING (
+    coalesce(auth.jwt()->>'role', '') IN (
+      'admin', 'superadmin', 'margin-minder-user', 'ops-user'
+    )
+  );
+
+-- Anon role no longer reads the PII master table.
+REVOKE SELECT ON ops.qbo_customers FROM anon;
+
+-- Authenticated role keeps SELECT (gated by the policy above).
+GRANT SELECT ON ops.qbo_customers TO authenticated;
+
+COMMENT ON POLICY qbo_customers_read ON ops.qbo_customers IS
+  'PII gate: SELECT requires a JWT with role claim in the allowed set. Anon callers must use ops.v_customer_directory or ops.fn_customer_directory() for safe-column reads, or the existing SECURITY DEFINER RPCs (fn_customer_detail, fn_customer_health) for elevated reads.';


### PR DESCRIPTION
## Summary

Architecture review §12 #6 PR B2 — destructive half of the PII gate on `ops.qbo_customers`. Companion to PR #25 (additive half).

Per ops Claude's verification round on 2026-05-05: apbg-ops has zero direct reads of `ops.qbo_customers`. All customer signal in apbg-ops flows through denormalized `customer_name` columns on side tables or through SECURITY DEFINER RPCs. Margin Minder side already cut over to `fn_customer_directory()` in PR #25.

## What changes

- Replaces `qbo_customers_read` policy: was `USING (true) FOR {public}`, now requires `authenticated` + JWT role claim in `('admin', 'superadmin', 'margin-minder-user', 'ops-user')`.
- `REVOKE SELECT ON ops.qbo_customers FROM anon`.
- `GRANT SELECT ON ops.qbo_customers TO authenticated` (gated by the policy above).

SECURITY DEFINER RPCs (`fn_customer_detail`, `fn_customer_directory`, `fn_customer_health`, etc.) continue to work — they bypass RLS by design.

## Dependencies

- PR #25 (additive half) must land first. The Margin Minder consumers in `public/sales/index.html` need `fn_customer_directory()` to exist before the REVOKE shuts the table.
- Gateway role-claim minting (joint doc §5 roadmap) — when that deploys, the roles list in the policy may need to be adjusted to match what the gateway actually mints.

## Test plan

- [ ] Confirm PR #25 is merged before merging this.
- [ ] After apply: anon-only `SELECT * FROM ops.qbo_customers` returns 0 rows (or denied).
- [ ] After apply: anon `SELECT * FROM ops.v_customer_directory` still returns rows.
- [ ] After apply: anon `SELECT ops.fn_customer_directory()` still returns rows.
- [ ] Open Margin Minder BulkClassify modal at `/sales-next/` — customer list still loads (via the RPC).
- [ ] Open inventory-velocity-excludes picker — customer typeahead still works.
- [ ] Spot-check apbg-ops dashboard: customer-detail panel + RFM views still render (they go through SECURITY DEFINER RPCs, should be unaffected).
- [ ] Confirm `pg_policies` shows the new `qbo_customers_read` policy with the role-claim USING clause.

## Rollback

Revert: drop the new policy, recreate `qbo_customers_read FOR SELECT USING (true)`, re-grant SELECT to anon. One-line revert migration if anything breaks.

https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL

---
_Generated by [Claude Code](https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL)_