### PR TITLE
feat(architecture): migration-apply drift checker + APPLY-MIGRATIONS doc

### DIFF
--- a/architecture/APPLY-MIGRATIONS.md
+++ b/architecture/APPLY-MIGRATIONS.md
@@ -1,0 +1,70 @@
+# Applying Supabase migrations
+
+The Netlify deploy pipeline does **not** auto-apply migrations from
+`supabase/migrations/`. Merging a migration PR ships the file to git but
+leaves the prod schema unchanged until someone applies it.
+
+This page documents the apply workflow + the drift checker.
+
+## Applying a new migration
+
+Three options, pick whichever is convenient:
+
+### 1. Supabase MCP (preferred for Claude)
+
+Claude Code with the Supabase MCP server uses the
+`mcp__d091b47c…__apply_migration` tool to apply DDL. Each call records the
+migration in `supabase_migrations.schema_migrations` with the name you
+pass in. This is the path I've been using throughout this session.
+
+### 2. Supabase Studio SQL editor
+
+Open the project's SQL editor, paste the migration body, run. Studio
+records the apply in `supabase_migrations.schema_migrations`.
+
+### 3. Supabase CLI
+
+```bash
+supabase db push
+```
+
+Picks up everything in `supabase/migrations/` not yet in
+`schema_migrations` and applies in order. Requires the project to be
+linked (`supabase link --project-ref gfsdpwiqzshhexkofiif`).
+
+## Checking for drift
+
+After merging migration PRs, run:
+
+```bash
+node architecture/check-pending-migrations.mjs
+```
+
+It calls `ops.fn_list_applied_migrations()` (SECURITY DEFINER, anon-callable)
+and prints any `*.sql` file in `supabase/migrations/` whose name component
+isn't in the applied set. Common reasons for false positives:
+
+- An MCP apply split one file into multiple `apply_migration` calls
+  (e.g. PR #27's rep teardown applied as `taxonomy_drop_rep_tables` +
+  `rep_free_rpcs` + `rep_free_rpcs_part2`). The original file
+  (`20260505d_taxonomy_drop_rep_tables.sql`) appears pending even though
+  its content is live.
+- Very old files applied before `supabase_migrations.schema_migrations`
+  existed are listed as pending.
+
+When the script flags a real pending migration, apply via one of the
+three paths above.
+
+## Why isn't this CI-enforced?
+
+The lint catches manifest drift because the snapshot is checked into git.
+Migration drift is operational — applying is a deploy action, not a
+correctness property of the code. Failing CI on "you forgot to apply"
+would also fail on every PR until the merge happens, which is annoying.
+The script is a deliberate "informational, run when you want to check"
+tool rather than a gate.
+
+If we ever want CI enforcement, the right shape is a separate "apply on
+merge" GitHub Action gated on the `main` branch — not a build-time check.
+That's a future-state migration; today's convention is manual apply +
+this drift checker.

--- a/architecture/check-pending-migrations.mjs
+++ b/architecture/check-pending-migrations.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Lists migration files in supabase/migrations/ alongside what's actually
+// been applied to prod (per supabase_migrations.schema_migrations). Flags
+// files whose name component doesn't appear in the applied list.
+//
+// Why this exists: Netlify doesn't auto-apply Supabase migrations on
+// deploy. Migrations are applied manually (Supabase Studio, the CLI's
+// `supabase db push`, or the `apply_migration` MCP tool). It's easy to
+// merge a PR and forget to apply, leaving the schema and the repo out
+// of sync. This script makes that drift visible.
+//
+// File naming convention: <YYYYMMDD><suffix?>_<name>.sql
+// The matching key is the <name> portion (everything after the first _).
+// MCP applies use the same name; supabase db push uses the full filename
+// including date prefix as the version, but the function still records
+// the same name. So matching by name works in both cases.
+//
+// Exit code: 0 always (informational only — applying is operational, the
+// repo state isn't authoritative). Print to stdout for human review.
+
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const SB_URL = 'https://gfsdpwiqzshhexkofiif.supabase.co';
+const SB_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdmc2Rwd2lxenNoaGV4a29maWlmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU1OTUyMzcsImV4cCI6MjA5MTE3MTIzN30.AygnPJwQ5NfIeKwPtkO6tgVYmkV3MAxL1lMFwN9HPnY';
+
+const MIGRATIONS_DIR = resolve(__dirname, '..', 'supabase', 'migrations');
+
+async function fetchAppliedNames() {
+  const res = await fetch(SB_URL + '/rest/v1/rpc/fn_list_applied_migrations', {
+    method: 'POST',
+    headers: {
+      apikey: SB_KEY,
+      Authorization: 'Bearer ' + SB_KEY,
+      'Accept-Profile': 'ops',
+      'Content-Profile': 'ops',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({}),
+  });
+  if (!res.ok) {
+    throw new Error('fn_list_applied_migrations failed: ' + res.status + ' ' + (await res.text()));
+  }
+  const names = await res.json();
+  if (!Array.isArray(names)) {
+    throw new Error('fn_list_applied_migrations returned non-array: ' + JSON.stringify(names));
+  }
+  return names;
+}
+
+// Strip the leading <YYYYMMDD><optional letter>_ prefix from a filename
+// like 20260505d_taxonomy_drop_rep_tables.sql → taxonomy_drop_rep_tables
+function nameFromFile(filename) {
+  const stripped = filename.replace(/\.sql$/, '');
+  const match = stripped.match(/^\d{8}[a-z]?_(.+)$/);
+  return match ? match[1] : stripped;
+}
+
+(async () => {
+  const files = readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith('.sql')).sort();
+  const fileNames = files.map((f) => ({ file: f, name: nameFromFile(f) }));
+
+  console.log('Fetching applied migrations from Supabase…');
+  const applied = await fetchAppliedNames();
+  const appliedSet = new Set(applied);
+  console.log('  → ' + applied.length + ' migrations applied in prod.');
+
+  const pending = fileNames.filter(({ name }) => !appliedSet.has(name));
+
+  if (pending.length === 0) {
+    console.log('\nAll repo migrations look applied.');
+    return;
+  }
+
+  console.log('\n⚠ ' + pending.length + ' migration file(s) in the repo without a matching applied entry:');
+  for (const p of pending) {
+    console.log('  · ' + p.file + '  (name: ' + p.name + ')');
+  }
+  console.log('\nReasons this can happen:');
+  console.log('  1. The migration was merged but never applied — apply it (Studio / CLI / MCP).');
+  console.log('  2. The migration was applied under a different name (e.g. an MCP apply split');
+  console.log('     one file into multiple statements with separate names). Check Supabase Studio');
+  console.log('     migrations panel against the file content.');
+  console.log('  3. The file was applied before supabase_migrations.schema_migrations existed.');
+  console.log('     For very old migrations this is normal.');
+})().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/supabase/migrations/20260506e_fn_list_applied_migrations.sql
+++ b/supabase/migrations/20260506e_fn_list_applied_migrations.sql
@@ -1,0 +1,23 @@
+-- Helper RPC for the migration-apply drift checker. Returns the list of
+-- migration names recorded in supabase_migrations.schema_migrations (the
+-- internal Supabase-managed history table), so a script using only the
+-- anon key can compare to the migration files in supabase/migrations/.
+--
+-- SECURITY DEFINER because anon doesn't have direct read on
+-- supabase_migrations.schema_migrations. Returns names only — no SQL
+-- bodies, no version timestamps that could leak credentials.
+--
+-- Naming follows ops.fn_list_ops_tables() (the schema-snapshot helper).
+
+CREATE OR REPLACE FUNCTION ops.fn_list_applied_migrations()
+RETURNS text[]
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $$
+  SELECT array_agg(DISTINCT name ORDER BY name)
+  FROM supabase_migrations.schema_migrations
+$$;
+
+GRANT EXECUTE ON FUNCTION ops.fn_list_applied_migrations() TO anon, authenticated;
+
+COMMENT ON FUNCTION ops.fn_list_applied_migrations() IS
+  'Returns the alphabetized DISTINCT list of migration names recorded in supabase_migrations.schema_migrations. Used by architecture/check-pending-migrations.mjs to flag migration files that haven''t been applied yet. SECURITY DEFINER because anon can''t read the system migrations table.';


### PR DESCRIPTION
## Summary

**Investigation**: Netlify doesn't auto-apply Supabase migrations on deploy. Each migration file in `supabase/migrations/` requires a manual apply via Supabase Studio, the CLI's `supabase db push`, or the Supabase MCP `apply_migration` tool. That's how 5 architecture migrations from PRs #24–#28 sat unapplied for several days until I caught the gap and applied them via MCP earlier today.

**Resolution**: documents the existing manual-apply convention + adds a drift checker so the gap is visible.

## What's added

- **`supabase/migrations/20260506e_fn_list_applied_migrations.sql`** — SECURITY DEFINER RPC returning alphabetized DISTINCT names from `supabase_migrations.schema_migrations` (Supabase's internal history table). Anon-callable; schema introspection only. Already applied via MCP.
- **`architecture/check-pending-migrations.mjs`** — Node script (no deps). Reads `*.sql` files from `supabase/migrations/`, calls the RPC, prints any file whose name component isn't in the applied set. Informational; doesn't fail.
- **`architecture/APPLY-MIGRATIONS.md`** — documents the three apply paths (MCP, Studio, CLI), how to use the drift checker, and why the check isn't CI-enforced.

## Caveats (documented)

- MCP applies that split one file across multiple `apply_migration` calls (e.g. PR #27's rep teardown, applied as `taxonomy_drop_rep_tables` + `rep_free_rpcs` + `rep_free_rpcs_part2`) produce false positives — the original file shows pending even though its content is live.
- Very old files applied before `supabase_migrations.schema_migrations` existed are listed as pending.

## Not in scope

CI-enforcement of "every migration is applied." That fights the workflow (every PR would fail until merge → apply happens). The right shape is a future "apply on merge" GitHub Action gated on `main`, not a build-time gate. Today's convention stays manual + this informational checker.

## Test plan

- [ ] After deploy: `node architecture/check-pending-migrations.mjs` prints applied count + any pending files.
- [ ] Add a fake migration file (don't apply); rerun script; should appear in pending list.
- [ ] Apply via MCP; rerun; should disappear.

https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL

---
_Generated by [Claude Code](https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL)_