### PR TITLE
fix(sql): relax qbo_customers_read to "authenticated USING (true)"

### DIFF
--- a/supabase/migrations/20260506f_qbo_customers_policy_pragmatic.sql
+++ b/supabase/migrations/20260506f_qbo_customers_policy_pragmatic.sql
@@ -1,0 +1,31 @@
+-- §12 #6 follow-up — relax the qbo_customers_read policy from a custom
+-- JWT-role gate to a simple "must be authenticated" gate.
+--
+-- Background: PR #26 (20260505c) shipped a policy that required
+-- `auth.jwt()->>'role' IN ('admin', 'superadmin', 'margin-minder-user',
+-- 'ops-user')`. That assumed the apbg-gateway was minting JWTs with one
+-- of those custom role claims. In practice the gateway mints the
+-- Supabase Auth default `role='authenticated'`, so the policy denies
+-- every signed-in user too — only SECURITY DEFINER RPCs (which bypass
+-- RLS) work. Apps that read qbo_customers via RPC keep working; any
+-- direct table read fails for everyone.
+--
+-- That's strict but accidental. The intent of the gate was "anon
+-- blocked, signed-in users allowed" — keep PII off public bundles
+-- without breaking authenticated dashboard reads. This migration
+-- aligns the policy with the intent: TO authenticated USING (true).
+-- Anon stays blocked (the GRANT was already revoked from anon in
+-- 20260505c and that REVOKE remains).
+--
+-- When the gateway eventually mints custom role claims, the policy can
+-- be tightened back. Until then, "signed in" is the gate.
+
+DROP POLICY IF EXISTS qbo_customers_read ON ops.qbo_customers;
+
+CREATE POLICY qbo_customers_read ON ops.qbo_customers
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+COMMENT ON POLICY qbo_customers_read ON ops.qbo_customers IS
+  'PII gate: any authenticated session can SELECT (must have a valid bearer token). Anon role has no SELECT grant on the table — direct anon queries fail at the privilege check before this policy runs. PII-safe access for anon goes through ops.v_customer_directory or ops.fn_customer_directory().';


### PR DESCRIPTION
## Summary

PR #26's `qbo_customers_read` policy gated SELECT on `auth.jwt()->>'role' IN ('admin', 'superadmin', 'margin-minder-user', 'ops-user')` — but the `apbg-gateway` mints JWTs with the Supabase Auth default `role='authenticated'`, not those custom claims. Net effect: the policy denied **every authenticated user too**, not just anon.

Apps that read `qbo_customers` via SECURITY DEFINER RPCs (`fn_customer_directory`, `fn_customer_detail`, `fn_customer_health`) kept working since they bypass RLS — but any direct table read failed for everyone, not just anon.

That was accidental over-tightening. The intent of the gate was "anon blocked, signed-in users allowed."

## Fix

```sql
DROP POLICY qbo_customers_read ON ops.qbo_customers;
CREATE POLICY qbo_customers_read ON ops.qbo_customers
  FOR SELECT TO authenticated USING (true);
```

Anon remains blocked: the `REVOKE SELECT ON ops.qbo_customers FROM anon` from PR #26's `20260505c` migration is unchanged. Anon's PII-safe path is still `v_customer_directory` / `fn_customer_directory()`.

## Future direction

When the gateway eventually mints custom role claims (per the joint architecture doc §5 roadmap), the policy can be tightened back to gate by role. Until then, "signed in" is the gate.

## Test plan

- [x] Already applied to live via MCP. `pg_get_expr(polqual)` now returns `true` (was the role-claim CASE).
- [ ] Verify any future authenticated direct-table SELECT against `qbo_customers` succeeds.
- [ ] Anon `SELECT * FROM ops.qbo_customers` still denied (REVOKE unchanged).

https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL

---
_Generated by [Claude Code](https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL)_