### PR TITLE
fix(sql): proper REVOKE-table + GRANT-safe-columns for PII redact (§12 #6b)

### DIFF
--- a/supabase/migrations/20260506d_pii_redact_side_tables_fix.sql
+++ b/supabase/migrations/20260506d_pii_redact_side_tables_fix.sql
@@ -1,0 +1,54 @@
+-- Fix for the column-level REVOKE pattern in 20260505e_pii_redact_side_tables.sql.
+--
+-- The original migration ran `REVOKE SELECT (col) ON ops.X FROM anon` and
+-- expected anon's SELECT * queries to no longer return that column. In
+-- Postgres, that's not how column-level GRANT/REVOKE interacts with
+-- table-level privileges: when a role still holds a table-level SELECT
+-- grant, the role can read every column regardless of any column-level
+-- REVOKE. Verified post-apply via `SET ROLE anon; SELECT notes FROM
+-- ops.delivery_stops` — the SELECT succeeded, returning the column.
+--
+-- The correct pattern is to revoke the table-level grant entirely and then
+-- re-grant SELECT only on the safe columns. Once that's in place, anon
+-- queries that reference a redacted column return permission denied; safe
+-- columns continue to read normally.
+--
+-- Both consumer audits (Margin Minder + apbg-ops) were already clean of
+-- notes/memo references, so this is a no-op for current consumers — it
+-- just makes the redaction actually work.
+
+REVOKE SELECT ON ops.delivery_stops FROM anon;
+GRANT SELECT (
+  id, sf_job_id, sf_job_number, stop_date, driver_id, driver_name,
+  customer_ref_id, customer_name, address, arrival_time, departure_time,
+  duration_min, status, invoice_amount, qbo_invoice_id, synced_at,
+  sf_total, payment_status, qbo_invoice_matched, stale_alert_sent,
+  sf_status, sf_qb_invoice_number, sf_encoded_id
+) ON ops.delivery_stops TO anon;
+
+REVOKE SELECT ON ops.service_jobs FROM anon;
+GRANT SELECT (
+  id, sf_job_id, sf_job_number, job_date, tech_id, tech_name,
+  customer_ref_id, customer_name, job_type, status, dispatch_time,
+  arrival_time, completion_time, duration_min, billable_hours,
+  parts_cost, labor_cost, invoice_amount, qbo_invoice_id, is_callback,
+  first_time_fix, synced_at, sf_total, payment_status, qbo_invoice_matched,
+  stale_alert_sent, sf_status, sf_qb_invoice_number, sf_encoded_id
+) ON ops.service_jobs TO anon;
+
+REVOKE SELECT ON ops.reman_jobs FROM anon;
+GRANT SELECT (
+  id, sf_job_id, sf_job_number, intake_date, completion_date, tech_id,
+  tech_name, equipment_type, serial_number, status, parts_cost,
+  labor_hours, labor_cost, sale_price, customer_ref_id, synced_at,
+  sf_total, payment_status, qbo_invoice_matched, stale_alert_sent,
+  sf_status, sf_qb_invoice_number, sf_encoded_id, warranty_returned_at,
+  warranty_returned_reason, field_failure_at, field_failure_reason
+) ON ops.reman_jobs TO anon;
+
+REVOKE SELECT ON ops.qbo_invoices FROM anon;
+GRANT SELECT (
+  id, qbo_invoice_id, doc_number, txn_date, due_date, customer_ref_id,
+  customer_name, public_customer_id, total_amount, balance, status,
+  department, entity, synced_at, qbo_updated_at
+) ON ops.qbo_invoices TO anon;


### PR DESCRIPTION
## Summary

Fix for the column-level REVOKE pattern in `20260505e_pii_redact_side_tables.sql` (PR #28).

When I applied PR #28 to live via MCP today, post-apply verification with `SET ROLE anon; SELECT notes FROM ops.delivery_stops` revealed the SELECT **succeeded**. The redaction wasn't actually working.

## Root cause

`REVOKE SELECT (col) ON table FROM role` does nothing when the role still holds a table-level SELECT grant — Postgres column-level REVOKE only applies when there's no table-level grant covering it. The original migration left the table-level grant in place, so `anon` could still read `notes` / `memo` directly.

## The fix

REVOKE the table-level SELECT, then GRANT SELECT only on the safe columns:

```sql
REVOKE SELECT ON ops.delivery_stops FROM anon;
GRANT SELECT (id, sf_job_id, …, [all-but-notes]) ON ops.delivery_stops TO anon;
-- repeated for service_jobs, reman_jobs, qbo_invoices
```

Tables fixed:
- `ops.delivery_stops` — `notes` redacted
- `ops.service_jobs` — `notes` redacted
- `ops.reman_jobs` — `notes` redacted
- `ops.qbo_invoices` — `memo` redacted

## Verification (post-apply via MCP)

```
SET ROLE anon; SELECT notes FROM ops.delivery_stops LIMIT 1;
→ ERROR: 42501: permission denied for table delivery_stops

SET ROLE anon; SELECT id, customer_name, status FROM ops.delivery_stops LIMIT 1;
→ {"id":601,"customer_name":"STARBIRD CHICKEN - CAMPBELL","status":"completed"}
```

## Impact on consumers

Both consumer audits (Margin Minder + apbg-ops) were already clean of `notes` / `memo` references — this is a no-op for current consumers. The fix just makes the redaction actually work as documented.

## Test plan

- [ ] Confirm live state matches expectation: anon `SELECT notes` denied, anon `SELECT *` excluding redacted column succeeds.
- [ ] Margin Minder pivot + reports unaffected.
- [ ] Ops dashboard customer-detail / RFM unaffected.

https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL

---
_Generated by [Claude Code](https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL)_