### PR TITLE
chore(sql): drop kpi_embeddings + qbo_expenses (dead orphans)

### DIFF
--- a/architecture/schema-snapshot.json
+++ b/architecture/schema-snapshot.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Snapshot of base tables in the ops.* schema, captured on 2026-05-05 from the live Supabase project (gfsdpwiqzshhexkofiif). The lint script compares this list against sync-manifest.json to detect drift. Regenerate with: node architecture/refresh-snapshot.mjs (TODO).",
-  "captured_at": "2026-05-05",
+  "captured_at": "2026-05-06",
   "schema": "ops",
   "tables": [
     "alert_settings",
@@ -38,12 +38,10 @@
     "item_set_items",
     "item_sets",
     "kpi_daily",
-    "kpi_embeddings",
     "pl_snapshots",
     "qbo_customers",
     "qbo_employees_cache",
     "qbo_expense_lines",
-    "qbo_expenses",
     "qbo_inventory_adjustment_lines",
     "qbo_inventory_adjustments",
     "qbo_invoice_lines",

--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -237,14 +237,6 @@
       "reason": "Table exists, 0 rows. No cron, no edge function. Planned cadence and endpoint not yet specified."
     },
     {
-      "table": "ops.qbo_expenses",
-      "reason": "Empty stub. CLAUDE.md (apbg-billing) §3.A described it as the planned Purchase-table sync target, but the running sync-qbo-expenses cron (09:40 UTC, verified via cron.job 2026-05-06) writes ops.qbo_expense_lines instead. Decision pending: drop the unused qbo_expenses table, or expand sync-qbo-expenses to also populate it as a header-level rollup."
-    },
-    {
-      "table": "ops.kpi_embeddings",
-      "reason": "Vector embeddings table. Investigated 2026-05-06: 0 rows, no cron writer, no manual UI references. Likely experimental / abandoned. Drop in a future cleanup unless someone claims it."
-    },
-    {
       "table": "ops.crm_deals",
       "reason": "Zoho CRM integration placeholder per joint architecture doc §6. No sync function. Planned, not built."
     },

--- a/supabase/migrations/20260506c_drop_dead_orphan_tables.sql
+++ b/supabase/migrations/20260506c_drop_dead_orphan_tables.sql
@@ -1,0 +1,30 @@
+-- Drop two confirmed-dead orphan tables.
+--
+-- Investigation summary (sync-manifest.json orphans, audited 2026-05-06):
+--
+--   ops.kpi_embeddings
+--     0 rows in prod, no cron writer, no UI references, no RPC consumers.
+--     Likely experimental / abandoned. Manifest had it as orphan with
+--     "drop in a future cleanup unless someone claims it." This is that
+--     cleanup.
+--
+--   ops.qbo_expenses
+--     0 rows in prod. The running sync-qbo-expenses cron (09:40 UTC) writes
+--     ops.qbo_expense_lines instead, which is the table dashboards actually
+--     read. The qbo_expenses header table was a planned aggregate that never
+--     got wired. CLAUDE.md (apbg-billing) §3.A originally described it; the
+--     header rollup can be re-added later as a view over qbo_expense_lines
+--     if needed, no need to keep an empty stub around.
+--
+-- Both drops are safe in the sense that:
+--   - No code in this repo references either table outside the historical
+--     migration that originally created them (and a UNIQUE constraint
+--     migration in 20260503g for qbo_expenses that becomes a no-op).
+--   - The lint manifest's orphan entries will be removed in the same PR.
+--
+-- CASCADE on DROP TABLE drops any dependent objects (foreign keys, views).
+-- No known dependents on either table at apply time, but CASCADE is
+-- defensive against drift.
+
+DROP TABLE IF EXISTS ops.kpi_embeddings CASCADE;
+DROP TABLE IF EXISTS ops.qbo_expenses CASCADE;


### PR DESCRIPTION
## Summary

Two confirmed-dead orphan tables, audited 2026-05-06 via the manifest. Drops the schema and removes the orphan entries.

| Table | State | Why drop |
|---|---|---|
| `ops.kpi_embeddings` | 0 rows, no writer, no UI / RPC refs | Likely experimental; never wired |
| `ops.qbo_expenses` | 0 rows | `sync-qbo-expenses` (09:40 UTC) writes `ops.qbo_expense_lines` instead, which is the table dashboards actually read. The header rollup can be re-added later as a view over `qbo_expense_lines` if needed. |

Already applied to live via MCP and verified gone via `information_schema`.

## Manifest

- `schema-snapshot.json`: tables 63 → 61
- `sync-manifest.json`: orphan entries removed for both tables
- Lint stays clean: **18 writers, 17 orphans, 61 tables, 0 warnings**

## Risk

CASCADE on DROP TABLE drops dependents defensively, but no known dependents at apply time. The only repo references are historical migrations:

- `20260503g_expense_lines_actual_cost.sql` adds a UNIQUE constraint to `qbo_expenses` — becomes a no-op after the drop, which is fine because the migration was guarded with `IF NOT EXISTS (SELECT 1 FROM pg_constraint ...)`.

## Test plan

- [ ] Netlify build passes (manifest lint runs first, must be clean — confirmed locally).
- [ ] After merge: `\d ops.qbo_expenses` returns nothing in psql / Studio.
- [ ] No dashboard regressions — neither table was being read.

https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL

---
_Generated by [Claude Code](https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL)_