### PR TITLE
feat(sql): wire kpi_daily nightly rollup

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -45,7 +45,15 @@ node architecture/lint-manifest.mjs
 
 ### Refreshing the snapshot
 
-Today this is manual: query `information_schema.tables` against the live Supabase project and replace the `tables` array in `schema-snapshot.json`. The snapshot for 2026-05-05 was captured via:
+Run the helper after any migration that creates or drops an `ops.*` table:
+
+```bash
+node architecture/refresh-snapshot.mjs
+```
+
+It calls the `ops.fn_list_ops_tables()` SECURITY DEFINER RPC (anon-callable; introspection only) and rewrites `schema-snapshot.json` with today's date. Prints a diff: tables added, tables removed. Flags any manifest entries (writers or orphans) that reference removed tables so you know to clean them up before the lint runs.
+
+Manual fallback (no Node, no anon key) — query `information_schema.tables` against the live Supabase project and replace the `tables` array in `schema-snapshot.json` directly:
 
 ```sql
 SELECT table_name
@@ -53,8 +61,6 @@ FROM information_schema.tables
 WHERE table_schema = 'ops' AND table_type = 'BASE TABLE'
 ORDER BY table_name;
 ```
-
-A `refresh-snapshot.mjs` helper (TODO) would automate this with a service-role key.
 
 ## Out of scope (intentional)
 

--- a/architecture/refresh-snapshot.mjs
+++ b/architecture/refresh-snapshot.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Refresh architecture/schema-snapshot.json from the live Supabase project.
+//
+// Calls ops.fn_list_ops_tables() (SECURITY DEFINER, anon-callable), writes
+// the alphabetized table list to schema-snapshot.json with today's date,
+// and prints a diff: tables added since the last snapshot, tables removed.
+//
+// Run after merging any migration that creates or drops an ops.* table.
+// The Netlify build runs `node architecture/lint-manifest.mjs` first, and
+// the lint will fail if the manifest references tables that no longer exist
+// (or if a new table has neither a writer nor an orphan entry).
+//
+// No external dependencies; runs on Node 22+ with fetch built in.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const SB_URL = 'https://gfsdpwiqzshhexkofiif.supabase.co';
+const SB_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdmc2Rwd2lxenNoaGV4a29maWlmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU1OTUyMzcsImV4cCI6MjA5MTE3MTIzN30.AygnPJwQ5NfIeKwPtkO6tgVYmkV3MAxL1lMFwN9HPnY';
+
+const SNAPSHOT_PATH = resolve(__dirname, 'schema-snapshot.json');
+const MANIFEST_PATH = resolve(__dirname, 'sync-manifest.json');
+
+async function fetchTables() {
+  const res = await fetch(SB_URL + '/rest/v1/rpc/fn_list_ops_tables', {
+    method: 'POST',
+    headers: {
+      apikey: SB_KEY,
+      Authorization: 'Bearer ' + SB_KEY,
+      'Accept-Profile': 'ops',
+      'Content-Profile': 'ops',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({}),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error('fn_list_ops_tables failed: ' + res.status + ' ' + text);
+  }
+  const tables = await res.json();
+  if (!Array.isArray(tables)) {
+    throw new Error('fn_list_ops_tables returned non-array: ' + JSON.stringify(tables));
+  }
+  return tables;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function writeJson(path, data) {
+  writeFileSync(path, JSON.stringify(data, null, 2) + '\n', 'utf8');
+}
+
+function todayIsoDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+(async () => {
+  console.log('Fetching ops.* table list from Supabase…');
+  const live = await fetchTables();
+  console.log('  → ' + live.length + ' tables in prod.');
+
+  const prior = readJson(SNAPSHOT_PATH);
+  const priorSet = new Set(prior.tables);
+  const liveSet = new Set(live);
+
+  const added = live.filter((t) => !priorSet.has(t));
+  const removed = prior.tables.filter((t) => !liveSet.has(t));
+
+  if (added.length === 0 && removed.length === 0) {
+    console.log('No drift — snapshot already in sync.');
+    return;
+  }
+
+  if (added.length) {
+    console.log('\nAdded tables (' + added.length + '):');
+    for (const t of added) console.log('  + ops.' + t);
+  }
+  if (removed.length) {
+    console.log('\nRemoved tables (' + removed.length + '):');
+    for (const t of removed) console.log('  - ops.' + t);
+  }
+
+  // Heads-up if the manifest references any removed tables.
+  if (removed.length) {
+    const manifest = readJson(MANIFEST_PATH);
+    const removedFq = new Set(removed.map((t) => 'ops.' + t));
+    const writerHits = (manifest.writers ?? [])
+      .flatMap((w) => (w.writes ?? []).filter((tbl) => removedFq.has(tbl)).map((tbl) => ({ writer: w.name, table: tbl })));
+    const orphanHits = (manifest.orphans ?? []).filter((o) => removedFq.has(o.table));
+
+    if (writerHits.length || orphanHits.length) {
+      console.log('\n⚠ Manifest references tables that no longer exist:');
+      for (const h of writerHits) console.log('  · writer "' + h.writer + '" claims ' + h.table);
+      for (const o of orphanHits) console.log('  · orphan entry for ' + o.table + ' (will become a no-op)');
+      console.log('Run `node architecture/lint-manifest.mjs` after committing this snapshot — it will fail until those manifest entries are removed.');
+    }
+  }
+
+  writeJson(SNAPSHOT_PATH, {
+    $comment: prior.$comment,
+    captured_at: todayIsoDate(),
+    schema: 'ops',
+    tables: live.slice().sort(),
+  });
+  console.log('\nWrote ' + SNAPSHOT_PATH + ' (captured_at: ' + todayIsoDate() + ').');
+})().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -157,6 +157,15 @@
       "last_verified": "2026-05-05"
     },
     {
+      "name": "fn_compute_kpi_daily",
+      "kind": "sql-function-cron",
+      "source_repo": "skypace/apbg-billing",
+      "schedule": "nightly 11:00 UTC (cron nightly-kpi-daily) for current_date - 1",
+      "writes": ["ops.kpi_daily"],
+      "notes": "Postgres function called by pg_cron. Joins delivery_stops/service_jobs/reman_jobs to team_members via driver_id/tech_id and upserts per-(date, team_member) rows. Defined in 20260506b_kpi_daily_rollup.sql; backfills last 30 days at apply time.",
+      "last_verified": "2026-05-06"
+    },
+    {
       "name": "manual-ui:margin-minder-settings",
       "kind": "manual-ui",
       "source_repo": "skypace/apbg-billing",
@@ -217,10 +226,6 @@
     {
       "table": "ops.balance_sheet_snapshots",
       "reason": "Table exists, 0 rows. No cron, no edge function. Planned cadence and endpoint not yet specified."
-    },
-    {
-      "table": "ops.kpi_daily",
-      "reason": "Table exists per CLAUDE.md (apbg-billing); no rows. Planned: Postgres function + pg_cron nightly rollup. Not built."
     },
     {
       "table": "ops.qbo_expenses",

--- a/supabase/migrations/20260506a_fn_list_ops_tables.sql
+++ b/supabase/migrations/20260506a_fn_list_ops_tables.sql
@@ -1,0 +1,20 @@
+-- §12 #4 follow-up — helper RPC for refreshing architecture/schema-snapshot.json.
+--
+-- SECURITY DEFINER + anon-callable so the architecture/refresh-snapshot.mjs
+-- helper script can run from any developer machine using only the anon key
+-- already baked into every JS bundle. Returns the bare list of ops.* base
+-- table names; nothing sensitive — schema introspection only.
+
+CREATE OR REPLACE FUNCTION ops.fn_list_ops_tables()
+RETURNS text[]
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $$
+  SELECT array_agg(table_name ORDER BY table_name)
+  FROM information_schema.tables
+  WHERE table_schema = 'ops' AND table_type = 'BASE TABLE'
+$$;
+
+GRANT EXECUTE ON FUNCTION ops.fn_list_ops_tables() TO anon, authenticated;
+
+COMMENT ON FUNCTION ops.fn_list_ops_tables() IS
+  'Returns the alphabetized list of base table names in ops schema. Used by architecture/refresh-snapshot.mjs to keep schema-snapshot.json in sync with prod. SECURITY DEFINER so it works without service-role; introspection only.';

--- a/supabase/migrations/20260506b_kpi_daily_rollup.sql
+++ b/supabase/migrations/20260506b_kpi_daily_rollup.sql
@@ -1,0 +1,213 @@
+-- §3.B from CLAUDE.md (apbg-billing) — kpi_daily nightly rollup.
+--
+-- ops.kpi_daily was created with the right shape but never wired. This
+-- migration:
+--   1. Defines ops.fn_compute_kpi_daily(p_date) — single-day rollup.
+--      For every active team_members row in delivery / service / reman
+--      departments, it computes that day's KPIs from delivery_stops /
+--      service_jobs / reman_jobs (joined on driver_id / tech_id) and
+--      upserts into ops.kpi_daily keyed on (kpi_date, team_member_id).
+--   2. Schedules pg_cron 'nightly-kpi-daily' at 11:00 UTC, covering
+--      yesterday (current_date - 1). 11:00 UTC is comfortably after
+--      sync-qbo's 09:00 UTC + the half-hourly sync-sf cycle, so the
+--      day's data has settled.
+--   3. Backfills the last 30 days at apply time so the table isn't
+--      empty when the dashboard first reads it.
+--
+-- Updates the orphan list in architecture/sync-manifest.json — kpi_daily
+-- now has fn_compute_kpi_daily as its writer.
+
+-- ------------------------------------------------------------------
+-- 1. Single-day rollup function.
+-- ------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION ops.fn_compute_kpi_daily(p_date date DEFAULT (current_date - 1))
+RETURNS int
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ops, public
+AS $$
+DECLARE
+  rows_affected int := 0;
+BEGIN
+  WITH
+  -- Per-driver delivery aggregates for the day.
+  del AS (
+    SELECT driver_id AS tm_id,
+           count(*)::int             AS stops,
+           sum(sf_total)::numeric    AS revenue
+    FROM ops.delivery_stops
+    WHERE stop_date = p_date
+      AND driver_id IS NOT NULL
+    GROUP BY driver_id
+  ),
+  -- Per-tech service aggregates.
+  svc AS (
+    SELECT tech_id AS tm_id,
+           count(*)::int                                   AS jobs,
+           sum(COALESCE(sf_total, invoice_amount))::numeric AS revenue,
+           sum(billable_hours)::numeric                     AS billable_hours,
+           -- Total hours: dispatch→completion duration when present, else billable.
+           sum(COALESCE(
+             EXTRACT(EPOCH FROM (completion_time - dispatch_time)) / 3600,
+             billable_hours,
+             0
+           ))::numeric                                       AS total_hours,
+           count(*) FILTER (WHERE first_time_fix = true)::int AS first_fix_count,
+           avg(EXTRACT(EPOCH FROM (arrival_time - dispatch_time)) / 60)::numeric AS avg_response_min
+    FROM ops.service_jobs
+    WHERE job_date = p_date
+      AND tech_id IS NOT NULL
+    GROUP BY tech_id
+  ),
+  -- Per-tech reman aggregates (keyed on completion_date, not intake).
+  rmn AS (
+    SELECT tech_id AS tm_id,
+           count(*)::int                                  AS units,
+           sum(sale_price)::numeric                        AS revenue,
+           sum(parts_cost)::numeric                        AS parts_cost,
+           sum(labor_cost)::numeric                        AS labor_cost,
+           avg(completion_date - intake_date)::numeric     AS turnaround_days
+    FROM ops.reman_jobs
+    WHERE completion_date = p_date
+      AND tech_id IS NOT NULL
+    GROUP BY tech_id
+  )
+  INSERT INTO ops.kpi_daily (
+    kpi_date, team_member_id, member_name, department, entity,
+    stops_completed, delivery_revenue, delivery_cost,
+    cost_per_stop, revenue_per_stop, margin_per_stop,
+    jobs_completed, service_revenue, service_cost,
+    cost_per_job, revenue_per_job,
+    billable_hours, total_hours, utilization_pct,
+    first_fix_pct, avg_response_min,
+    units_completed, reman_revenue, reman_cost,
+    labor_per_unit, parts_per_unit, margin_per_unit, turnaround_days,
+    computed_at
+  )
+  SELECT
+    p_date                                                         AS kpi_date,
+    tm.id                                                          AS team_member_id,
+    tm.name                                                        AS member_name,
+    tm.department                                                  AS department,
+    tm.entity                                                      AS entity,
+
+    -- Delivery columns (only populate when this is a delivery member).
+    CASE WHEN tm.department = 'delivery' THEN COALESCE(d.stops, 0) END,
+    CASE WHEN tm.department = 'delivery' THEN COALESCE(d.revenue, 0) END,
+    CASE WHEN tm.department = 'delivery' THEN
+      COALESCE(tm.annual_wage, 0) / 260.0 * COALESCE(tm.split_pct, 1)
+    END,
+    CASE WHEN tm.department = 'delivery' AND COALESCE(d.stops, 0) > 0 THEN
+      (COALESCE(tm.annual_wage, 0) / 260.0 * COALESCE(tm.split_pct, 1)) / d.stops
+    END,
+    CASE WHEN tm.department = 'delivery' AND COALESCE(d.stops, 0) > 0 THEN
+      COALESCE(d.revenue, 0) / d.stops
+    END,
+    CASE WHEN tm.department = 'delivery' AND COALESCE(d.stops, 0) > 0 THEN
+      (COALESCE(d.revenue, 0) / d.stops)
+        - ((COALESCE(tm.annual_wage, 0) / 260.0 * COALESCE(tm.split_pct, 1)) / d.stops)
+    END,
+
+    -- Service columns.
+    CASE WHEN tm.department = 'service' THEN COALESCE(s.jobs, 0) END,
+    CASE WHEN tm.department = 'service' THEN COALESCE(s.revenue, 0) END,
+    CASE WHEN tm.department = 'service' THEN
+      COALESCE(tm.annual_wage, 0) / 260.0 * COALESCE(tm.split_pct, 1)
+    END,
+    CASE WHEN tm.department = 'service' AND COALESCE(s.jobs, 0) > 0 THEN
+      (COALESCE(tm.annual_wage, 0) / 260.0 * COALESCE(tm.split_pct, 1)) / s.jobs
+    END,
+    CASE WHEN tm.department = 'service' AND COALESCE(s.jobs, 0) > 0 THEN
+      COALESCE(s.revenue, 0) / s.jobs
+    END,
+    CASE WHEN tm.department = 'service' THEN s.billable_hours END,
+    CASE WHEN tm.department = 'service' THEN s.total_hours END,
+    CASE WHEN tm.department = 'service' AND COALESCE(s.total_hours, 0) > 0 THEN
+      s.billable_hours / s.total_hours * 100
+    END,
+    CASE WHEN tm.department = 'service' AND COALESCE(s.jobs, 0) > 0 THEN
+      s.first_fix_count::numeric / s.jobs * 100
+    END,
+    CASE WHEN tm.department = 'service' THEN s.avg_response_min END,
+
+    -- Reman columns.
+    CASE WHEN tm.department = 'reman' THEN COALESCE(r.units, 0) END,
+    CASE WHEN tm.department = 'reman' THEN COALESCE(r.revenue, 0) END,
+    CASE WHEN tm.department = 'reman' THEN
+      COALESCE(r.parts_cost, 0) + COALESCE(r.labor_cost, 0)
+    END,
+    CASE WHEN tm.department = 'reman' AND COALESCE(r.units, 0) > 0 THEN
+      COALESCE(r.labor_cost, 0) / r.units
+    END,
+    CASE WHEN tm.department = 'reman' AND COALESCE(r.units, 0) > 0 THEN
+      COALESCE(r.parts_cost, 0) / r.units
+    END,
+    CASE WHEN tm.department = 'reman' AND COALESCE(r.units, 0) > 0 THEN
+      (COALESCE(r.revenue, 0) - COALESCE(r.parts_cost, 0) - COALESCE(r.labor_cost, 0)) / r.units
+    END,
+    CASE WHEN tm.department = 'reman' THEN r.turnaround_days END,
+
+    now() AS computed_at
+  FROM ops.team_members tm
+    LEFT JOIN del d ON d.tm_id = tm.id
+    LEFT JOIN svc s ON s.tm_id = tm.id
+    LEFT JOIN rmn r ON r.tm_id = tm.id
+  WHERE tm.active = true
+    AND tm.department IN ('delivery', 'service', 'reman')
+  ON CONFLICT (kpi_date, team_member_id) DO UPDATE SET
+    member_name      = EXCLUDED.member_name,
+    department       = EXCLUDED.department,
+    entity           = EXCLUDED.entity,
+    stops_completed  = EXCLUDED.stops_completed,
+    delivery_revenue = EXCLUDED.delivery_revenue,
+    delivery_cost    = EXCLUDED.delivery_cost,
+    cost_per_stop    = EXCLUDED.cost_per_stop,
+    revenue_per_stop = EXCLUDED.revenue_per_stop,
+    margin_per_stop  = EXCLUDED.margin_per_stop,
+    jobs_completed   = EXCLUDED.jobs_completed,
+    service_revenue  = EXCLUDED.service_revenue,
+    service_cost     = EXCLUDED.service_cost,
+    cost_per_job     = EXCLUDED.cost_per_job,
+    revenue_per_job  = EXCLUDED.revenue_per_job,
+    billable_hours   = EXCLUDED.billable_hours,
+    total_hours      = EXCLUDED.total_hours,
+    utilization_pct  = EXCLUDED.utilization_pct,
+    first_fix_pct    = EXCLUDED.first_fix_pct,
+    avg_response_min = EXCLUDED.avg_response_min,
+    units_completed  = EXCLUDED.units_completed,
+    reman_revenue    = EXCLUDED.reman_revenue,
+    reman_cost       = EXCLUDED.reman_cost,
+    labor_per_unit   = EXCLUDED.labor_per_unit,
+    parts_per_unit   = EXCLUDED.parts_per_unit,
+    margin_per_unit  = EXCLUDED.margin_per_unit,
+    turnaround_days  = EXCLUDED.turnaround_days,
+    computed_at      = EXCLUDED.computed_at;
+
+  GET DIAGNOSTICS rows_affected = ROW_COUNT;
+  RETURN rows_affected;
+END $$;
+
+GRANT EXECUTE ON FUNCTION ops.fn_compute_kpi_daily(date) TO authenticated, service_role;
+
+COMMENT ON FUNCTION ops.fn_compute_kpi_daily(date) IS
+  'Compute and upsert ops.kpi_daily rows for a single date. Joins delivery_stops/service_jobs/reman_jobs to team_members via driver_id/tech_id. Idempotent. Called nightly by cron nightly-kpi-daily for current_date - 1.';
+
+-- ------------------------------------------------------------------
+-- 2. Nightly cron at 11:00 UTC for yesterday's KPIs.
+-- ------------------------------------------------------------------
+SELECT cron.schedule('nightly-kpi-daily', '0 11 * * *', $$
+  SELECT ops.fn_compute_kpi_daily(current_date - 1);
+$$);
+
+-- ------------------------------------------------------------------
+-- 3. Backfill the last 30 days at apply time so kpi_daily isn't empty
+--    when dashboards first read it.
+-- ------------------------------------------------------------------
+DO $$
+DECLARE
+  d date;
+BEGIN
+  FOR d IN
+    SELECT generate_series(current_date - 30, current_date - 1, interval '1 day')::date
+  LOOP
+    PERFORM ops.fn_compute_kpi_daily(d);
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Summary

CLAUDE.md (apbg-billing) §3.B — `ops.kpi_daily` was created with the right shape but no writer. This wires the nightly rollup.

## Stacking note

Built on top of PR #34 (refresh-snapshot helper). Diff against main shows two commits — once PR #34 merges, this rebases cleanly to just the kpi_daily commit. Or merge in either order; they don't conflict.

## What's added

**`ops.fn_compute_kpi_daily(p_date date)`** — single-day rollup. For every active `ops.team_members` row in `department IN ('delivery', 'service', 'reman')`, aggregates that day's signal from `delivery_stops` / `service_jobs` / `reman_jobs` (joined via `driver_id` / `tech_id`) and upserts into `ops.kpi_daily` keyed on `(kpi_date, team_member_id)`. Idempotent.

| Department | Computed metrics |
|---|---|
| delivery | `stops_completed`, `delivery_revenue` (`sum(sf_total)`), `delivery_cost` (`annual_wage / 260 × split_pct`), `cost_per_stop`, `revenue_per_stop`, `margin_per_stop` |
| service  | `jobs_completed`, `service_revenue`, `service_cost`, `cost_per_job`, `revenue_per_job`, `billable_hours`, `total_hours` (dispatch→completion or billable fallback), `utilization_pct`, `first_fix_pct`, `avg_response_min` (dispatch→arrival) |
| reman    | `units_completed` (keyed on `completion_date`), `reman_revenue`, `reman_cost`, `labor_per_unit`, `parts_per_unit`, `margin_per_unit`, `turnaround_days` (intake→completion) |

**Cron `nightly-kpi-daily`** — `0 11 * * *` UTC. Runs `fn_compute_kpi_daily(current_date - 1)`. 11 UTC sits comfortably after `sync-qbo` (09 UTC) and the half-hourly `sync-sf` cycle, so the day's data has settled.

**Backfill at apply time** — `DO` loop calls `fn_compute_kpi_daily` over `current_date - 30 .. current_date - 1`. Already applied via MCP; produced **210 rows** (30 days × 7 active members in delivery/service/reman):

```
total_rows: 210
distinct_dates: 30
distinct_members: 7
rows_with_stops:  28  (delivery activity)
rows_with_jobs:   16  (service activity)
rows_with_units:   0  (reman: only 5 jobs in prod, none mapped to a tech_id yet)
latest_date: 2026-05-05
```

## Manifest update

`architecture/sync-manifest.json`:
- `kpi_daily` removed from `orphans`.
- `fn_compute_kpi_daily` added to `writers`.
- Lint stays clean: 17 writers, 20 orphans, 0 warnings.

## Test plan

- [ ] Confirm the manifest lint passes on this PR (Netlify build runs it).
- [ ] After deploy: query `SELECT count(*) FROM ops.kpi_daily` — should be ≥210 rows.
- [ ] Tomorrow's 11:00 UTC: confirm cron fired and added today's rows.
- [ ] Spot-check `cost_per_stop` and `revenue_per_stop` math for a known driver/day.

## Notes

- 0 reman units in the backfill is expected — only 5 reman jobs exist in prod and none are mapped to a `team_members.id` yet (per CLAUDE.md, "name must match SF tech name exactly for job attribution"; reman tech assignment is still being onboarded).
- `miles_driven` / `revenue_per_mile` columns stay `NULL` until FleetComplete sync lands (planned, see `fleet_*` orphans).

https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL

---
_Generated by [Claude Code](https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL)_