### PR TITLE
feat(architecture): refresh-snapshot.mjs helper + ops.fn_list_ops_tables RPC

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -45,7 +45,15 @@ node architecture/lint-manifest.mjs
 
 ### Refreshing the snapshot
 
-Today this is manual: query `information_schema.tables` against the live Supabase project and replace the `tables` array in `schema-snapshot.json`. The snapshot for 2026-05-05 was captured via:
+Run the helper after any migration that creates or drops an `ops.*` table:
+
+```bash
+node architecture/refresh-snapshot.mjs
+```
+
+It calls the `ops.fn_list_ops_tables()` SECURITY DEFINER RPC (anon-callable; introspection only) and rewrites `schema-snapshot.json` with today's date. Prints a diff: tables added, tables removed. Flags any manifest entries (writers or orphans) that reference removed tables so you know to clean them up before the lint runs.
+
+Manual fallback (no Node, no anon key) — query `information_schema.tables` against the live Supabase project and replace the `tables` array in `schema-snapshot.json` directly:
 
 ```sql
 SELECT table_name
@@ -53,8 +61,6 @@ FROM information_schema.tables
 WHERE table_schema = 'ops' AND table_type = 'BASE TABLE'
 ORDER BY table_name;
 ```
-
-A `refresh-snapshot.mjs` helper (TODO) would automate this with a service-role key.
 
 ## Out of scope (intentional)
 

--- a/architecture/refresh-snapshot.mjs
+++ b/architecture/refresh-snapshot.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Refresh architecture/schema-snapshot.json from the live Supabase project.
+//
+// Calls ops.fn_list_ops_tables() (SECURITY DEFINER, anon-callable), writes
+// the alphabetized table list to schema-snapshot.json with today's date,
+// and prints a diff: tables added since the last snapshot, tables removed.
+//
+// Run after merging any migration that creates or drops an ops.* table.
+// The Netlify build runs `node architecture/lint-manifest.mjs` first, and
+// the lint will fail if the manifest references tables that no longer exist
+// (or if a new table has neither a writer nor an orphan entry).
+//
+// No external dependencies; runs on Node 22+ with fetch built in.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const SB_URL = 'https://gfsdpwiqzshhexkofiif.supabase.co';
+const SB_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdmc2Rwd2lxenNoaGV4a29maWlmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU1OTUyMzcsImV4cCI6MjA5MTE3MTIzN30.AygnPJwQ5NfIeKwPtkO6tgVYmkV3MAxL1lMFwN9HPnY';
+
+const SNAPSHOT_PATH = resolve(__dirname, 'schema-snapshot.json');
+const MANIFEST_PATH = resolve(__dirname, 'sync-manifest.json');
+
+async function fetchTables() {
+  const res = await fetch(SB_URL + '/rest/v1/rpc/fn_list_ops_tables', {
+    method: 'POST',
+    headers: {
+      apikey: SB_KEY,
+      Authorization: 'Bearer ' + SB_KEY,
+      'Accept-Profile': 'ops',
+      'Content-Profile': 'ops',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({}),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error('fn_list_ops_tables failed: ' + res.status + ' ' + text);
+  }
+  const tables = await res.json();
+  if (!Array.isArray(tables)) {
+    throw new Error('fn_list_ops_tables returned non-array: ' + JSON.stringify(tables));
+  }
+  return tables;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function writeJson(path, data) {
+  writeFileSync(path, JSON.stringify(data, null, 2) + '\n', 'utf8');
+}
+
+function todayIsoDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+(async () => {
+  console.log('Fetching ops.* table list from Supabase…');
+  const live = await fetchTables();
+  console.log('  → ' + live.length + ' tables in prod.');
+
+  const prior = readJson(SNAPSHOT_PATH);
+  const priorSet = new Set(prior.tables);
+  const liveSet = new Set(live);
+
+  const added = live.filter((t) => !priorSet.has(t));
+  const removed = prior.tables.filter((t) => !liveSet.has(t));
+
+  if (added.length === 0 && removed.length === 0) {
+    console.log('No drift — snapshot already in sync.');
+    return;
+  }
+
+  if (added.length) {
+    console.log('\nAdded tables (' + added.length + '):');
+    for (const t of added) console.log('  + ops.' + t);
+  }
+  if (removed.length) {
+    console.log('\nRemoved tables (' + removed.length + '):');
+    for (const t of removed) console.log('  - ops.' + t);
+  }
+
+  // Heads-up if the manifest references any removed tables.
+  if (removed.length) {
+    const manifest = readJson(MANIFEST_PATH);
+    const removedFq = new Set(removed.map((t) => 'ops.' + t));
+    const writerHits = (manifest.writers ?? [])
+      .flatMap((w) => (w.writes ?? []).filter((tbl) => removedFq.has(tbl)).map((tbl) => ({ writer: w.name, table: tbl })));
+    const orphanHits = (manifest.orphans ?? []).filter((o) => removedFq.has(o.table));
+
+    if (writerHits.length || orphanHits.length) {
+      console.log('\n⚠ Manifest references tables that no longer exist:');
+      for (const h of writerHits) console.log('  · writer "' + h.writer + '" claims ' + h.table);
+      for (const o of orphanHits) console.log('  · orphan entry for ' + o.table + ' (will become a no-op)');
+      console.log('Run `node architecture/lint-manifest.mjs` after committing this snapshot — it will fail until those manifest entries are removed.');
+    }
+  }
+
+  writeJson(SNAPSHOT_PATH, {
+    $comment: prior.$comment,
+    captured_at: todayIsoDate(),
+    schema: 'ops',
+    tables: live.slice().sort(),
+  });
+  console.log('\nWrote ' + SNAPSHOT_PATH + ' (captured_at: ' + todayIsoDate() + ').');
+})().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/supabase/migrations/20260506a_fn_list_ops_tables.sql
+++ b/supabase/migrations/20260506a_fn_list_ops_tables.sql
@@ -1,0 +1,20 @@
+-- §12 #4 follow-up — helper RPC for refreshing architecture/schema-snapshot.json.
+--
+-- SECURITY DEFINER + anon-callable so the architecture/refresh-snapshot.mjs
+-- helper script can run from any developer machine using only the anon key
+-- already baked into every JS bundle. Returns the bare list of ops.* base
+-- table names; nothing sensitive — schema introspection only.
+
+CREATE OR REPLACE FUNCTION ops.fn_list_ops_tables()
+RETURNS text[]
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $$
+  SELECT array_agg(table_name ORDER BY table_name)
+  FROM information_schema.tables
+  WHERE table_schema = 'ops' AND table_type = 'BASE TABLE'
+$$;
+
+GRANT EXECUTE ON FUNCTION ops.fn_list_ops_tables() TO anon, authenticated;
+
+COMMENT ON FUNCTION ops.fn_list_ops_tables() IS
+  'Returns the alphabetized list of base table names in ops schema. Used by architecture/refresh-snapshot.mjs to keep schema-snapshot.json in sync with prod. SECURITY DEFINER so it works without service-role; introspection only.';


### PR DESCRIPTION
## Summary

Architecture review §12 #4 follow-up — automate `schema-snapshot.json` refresh so drift between prod and the lint contract is one command to fix.

## What's added

**`supabase/migrations/20260506a_fn_list_ops_tables.sql`** — adds `ops.fn_list_ops_tables()`:
- SECURITY DEFINER, anon-callable
- Returns alphabetized `text[]` of base table names in `ops` schema
- No data exposed; schema introspection only
- Already applied to live DB (idempotent `CREATE OR REPLACE`)

**`architecture/refresh-snapshot.mjs`** — Node helper:
- Calls the RPC via the anon key (no new env vars / service-role needed)
- Writes `schema-snapshot.json` with today's date
- Prints a diff: tables added / tables removed
- Flags any manifest writer or orphan entries that reference removed tables, so you know what to clean up before the lint runs
- Built-in `fetch` on Node 22+; no external dependencies

**`architecture/README.md`** — replaces manual SQL-paste workflow with the helper. Manual SQL kept as fallback for "I have no Node" cases.

## How to use

```bash
# After merging any migration that creates or drops an ops.* table:
node architecture/refresh-snapshot.mjs
git add architecture/schema-snapshot.json
git commit -m "chore(architecture): refresh schema snapshot"
```

## Test plan

- [ ] Run locally: `node architecture/refresh-snapshot.mjs` should print `No drift — snapshot already in sync.` (assuming no migrations have landed since the last refresh).
- [ ] Manually break by editing `schema-snapshot.json` to add a fake table; rerun helper; should print "Removed tables: 1" and rewrite to clean state.
- [ ] After a future migration adds a table, helper should print "Added tables: …" and update the snapshot.

## Notes

The local sandbox can't reach `gfsdpwiqzshhexkofiif.supabase.co` directly (host not in allowlist), so I couldn't run the helper end-to-end from here — but the SQL function is applied to live and the script logic is straightforward fetch+JSON. Sky / Netlify / dev machines will work.

https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL

---
_Generated by [Claude Code](https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL)_