### PR TITLE
chore(architecture): refresh schema snapshot post rep-table drop

### DIFF
--- a/architecture/schema-snapshot.json
+++ b/architecture/schema-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Snapshot of base tables in the ops.* schema, captured on 2026-05-05 from the live Supabase project (gfsdpwiqzshhexkofiif). The lint script compares this list against sync-manifest.json to detect drift. Regenerate with: node architecture/refresh-snapshot.mjs (TODO).",
+  "$comment": "Snapshot of base tables in the ops.* schema, captured from the live Supabase project (gfsdpwiqzshhexkofiif). The lint script compares this list against sync-manifest.json to detect drift. Refresh with: node architecture/refresh-snapshot.mjs",
   "captured_at": "2026-05-06",
   "schema": "ops",
   "tables": [
@@ -8,11 +8,9 @@
     "category_segments",
     "channels",
     "cogs_accounts",
-    "commission_rules",
     "crm_deals",
     "customer_channels",
     "customer_health_snapshots",
-    "customer_sales_reps",
     "dashboard_settings",
     "db_health_snapshots",
     "delivery_stops",
@@ -54,7 +52,6 @@
     "role_types",
     "sales_plan_lines",
     "sales_plans",
-    "sales_reps",
     "saved_views",
     "segments",
     "service_jobs",

--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -283,18 +283,6 @@
     {
       "table": "ops.hr_time_off",
       "reason": "HR integration placeholder; pending. Could be fed by qbo_pto_cache if that gets wired."
-    },
-    {
-      "table": "ops.commission_rules",
-      "reason": "Scheduled for drop in 20260505d_taxonomy_drop_rep_tables.sql (PR #27, merged 2026-05-05). Will be removed at next migration apply. Lint should ignore once the drop runs."
-    },
-    {
-      "table": "ops.customer_sales_reps",
-      "reason": "Scheduled for drop in 20260505d_taxonomy_drop_rep_tables.sql (PR #27, merged 2026-05-05)."
-    },
-    {
-      "table": "ops.sales_reps",
-      "reason": "Scheduled for drop in 20260505d_taxonomy_drop_rep_tables.sql (PR #27, merged 2026-05-05)."
     }
   ]
 }


### PR DESCRIPTION
## Summary

When PR #27's rep-teardown migration was applied to prod via MCP earlier today, the live schema dropped 3 tables (`commission_rules`, `customer_sales_reps`, `sales_reps`) that the snapshot still listed. Lint kept passing because their orphan entries in `sync-manifest.json` justified them — but the entries had become stale references to non-existent tables.

## Changes

- `schema-snapshot.json`: tables 61 → 58, `captured_at` bumped to 2026-05-06.
- `sync-manifest.json`: removes the 3 stale rep-table orphan entries.

## Lint

```
Manifest clean: 18 writers, 14 orphans, 58 tables in snapshot. 0 warning(s).
```

(was: 18 writers / 17 orphans / 61 tables)

## Test plan

- [ ] Netlify build passes (`node architecture/lint-manifest.mjs` runs first).
- [ ] No code changes; manifest-only.

https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL

---
_Generated by [Claude Code](https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL)_