### PR TITLE
feat: sync-fleetcomplete edge function for Unity GraphQL API (CLAUDE.md §3.C)

### DIFF
--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -175,6 +175,22 @@
       "last_verified": "2026-05-06"
     },
     {
+      "name": "sync-fleetcomplete",
+      "kind": "supabase-edge-function",
+      "source_repo": "skypace/apbg-billing",
+      "schedule": "hourly :05 (cron disabled until env vars configured; see supabase/functions/sync-fleetcomplete/README.md)",
+      "writes": [
+        "ops.fc_token_cache",
+        "ops.fleet_vehicles",
+        "ops.fleet_trips",
+        "ops.fleet_fuel_transactions",
+        "ops.fleet_maintenance"
+      ],
+      "external_inputs": ["Unity by Powerfleet GraphQL API at api.fleetcomplete.com"],
+      "notes": "Source at supabase/functions/sync-fleetcomplete/. Vehicles sync IMPLEMENTED; trips / fuel / maintenance STUBBED awaiting GraphQL queries from the GraphiQL IDE. Cron in 20260506h_sync_fleetcomplete_cron.sql ships disabled — uncomment + re-apply once FC_USERNAME / FC_PASSWORD secrets are set and a manual run verifies.",
+      "last_verified": "2026-05-06"
+    },
+    {
       "name": "manual-ui:margin-minder-settings",
       "kind": "manual-ui",
       "source_repo": "skypace/apbg-billing",
@@ -241,28 +257,8 @@
       "reason": "Zoho CRM integration placeholder per joint architecture doc §6. No sync function. Planned, not built."
     },
     {
-      "table": "ops.fc_token_cache",
-      "reason": "FleetComplete OAuth token store. Writer would be sync-fleetcomplete (planned, not built). Joint doc §3 priority item."
-    },
-    {
-      "table": "ops.fleet_vehicles",
-      "reason": "FleetComplete integration; sync-fleetcomplete planned, not built."
-    },
-    {
-      "table": "ops.fleet_trips",
-      "reason": "FleetComplete integration; sync-fleetcomplete planned, not built."
-    },
-    {
-      "table": "ops.fleet_fuel_transactions",
-      "reason": "FleetComplete integration; sync-fleetcomplete planned, not built."
-    },
-    {
-      "table": "ops.fleet_maintenance",
-      "reason": "FleetComplete integration; sync-fleetcomplete planned, not built."
-    },
-    {
       "table": "ops.fleet_daily",
-      "reason": "FleetComplete daily rollup; planned, not built."
+      "reason": "FleetComplete daily rollup. Will be written by a daily aggregator that joins fleet_trips + fleet_fuel_transactions. Not yet built; sync-fleetcomplete handles per-resource pulls but doesn't compute the daily rollup."
     },
     {
       "table": "ops.hr_employees",

--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -187,8 +187,8 @@
         "ops.fleet_maintenance"
       ],
       "external_inputs": ["Unity by Powerfleet GraphQL API at api.fleetcomplete.com"],
-      "notes": "Source at supabase/functions/sync-fleetcomplete/. Vehicles sync IMPLEMENTED; trips / fuel / maintenance STUBBED awaiting GraphQL queries from the GraphiQL IDE. Cron in 20260506h_sync_fleetcomplete_cron.sql ships disabled — uncomment + re-apply once FC_USERNAME / FC_PASSWORD secrets are set and a manual run verifies.",
-      "last_verified": "2026-05-06"
+      "notes": "Source at supabase/functions/sync-fleetcomplete/. Vehicles sync IMPLEMENTED. Trips STUBBED (data source confirmed: getSnapshots(vehicleId, from, to) — needs trip-reconstruction logic from event-driven snapshots). Fuel NOT POSSIBLE via Unity (no fuel-transaction API; needs separate fuel-card integration). Maintenance BLOCKED upstream (only path is getWrappedReport which returns php-exception for every call regardless of input). See supabase/functions/sync-fleetcomplete/README.md for the full diagnostic. Cron in 20260506h_sync_fleetcomplete_cron.sql ships disabled — uncomment + re-apply once FC_USERNAME / FC_PASSWORD secrets are set and a manual run verifies.",
+      "last_verified": "2026-05-08"
     },
     {
       "name": "manual-ui:margin-minder-settings",

--- a/supabase/functions/sync-fleetcomplete/README.md
+++ b/supabase/functions/sync-fleetcomplete/README.md
@@ -2,14 +2,14 @@
 
 Pulls fleet data from the Unity (Powerfleet / FleetComplete) GraphQL API at `https://api.fleetcomplete.com/graphql` and upserts into `ops.fleet_*` tables.
 
-Status:
+Status (verified against the live schema 2026-05-08):
 
-| Resource | Status |
-|---|---|
-| `getVehicles` → `ops.fleet_vehicles` | Implemented |
-| `getTrips` → `ops.fleet_trips` | Stubbed; paste GraphQL query from GraphiQL IDE |
-| `getFuelTransactions` → `ops.fleet_fuel_transactions` | Stubbed |
-| `getMaintenance` → `ops.fleet_maintenance` | Stubbed |
+| Resource | Status | Source |
+|---|---|---|
+| `ops.fleet_vehicles` | **Implemented** | `getVehicles { vin id name assignedGroups{...} assignedDevices{...} }` |
+| `ops.fleet_trips` | **Stubbed (data source confirmed)** | `getSnapshots(vehicleId, from, to)` works — needs trip-reconstruction logic. See [Filling in the stubs](#filling-in-the-stubs). |
+| `ops.fleet_fuel_transactions` | **Not possible via Unity** | No fuel-transaction API exists in Unity GraphQL. Needs a separate fuel-card integration (Wex / Fleetcor / Voyager). |
+| `ops.fleet_maintenance` | **Blocked upstream** | Only path is `getWrappedReport(reportId="maintenance-schedule")`. The report engine returns `php-exception` for every call regardless of input. Needs Powerfleet support ticket. |
 
 ## Setup
 
@@ -71,17 +71,88 @@ The function's `ensureToken()` handles the lifecycle: cache hit → use; access 
 
 Unity allows **one active request per user**. Sending parallel requests returns HTTP 429. The function makes calls strictly sequentially and retries once after a 2-second backoff if it ever hits 429.
 
-## Filling in the stubbed syncs
+## Filling in the stubs
 
-For trips / fuel / maintenance:
+GraphiQL has been flaky for us — we recommend probing the schema directly via SQL through the Supabase MCP server (or any HTTP client) using `pg_net.http_post` against `https://api.fleetcomplete.com/graphql` with `Bearer <api_token>` + `userId: <account_id>` headers. The current token sits in `ops.fc_token_cache` (id=1) and is rotated by every function run.
 
-1. Open `https://api.fleetcomplete.com/graphiql?path=/graphql` in your browser.
-2. In the **Headers** panel paste:
-   ```json
-   { "userId": "82273656-cd69-4044-a431-36288e840181", "Authorization": "Bearer <fresh-access_token>" }
-   ```
-3. Browse the schema sidebar for query names matching the stubbed resources (likely `getTrips`, `getFuelTransactions`, `getMaintenance` — names are guesses; the IDE's autocomplete will reveal the truth).
-4. Run a query, copy the working query string + the JSON shape of the result.
-5. Paste both into the corresponding stub function in `index.ts` (the TODO comments document exactly which `ops.fleet_*` columns to populate).
+### Trips — `getSnapshots`-based reconstruction
+
+There is no direct `getTrips` query. The data is in `getSnapshots(vehicleId: UUID!, from: DateTime!, to: DateTime!) -> [CommonFormat]`. Snapshots are **event-driven** (not at fixed intervals — there are bursts of records when the engine starts and around state changes). To turn snapshots into `fleet_trips` rows:
+
+1. For each `fc_asset_id` in `ops.fleet_vehicles`, look up the bigint `vehicle_id`.
+2. Call `getSnapshots` for the desired window (last 26 h to overlap with the previous run).
+3. Walk snapshots in `timestamp` order. A trip is a maximal segment where `ignition.engineStatus = true`, separated by ≥ 2 minutes of off.
+4. `fc_trip_id = sha1(fc_asset_id + start_timestamp)` for upsert idempotency.
+5. Compute per trip:
+   - `trip_date` — start_time at vehicle local TZ
+   - `distance_miles` — sum of haversine between consecutive `gps.{latitude,longitude}` (or sum `canBus.canDeltaDistance`) × 0.621371
+   - `drive_time_min` — (end - start) / 60_000
+   - `idle_time_min` — sum of intra-trip seconds with `gps.speed = 0` / 60
+   - `max_speed_mph` — `max(gps.speed) × 0.621371` (Unity reports km/h)
+   - `avg_speed_mph` — `distance_miles / (drive_time_min / 60)`
+   - `driver_id` — lookup `ops.staff` by `driver.driverId` or `driver.iButton` (driver records are sparse; many snapshots have `driver: null`)
+   - `hard_brakes` / `hard_accels` / `speed_violations` — from `driverBehaviour` events; left null until the `DriverBehaviourType` enum is mapped
+6. Upsert into `ops.fleet_trips` on `fc_trip_id`.
+
+Volume estimate at the current 9-asset fleet: ~75 K snapshots/day, ~5 MB JSON per daily run. Keep `getSnapshots` calls **strictly sequential** (Unity allows one active request per user).
+
+Once the wrapped-report engine is fixed, `getWrappedReport(reportId: "vehicle-trips", input: ...)` becomes the easier path — its `report` field is JSON with the trip rows already aggregated.
+
+### Maintenance — blocked
+
+Only path is `getWrappedReport(reportId: "maintenance-schedule")`. Every call to `getWrappedReport` we've tried returns:
+
+```json
+{ "errors": [{
+    "message": "Something went wrong",
+    "extensions": { "error": "php-exception", "classification": "BAD_REQUEST" }
+}]}
+```
+
+We confirmed this 2026-05-08 with empty input, full input matching `getWrappedReportInputs`, and explicit period/asset_uuids/timezone/working_hours. Other top-level queries (`getVehicles`, `getSnapshots`, `getPeople`, etc.) work — it is specifically the report engine. Open a Powerfleet support ticket with our userId (`82273656-cd69-4044-a431-36288e840181`) and timestamps of failing calls.
+
+When unblocked, the resolver returns `{ reportId, report }` where `report` is JSON with rows ready to map onto `ops.fleet_maintenance`.
+
+### Fuel — separate integration needed
+
+Unity GraphQL has no fuel-transaction API. Per-snapshot `CommonFormat.fuel` and `canBus.canFuel*` give telemetry (tank level, consumption rate) but not $-denominated transactions. For `ops.fleet_fuel_transactions` we need to integrate the fuel-card provider (Wex / Fleetcor / Voyager / Comdata, depending on what APBG uses). Build that as a separate edge function (`sync-wex-fuel` or similar) and add it to `architecture/sync-manifest.json`.
+
+## Schema discovery cheat sheet
+
+Top-level queries on the Unity endpoint (verified 2026-05-08):
+
+```
+getUserInfo, getVehicles, getActiveVehicles, getVehicleById, getVehiclesByVin,
+getPeople, getPersonById, getPersonCustomFields,
+getGeofences, getGeofenceById,
+getSnapshots, getLatestSnapshots,
+getWrappedReport, getWrappedReportInputs,
+getGroups, getMetaSensors, getVehicleMappedSensors, getVehicleCustomFields,
+getLabels, getDeviceById, getDevicesBySerial,
+getWorkSchedules, getWorkScheduleById,
+getVehicleTypes, getRules, getRuleById, getRoles,
+getDriverAssignments
+```
+
+`CommonFormat` (returned by `getSnapshots` / `getLatestSnapshots`) shape:
+
+```
+vehicleId         UUID
+timestamp         DateTime
+locationTimestamp DateTime
+locationTimeZone  String
+gps              { state, latitude, longitude, direction, altitude, speed }   // speed in km/h
+ignition         { engineStatus }                                              // boolean
+driver           { driverId, iButton, oneWire, rfidIButton, rfidIButtonHex, rfid, rfidHex, ... }
+canBus           { canDistance, canDeltaDistance, canTripDistance, canFuelUsed, canTripFuelUsed,
+                   canFuelRate, engineRunTime, engineIdleTime, ... ~80 fields }
+fuel             { fuel, rawFuel, fuelLevel, totalFuelEconomy, fuelTankSize }
+driverBehaviour  { driverBehaviourType, driverBehaviourValue }
+misc             { power, vehicleBusType }
+```
+
+Speeds are km/h; distances are km — convert before writing `fleet_trips` (multiply by 0.621371).
+
+Wrapped-report IDs available from `getWrappedReportInputs { id title description inputs }` (29 reports as of 2026-05-08): `distance-details, driver-performance, dvir-trips, emissions, engine-diagnostics, engine-diagnostics-summary, fleet-performance, fleet-sensors, geofence-interaction, geofence-list, group-list, ifta-distance, inspections, maintenance-schedule, people-list, safety-events, utilization, vehicle-activity, vehicle-daily-summary, vehicle-distance, vehicle-events, vehicle-idling, vehicle-period-summary, vehicle-positions, vehicle-sensor-measurements, vehicle-speeding, vehicle-stops, vehicle-towing, vehicle-trips, vehicles`. **All currently blocked by the upstream php-exception.**
 
 Once a stub is filled in, redeploy with `supabase functions deploy sync-fleetcomplete`.

--- a/supabase/functions/sync-fleetcomplete/README.md
+++ b/supabase/functions/sync-fleetcomplete/README.md
@@ -1,0 +1,87 @@
+# sync-fleetcomplete edge function
+
+Pulls fleet data from the Unity (Powerfleet / FleetComplete) GraphQL API at `https://api.fleetcomplete.com/graphql` and upserts into `ops.fleet_*` tables.
+
+Status:
+
+| Resource | Status |
+|---|---|
+| `getVehicles` → `ops.fleet_vehicles` | Implemented |
+| `getTrips` → `ops.fleet_trips` | Stubbed; paste GraphQL query from GraphiQL IDE |
+| `getFuelTransactions` → `ops.fleet_fuel_transactions` | Stubbed |
+| `getMaintenance` → `ops.fleet_maintenance` | Stubbed |
+
+## Setup
+
+### 1. Set the secrets
+
+The function authenticates against Unity by calling `POST /login/token` with form-encoded `username` and `password`. Those go in Supabase secrets, **not** in the database:
+
+```bash
+# Via Supabase CLI:
+supabase secrets set --env-file .env.fc
+
+# Or one-by-one:
+supabase secrets set FC_USERNAME=skypace@brixbev.com
+supabase secrets set FC_PASSWORD='your-password-here'
+```
+
+(The Supabase Studio UI also has a Secrets / Environment Variables panel under Project Settings → Edge Functions.)
+
+### 2. Deploy the function
+
+```bash
+supabase functions deploy sync-fleetcomplete
+```
+
+### 3. Verify
+
+```bash
+curl 'https://gfsdpwiqzshhexkofiif.supabase.co/functions/v1/sync-fleetcomplete?mode=vehicles' \
+  -H 'apikey: <anon-or-service-role>' \
+  -H 'Authorization: Bearer <anon-or-service-role>'
+```
+
+Expected first-run shape:
+
+```json
+{ "ok": true, "mode": "vehicles", "vehicles": { "count": 12 } }
+```
+
+After a successful run, `ops.fc_token_cache` (id=1) will hold the rotated `api_token` and `refresh_token`. The function will reuse those on subsequent runs and only re-login when the refresh token expires (12 hours).
+
+### 4. Enable the nightly cron
+
+After verifying a manual run works, enable the cron schedule. The cron is defined in `supabase/migrations/20260506h_sync_fleetcomplete_cron.sql` but ships **commented out** — uncomment, apply (Studio / CLI / MCP), and the function will run hourly.
+
+## How auth works
+
+Unity uses a 5-minute access token + 12-hour refresh token issued via username/password login:
+
+```
+POST /login/token  (form: username, password)         → access_token + refresh_token
+POST /login/refresh (form: refreshToken)              → new access_token (and possibly new refresh_token)
+GET  /login/userinfo (Bearer <access_token>)          → [{ userName, userId, fleetName, fleetId }, ...]
+POST /graphql (Bearer <access_token>, userId header)  → GraphQL responses
+```
+
+The function's `ensureToken()` handles the lifecycle: cache hit → use; access expired but refresh valid → refresh; both expired → full login. Cached state lives in `ops.fc_token_cache` (id=1, singleton).
+
+## Rate limiting
+
+Unity allows **one active request per user**. Sending parallel requests returns HTTP 429. The function makes calls strictly sequentially and retries once after a 2-second backoff if it ever hits 429.
+
+## Filling in the stubbed syncs
+
+For trips / fuel / maintenance:
+
+1. Open `https://api.fleetcomplete.com/graphiql?path=/graphql` in your browser.
+2. In the **Headers** panel paste:
+   ```json
+   { "userId": "82273656-cd69-4044-a431-36288e840181", "Authorization": "Bearer <fresh-access_token>" }
+   ```
+3. Browse the schema sidebar for query names matching the stubbed resources (likely `getTrips`, `getFuelTransactions`, `getMaintenance` — names are guesses; the IDE's autocomplete will reveal the truth).
+4. Run a query, copy the working query string + the JSON shape of the result.
+5. Paste both into the corresponding stub function in `index.ts` (the TODO comments document exactly which `ops.fleet_*` columns to populate).
+
+Once a stub is filled in, redeploy with `supabase functions deploy sync-fleetcomplete`.

--- a/supabase/functions/sync-fleetcomplete/index.ts
+++ b/supabase/functions/sync-fleetcomplete/index.ts
@@ -241,15 +241,35 @@ interface FcVehicle {
   vin: string | null;
   id: string;
   name: string | null;
+  licensePlate: string | null;
+  make: string | null;
+  model: string | null;
+  year: number | null;
   assignedGroups?: { id: string; description: string | null; name: string | null; fleetId: string; externalId: string | null }[];
   assignedDevices?: { id: string; serial: string | null; phoneNumber: string | null }[];
 }
 
+// NOTE: Vehicle.latestData (and its odometer / engineHours / fuel children) is
+// the obvious source for current odometer, but its resolver is broken on
+// Unity's side: any selection under latestData triggers
+//   "Invalid timestamp, ISO8601 format expected: 2023-08-01T00:00:00Z"
+// repeated once per vehicle (verified 2026-05-08, fleet of 9). The bug fires
+// even when `timestamp` is not in the selection set, so we cannot use this
+// path. Workarounds for current odometer:
+//   (a) getLatestSnapshots(vehicleIds: [UUID]) → CommonFormat.canBus.canDistance
+//       (cumulative km from CAN-bus; not all vehicles expose CAN data).
+//   (b) Sum CommonFormat.canBus.canDeltaDistance across getSnapshots over a
+//       sliding window, applied as a delta to the previous odometer reading.
+// Tracked alongside the wrapped-report bug for the Powerfleet support ticket.
 const VEHICLES_QUERY = `{
   getVehicles {
     vin
     id
     name
+    licensePlate
+    make
+    model
+    year
     assignedGroups { id description name fleetId externalId }
     assignedDevices { id serial phoneNumber }
   }
@@ -261,15 +281,15 @@ async function syncVehicles(ctx: { accessToken: string; userId: string }) {
   const now = new Date().toISOString();
 
   const rows = vehicles.map((v) => ({
-    fc_asset_id: v.id,
-    vehicle_name: v.name,
-    vin: v.vin,
-    // Unity's getVehicles doesn't expose make/model/year/license/odometer in
-    // this shape; if/when we find a richer query (e.g. getVehiclesById with a
-    // full projection), populate those fields here. For now, default status
-    // to 'active' to satisfy the CHECK constraint.
-    status: 'active' as const,
-    synced_at: now,
+    fc_asset_id:   v.id,
+    vehicle_name:  v.name,
+    vin:           v.vin,
+    license_plate: v.licensePlate,
+    make:          v.make,
+    model:         v.model,
+    year:          v.year,
+    status:        'active' as const,
+    synced_at:     now,
   }));
 
   if (rows.length === 0) return { count: 0 };

--- a/supabase/functions/sync-fleetcomplete/index.ts
+++ b/supabase/functions/sync-fleetcomplete/index.ts
@@ -26,16 +26,43 @@
 //   fleet_id   — Unity fleet UUID (informational; we use account_id)
 //   base_url   — defaults to https://api.fleetcomplete.com/
 //
-// Status of resource syncs:
-//   getVehicles         IMPLEMENTED  (queries vin / id / name / groups / devices)
-//   getTrips            STUBBED      (need GraphQL query name + shape from GraphiQL)
-//   getFuelTransactions STUBBED      (same)
-//   getMaintenance      STUBBED      (same)
+// Status of resource syncs (verified against the live schema 2026-05-08):
+//   getVehicles    IMPLEMENTED  via getVehicles { vin id name assignedGroups{...} assignedDevices{...} }
+//   syncTrips      STUBBED      — getSnapshots(vehicleId, from, to) works and returns CommonFormat
+//                                 records. Building fleet_trips rows requires reconstructing trips
+//                                 from event-driven snapshots (group by ignition.engineStatus
+//                                 transitions, sum haversine distance, max gps.speed). See the
+//                                 syncTrips comment for the concrete plan.
+//   syncFuel       NOT POSSIBLE — Unity GraphQL has no fuel-transaction API. Only per-snapshot
+//                                 CAN-bus fuel level / fuel rate (CommonFormat.canBus.canFuel*,
+//                                 CommonFormat.fuel.*). For $-denominated fuel transactions we
+//                                 need a separate fuel-card integration (Wex / Fleetcor / Voyager).
+//   syncMaintenance BLOCKED     — only path is getWrappedReport(reportId='maintenance-schedule').
+//                                 Every call to getWrappedReport returns
+//                                 {"error":"php-exception","message":"Something went wrong"}
+//                                 regardless of input shape (verified 2026-05-08 with empty
+//                                 input, full input matching getWrappedReportInputs schema, and
+//                                 explicit period/asset_uuids/timezone/working_hours). The other
+//                                 query types (getVehicles / getSnapshots / getPeople / etc.)
+//                                 work — the report engine itself is the problem. Needs Powerfleet
+//                                 support ticket: "getWrappedReport returns generic php-exception
+//                                 for all reportIds". Until that's fixed, no maintenance data.
 //
-// Once the GraphQL query strings are confirmed via the GraphiQL IDE at
-// https://api.fleetcomplete.com/graphiql?path=/graphql, fill in the
-// stubbed sync* functions below — the upsert plumbing is already wired
-// to the corresponding ops.fleet_* tables.
+// Schema discovery cheat sheet (use via direct GraphQL, not GraphiQL — GraphiQL has been
+// flaky for us):
+//   Top-level queries:  getVehicles, getActiveVehicles, getVehicleById, getPeople, getPersonById,
+//                       getGeofences, getSnapshots, getLatestSnapshots, getWrappedReport,
+//                       getWrappedReportInputs, getGroups, getDriverAssignments, ...
+//   CommonFormat fields: vehicleId, timestamp, locationTimestamp, locationTimeZone,
+//                        gps{state,latitude,longitude,direction,altitude,speed},
+//                        ignition{engineStatus},
+//                        driver{driverId,iButton,oneWire,rfidIButton,...},
+//                        canBus{canDistance,canDeltaDistance,canFuelUsed,canFuelRate,
+//                               engineRunTime,engineIdleTime,...},
+//                        fuel{fuel,rawFuel,fuelLevel,totalFuelEconomy,fuelTankSize},
+//                        driverBehaviour{driverBehaviourType,driverBehaviourValue},
+//                        misc{power,vehicleBusType}.
+//   Speeds are km/h, distances are km — convert to mph/miles before writing fleet_trips.
 
 // deno-lint-ignore-file no-explicit-any
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
@@ -258,31 +285,91 @@ async function syncVehicles(ctx: { accessToken: string; userId: string }) {
 // ---------- stubbed syncs (paste GraphQL queries from GraphiQL IDE) ----------
 
 async function syncTrips(_ctx: { accessToken: string; userId: string }) {
-  // TODO(unity): replace with the real GraphQL query for trips. From the
-  // GraphiQL IDE at https://api.fleetcomplete.com/graphiql?path=/graphql,
-  // search the schema for getTrips / getJourneys / getRouteHistory or
-  // similar, then map fields onto ops.fleet_trips:
-  //   fc_trip_id, vehicle_id (FK to fleet_vehicles), driver_id, trip_date,
-  //   start_time, end_time, start_address, end_address, distance_miles,
-  //   drive_time_min, idle_time_min, max_speed_mph, avg_speed_mph,
-  //   hard_brakes, hard_accels, speed_violations.
-  return { skipped: 'TODO: GraphQL query for trips not yet wired' };
+  // STUB: data source confirmed. Implementation deferred.
+  //
+  // No direct getTrips query — Unity exposes raw snapshots and expects clients
+  // to reconstruct trips. Two paths:
+  //
+  // (a) getWrappedReport(reportId: "vehicle-trips", input: ...)
+  //     Description: "Details about trips made by each asset within the
+  //     selected time period (based on vehicle ignition & idling states)."
+  //     Currently broken — returns php-exception for every call (see file
+  //     header). When Powerfleet fixes it, this is the easy path: the report
+  //     `report` field is JSON with the per-trip rows ready to upsert.
+  //
+  // (b) getSnapshots(vehicleId: UUID!, from: DateTime!, to: DateTime!) -> [CommonFormat]
+  //     Works today. Returns event-driven snapshots (not at fixed intervals).
+  //     To build a trip row:
+  //       1. Look up vehicle_id (bigint) by fc_asset_id from ops.fleet_vehicles.
+  //       2. For each fc_asset_id, call getSnapshots for the sync window
+  //          (e.g. last 26h to overlap with the previous run).
+  //       3. Walk snapshots in timestamp order; a "trip" is a maximal segment
+  //          where ignition.engineStatus = true, separated by ≥2 min of off.
+  //       4. fc_trip_id = sha1(fc_asset_id + start_timestamp) → deterministic
+  //          for upsert idempotency.
+  //       5. Per trip, compute:
+  //            trip_date         = start_time at vehicle local TZ
+  //            distance_miles    = haversine sum (or sum canBus.canDeltaDistance) × 0.621371
+  //            drive_time_min    = (end - start) / 60_000
+  //            idle_time_min     = sum of intra-trip seconds with speed=0 / 60
+  //            max_speed_mph     = max(gps.speed) × 0.621371
+  //            avg_speed_mph     = distance_miles / (drive_time_min / 60)
+  //            driver_id         = lookup ops.staff by driver.driverId or driver.iButton
+  //          (hard_brakes / hard_accels / speed_violations come from
+  //          driverBehaviour.driverBehaviourType events; left null until we
+  //          map the DriverBehaviourType enum.)
+  //       6. Upsert into ops.fleet_trips on fc_trip_id.
+  //
+  // Cost estimate for option (b) on the current fleet (9 fc_asset_ids, ~700
+  // snapshots / vehicle / 2h ≈ 8K snapshots/vehicle/day): ~75K snapshots/day,
+  // ~5MB JSON per daily run. Keep getSnapshots calls strictly sequential
+  // (Unity's one-active-request rule).
+  return {
+    skipped:
+      'getSnapshots-based trip reconstruction not yet implemented. ' +
+      'Wrapped report (reportId=vehicle-trips) blocked by upstream php-exception.',
+  };
 }
 
 async function syncFuel(_ctx: { accessToken: string; userId: string }) {
-  // TODO(unity): replace with the real GraphQL query for fuel transactions.
-  // Map onto ops.fleet_fuel_transactions:
-  //   vehicle_id, driver_id, txn_date, gallons, price_per_gal, total_cost,
-  //   odometer_at, station_name, station_address, fuel_type, receipt_ref.
-  return { skipped: 'TODO: GraphQL query for fuel not yet wired' };
+  // NOT POSSIBLE via Unity GraphQL.
+  //
+  // Confirmed via getWrappedReportInputs() 2026-05-08: the only fuel-related
+  // reports Unity exposes are emissions and engine-diagnostics — neither
+  // includes $-denominated fuel transactions. Per-snapshot CommonFormat.fuel
+  // gives tank level / consumption (telemetry), not station purchases.
+  //
+  // To populate ops.fleet_fuel_transactions (gallons / price_per_gal /
+  // total_cost / station_name / receipt_ref) we need a separate integration
+  // with whichever fuel card APBG uses (Wex, Fleetcor, Voyager, Comdata).
+  // Build that as sync-<provider>-fuel and add it as a separate writer in
+  // architecture/sync-manifest.json.
+  return { skipped: 'no fuel-transaction API in Unity GraphQL; needs separate fuel-card integration' };
 }
 
 async function syncMaintenance(_ctx: { accessToken: string; userId: string }) {
-  // TODO(unity): replace with the real GraphQL query for maintenance records.
-  // Map onto ops.fleet_maintenance:
-  //   vehicle_id, service_date, service_type, description, vendor_name,
-  //   cost, odometer_at, next_due_date, next_due_miles.
-  return { skipped: 'TODO: GraphQL query for maintenance not yet wired' };
+  // BLOCKED upstream.
+  //
+  // Unity has no direct getMaintenance query. The only path is
+  // getWrappedReport(reportId: "maintenance-schedule", input: ...). The
+  // report engine returns
+  //   { "errors": [{ "message": "Something went wrong",
+  //                  "extensions": { "error": "php-exception", "classification": "BAD_REQUEST" } }] }
+  // for every call we've tried (verified 2026-05-08 with the four input
+  // shapes documented in the file header). Other top-level queries on the
+  // same endpoint work fine — it is specifically getWrappedReport that's
+  // failing.
+  //
+  // Action: open a Powerfleet support ticket with our userId
+  // (82273656-cd69-4044-a431-36288e840181) and the timestamps of a few
+  // failing calls. When fixed, replace this stub with:
+  //   getWrappedReport(input: { reportId: "maintenance-schedule", input: {
+  //     period: { begin: ..., end: ... },
+  //     asset_uuids: [<every fleet_vehicles.fc_asset_id>],
+  //     maintenance_plans: [<plan ids from a separate query>]
+  //   }})
+  // and map the JSON `report` rows onto ops.fleet_maintenance.
+  return { skipped: 'getWrappedReport(reportId=maintenance-schedule) blocked by upstream php-exception' };
 }
 
 // ---------- HTTP entry point ----------

--- a/supabase/functions/sync-fleetcomplete/index.ts
+++ b/supabase/functions/sync-fleetcomplete/index.ts
@@ -1,0 +1,326 @@
+// Supabase Edge Function: sync-fleetcomplete
+// ------------------------------------------
+// Pulls fleet data from the Unity (Powerfleet / FleetComplete) GraphQL
+// API at https://api.fleetcomplete.com/graphql and upserts into the
+// ops.fleet_* tables.
+//
+// Auth flow (per Unity docs):
+//   1. POST /login/token  with form-encoded username + password
+//      → { access_token, refresh_token, ... }    access_token = 5 min
+//   2. POST /login/refresh with form-encoded refreshToken
+//      → { access_token, refresh_token }          refresh_token = 12 hr
+//   3. POST /graphql with headers:
+//      Authorization: Bearer <access_token>
+//      userId:        <UUID from /login/userinfo>
+//
+// Rate limiting: GraphQL allows ONE active request per user. Calls are
+// strictly sequential; on 429 we back off and retry once.
+//
+// Secrets (set via Supabase secrets / dashboard):
+//   FC_USERNAME       Unity portal username (skypace@brixbev.com)
+//   FC_PASSWORD       Unity portal password
+//
+// Public state in DB (ops.fc_token_cache singleton row id=1):
+//   api_token / refresh_token / *_expires_at — rotated each run
+//   account_id (user UUID) — sent as the `userId` header on /graphql
+//   fleet_id   — Unity fleet UUID (informational; we use account_id)
+//   base_url   — defaults to https://api.fleetcomplete.com/
+//
+// Status of resource syncs:
+//   getVehicles         IMPLEMENTED  (queries vin / id / name / groups / devices)
+//   getTrips            STUBBED      (need GraphQL query name + shape from GraphiQL)
+//   getFuelTransactions STUBBED      (same)
+//   getMaintenance      STUBBED      (same)
+//
+// Once the GraphQL query strings are confirmed via the GraphiQL IDE at
+// https://api.fleetcomplete.com/graphiql?path=/graphql, fill in the
+// stubbed sync* functions below — the upsert plumbing is already wired
+// to the corresponding ops.fleet_* tables.
+
+// deno-lint-ignore-file no-explicit-any
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+// ---------- env / config ----------
+
+const SB_URL = Deno.env.get('SUPABASE_URL')!;
+const SB_SERVICE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const FC_USERNAME = Deno.env.get('FC_USERNAME');
+const FC_PASSWORD = Deno.env.get('FC_PASSWORD');
+
+const FC_BASE = 'https://api.fleetcomplete.com';
+const ACCESS_TTL_MS = 5 * 60 * 1000;          // access_token: 5 min
+const REFRESH_TTL_MS = 12 * 60 * 60 * 1000;   // refresh_token: 12 hr
+const EXP_BUFFER_MS = 30_000;                 // refresh 30s before actual expiry
+
+const sb = createClient(SB_URL, SB_SERVICE_KEY, { db: { schema: 'ops' } });
+
+// ---------- token cache ----------
+
+interface TokenCache {
+  api_token: string | null;
+  refresh_token: string | null;
+  access_token_expires_at: string | null;
+  refresh_token_expires_at: string | null;
+  account_id: string | null;
+  fleet_id: string | null;
+  base_url: string | null;
+}
+
+async function loadCache(): Promise<TokenCache> {
+  const { data, error } = await sb.from('fc_token_cache').select('*').eq('id', 1).single();
+  if (error) throw new Error('fc_token_cache load: ' + error.message);
+  return data as TokenCache;
+}
+
+async function saveCache(patch: Partial<TokenCache>) {
+  const { error } = await sb
+    .from('fc_token_cache')
+    .update({ ...patch, updated_at: new Date().toISOString() })
+    .eq('id', 1);
+  if (error) throw new Error('fc_token_cache save: ' + error.message);
+}
+
+// ---------- auth ----------
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+}
+
+async function loginWithPassword(): Promise<TokenResponse> {
+  if (!FC_USERNAME || !FC_PASSWORD) {
+    throw new Error('FC_USERNAME and FC_PASSWORD env vars are required');
+  }
+  const form = new FormData();
+  form.append('username', FC_USERNAME);
+  form.append('password', FC_PASSWORD);
+  const res = await fetch(FC_BASE + '/login/token', { method: 'POST', body: form });
+  if (!res.ok) throw new Error('login/token: ' + res.status + ' ' + (await res.text()));
+  const j = await res.json() as TokenResponse;
+  if (!j.access_token) throw new Error('login/token: no access_token in response');
+  return j;
+}
+
+async function refreshAccess(refreshToken: string): Promise<TokenResponse> {
+  const form = new FormData();
+  form.append('refreshToken', refreshToken);
+  const res = await fetch(FC_BASE + '/login/refresh', { method: 'POST', body: form });
+  if (!res.ok) throw new Error('login/refresh: ' + res.status + ' ' + (await res.text()));
+  const j = await res.json() as TokenResponse;
+  if (!j.access_token) throw new Error('login/refresh: no access_token in response');
+  return j;
+}
+
+async function fetchUserId(accessToken: string): Promise<string> {
+  const res = await fetch(FC_BASE + '/login/userinfo', {
+    headers: { 'Authorization': 'Bearer ' + accessToken },
+  });
+  if (!res.ok) throw new Error('login/userinfo: ' + res.status);
+  const arr = await res.json();
+  if (!Array.isArray(arr) || arr.length === 0) throw new Error('login/userinfo: empty');
+  // If the user has multiple userIds, the docs say the user must choose.
+  // For now: pick the first. Add explicit selection if APBG ever has multiples.
+  return arr[0].userId;
+}
+
+async function ensureToken(): Promise<{ accessToken: string; userId: string }> {
+  const cache = await loadCache();
+  const now = Date.now();
+  const accessExp = cache.access_token_expires_at ? Date.parse(cache.access_token_expires_at) : 0;
+  const refreshExp = cache.refresh_token_expires_at ? Date.parse(cache.refresh_token_expires_at) : 0;
+
+  // Cache hit: token still valid + we know our userId.
+  if (cache.api_token && cache.account_id && accessExp - now > EXP_BUFFER_MS) {
+    return { accessToken: cache.api_token, userId: cache.account_id };
+  }
+
+  // Try refresh first.
+  if (cache.refresh_token && refreshExp - now > EXP_BUFFER_MS) {
+    try {
+      const t = await refreshAccess(cache.refresh_token);
+      const userId = cache.account_id ?? (await fetchUserId(t.access_token));
+      await saveCache({
+        api_token: t.access_token,
+        refresh_token: t.refresh_token ?? cache.refresh_token,
+        access_token_expires_at: new Date(now + ACCESS_TTL_MS).toISOString(),
+        // Only bump refresh_token_expires_at if we got a new refresh token.
+        ...(t.refresh_token && t.refresh_token !== cache.refresh_token
+          ? { refresh_token_expires_at: new Date(now + REFRESH_TTL_MS).toISOString() }
+          : {}),
+        account_id: userId,
+      });
+      return { accessToken: t.access_token, userId };
+    } catch (err) {
+      console.warn('refresh failed, falling back to full login:', (err as Error).message);
+    }
+  }
+
+  // Full login.
+  const t = await loginWithPassword();
+  const userId = cache.account_id ?? (await fetchUserId(t.access_token));
+  await saveCache({
+    api_token: t.access_token,
+    refresh_token: t.refresh_token ?? null,
+    access_token_expires_at: new Date(now + ACCESS_TTL_MS).toISOString(),
+    refresh_token_expires_at: t.refresh_token ? new Date(now + REFRESH_TTL_MS).toISOString() : null,
+    account_id: userId,
+  });
+  return { accessToken: t.access_token, userId };
+}
+
+// ---------- GraphQL client ----------
+
+interface GraphQLResponse<T> {
+  data?: T;
+  errors?: { message: string }[];
+}
+
+// Sleep helper for the 429 backoff.
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function graphql<T>(
+  query: string,
+  ctx: { accessToken: string; userId: string },
+  attempt = 1,
+): Promise<T> {
+  const res = await fetch(FC_BASE + '/graphql', {
+    method: 'POST',
+    headers: {
+      'Authorization': 'Bearer ' + ctx.accessToken,
+      'userId': ctx.userId,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query }),
+  });
+
+  if (res.status === 429) {
+    if (attempt >= 2) throw new Error('graphql: rate-limited (HTTP 429) after retry');
+    await sleep(2000);
+    return graphql<T>(query, ctx, attempt + 1);
+  }
+  if (!res.ok) throw new Error('graphql: ' + res.status + ' ' + (await res.text()));
+
+  const j = await res.json() as GraphQLResponse<T>;
+  if (j.errors?.length) throw new Error('graphql errors: ' + j.errors.map((e) => e.message).join('; '));
+  if (!j.data) throw new Error('graphql: empty response');
+  return j.data;
+}
+
+// ---------- vehicles sync ----------
+
+interface FcVehicle {
+  vin: string | null;
+  id: string;
+  name: string | null;
+  assignedGroups?: { id: string; description: string | null; name: string | null; fleetId: string; externalId: string | null }[];
+  assignedDevices?: { id: string; serial: string | null; phoneNumber: string | null }[];
+}
+
+const VEHICLES_QUERY = `{
+  getVehicles {
+    vin
+    id
+    name
+    assignedGroups { id description name fleetId externalId }
+    assignedDevices { id serial phoneNumber }
+  }
+}`;
+
+async function syncVehicles(ctx: { accessToken: string; userId: string }) {
+  const data = await graphql<{ getVehicles: FcVehicle[] }>(VEHICLES_QUERY, ctx);
+  const vehicles = data.getVehicles ?? [];
+  const now = new Date().toISOString();
+
+  const rows = vehicles.map((v) => ({
+    fc_asset_id: v.id,
+    vehicle_name: v.name,
+    vin: v.vin,
+    // Unity's getVehicles doesn't expose make/model/year/license/odometer in
+    // this shape; if/when we find a richer query (e.g. getVehiclesById with a
+    // full projection), populate those fields here. For now, default status
+    // to 'active' to satisfy the CHECK constraint.
+    status: 'active' as const,
+    synced_at: now,
+  }));
+
+  if (rows.length === 0) return { count: 0 };
+
+  const { error } = await sb
+    .from('fleet_vehicles')
+    .upsert(rows, { onConflict: 'fc_asset_id' });
+  if (error) throw new Error('fleet_vehicles upsert: ' + error.message);
+
+  return { count: rows.length };
+}
+
+// ---------- stubbed syncs (paste GraphQL queries from GraphiQL IDE) ----------
+
+async function syncTrips(_ctx: { accessToken: string; userId: string }) {
+  // TODO(unity): replace with the real GraphQL query for trips. From the
+  // GraphiQL IDE at https://api.fleetcomplete.com/graphiql?path=/graphql,
+  // search the schema for getTrips / getJourneys / getRouteHistory or
+  // similar, then map fields onto ops.fleet_trips:
+  //   fc_trip_id, vehicle_id (FK to fleet_vehicles), driver_id, trip_date,
+  //   start_time, end_time, start_address, end_address, distance_miles,
+  //   drive_time_min, idle_time_min, max_speed_mph, avg_speed_mph,
+  //   hard_brakes, hard_accels, speed_violations.
+  return { skipped: 'TODO: GraphQL query for trips not yet wired' };
+}
+
+async function syncFuel(_ctx: { accessToken: string; userId: string }) {
+  // TODO(unity): replace with the real GraphQL query for fuel transactions.
+  // Map onto ops.fleet_fuel_transactions:
+  //   vehicle_id, driver_id, txn_date, gallons, price_per_gal, total_cost,
+  //   odometer_at, station_name, station_address, fuel_type, receipt_ref.
+  return { skipped: 'TODO: GraphQL query for fuel not yet wired' };
+}
+
+async function syncMaintenance(_ctx: { accessToken: string; userId: string }) {
+  // TODO(unity): replace with the real GraphQL query for maintenance records.
+  // Map onto ops.fleet_maintenance:
+  //   vehicle_id, service_date, service_type, description, vendor_name,
+  //   cost, odometer_at, next_due_date, next_due_miles.
+  return { skipped: 'TODO: GraphQL query for maintenance not yet wired' };
+}
+
+// ---------- HTTP entry point ----------
+
+Deno.serve(async (req) => {
+  const url = new URL(req.url);
+  const mode = url.searchParams.get('mode') ?? 'all';
+
+  try {
+    if (!FC_USERNAME || !FC_PASSWORD) {
+      return new Response(
+        JSON.stringify({
+          ok: false,
+          error: 'FC_USERNAME and FC_PASSWORD env vars not configured. See supabase/functions/sync-fleetcomplete/README.md.',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const ctx = await ensureToken();
+    const result: Record<string, unknown> = { mode };
+
+    // Sequential — Unity allows only one active request per user.
+    if (mode === 'all' || mode === 'vehicles')    result.vehicles    = await syncVehicles(ctx);
+    if (mode === 'all' || mode === 'trips')       result.trips       = await syncTrips(ctx);
+    if (mode === 'all' || mode === 'fuel')        result.fuel        = await syncFuel(ctx);
+    if (mode === 'all' || mode === 'maintenance') result.maintenance = await syncMaintenance(ctx);
+
+    return new Response(JSON.stringify({ ok: true, ...result }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (e) {
+    const err = e as Error;
+    console.error('sync-fleetcomplete error:', err);
+    return new Response(JSON.stringify({ ok: false, error: err.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/migrations/20260506g_fc_token_cache_oauth_columns.sql
+++ b/supabase/migrations/20260506g_fc_token_cache_oauth_columns.sql
@@ -1,0 +1,45 @@
+-- Extend ops.fc_token_cache for the Unity (FleetComplete) OAuth-style auth flow:
+-- access_token (5 min) + refresh_token (12 hr), both rotated by /login/token
+-- and /login/refresh. Plus pre-seed the singleton row with the known
+-- base URL and Sky's identifiers (recovered from /login/userinfo on
+-- 2026-05-06).
+--
+-- account_id holds the user UUID (used as the `userId` header on
+-- /graphql calls). fleet_id holds the fleet UUID (also acceptable as
+-- a header per Powerfleet docs; we use account_id by default).
+--
+-- The actual username/password for /login/token are NOT stored in the
+-- DB — they live in Supabase secrets as FC_USERNAME / FC_PASSWORD env
+-- vars and are read by the edge function only.
+
+ALTER TABLE ops.fc_token_cache
+  ADD COLUMN IF NOT EXISTS refresh_token text,
+  ADD COLUMN IF NOT EXISTS access_token_expires_at timestamptz,
+  ADD COLUMN IF NOT EXISTS refresh_token_expires_at timestamptz,
+  ADD COLUMN IF NOT EXISTS fleet_id text;
+
+COMMENT ON COLUMN ops.fc_token_cache.api_token IS
+  'Unity access_token returned by POST /login/token. Valid for 5 minutes.';
+COMMENT ON COLUMN ops.fc_token_cache.refresh_token IS
+  'Unity refresh_token returned by POST /login/token. Valid for 12 hours.';
+COMMENT ON COLUMN ops.fc_token_cache.account_id IS
+  'Unity user UUID from /login/userinfo. Sent as userId header on /graphql calls.';
+COMMENT ON COLUMN ops.fc_token_cache.fleet_id IS
+  'Unity fleet UUID from /login/userinfo. Acceptable alternative to userId on /graphql calls.';
+COMMENT ON COLUMN ops.fc_token_cache.base_url IS
+  'API base URL. https://api.fleetcomplete.com/ for the Unity API.';
+
+-- Seed the singleton row.
+INSERT INTO ops.fc_token_cache (id, base_url, account_id, fleet_id, updated_at)
+VALUES (
+  1,
+  'https://api.fleetcomplete.com/',
+  '82273656-cd69-4044-a431-36288e840181',
+  '54bbc497-74a7-4403-9d56-fbcb5823bcca',
+  now()
+)
+ON CONFLICT (id) DO UPDATE SET
+  base_url   = EXCLUDED.base_url,
+  account_id = COALESCE(ops.fc_token_cache.account_id, EXCLUDED.account_id),
+  fleet_id   = COALESCE(ops.fc_token_cache.fleet_id,   EXCLUDED.fleet_id),
+  updated_at = now();

--- a/supabase/migrations/20260506h_sync_fleetcomplete_cron.sql
+++ b/supabase/migrations/20260506h_sync_fleetcomplete_cron.sql
@@ -1,0 +1,30 @@
+-- Cron schedule for sync-fleetcomplete edge function.
+--
+-- DISABLED by default (commented out below). Before enabling:
+--   1. Set FC_USERNAME + FC_PASSWORD secrets on the Supabase project.
+--   2. Deploy the edge function: `supabase functions deploy sync-fleetcomplete`.
+--   3. Verify with a manual call:
+--        curl '<project>/functions/v1/sync-fleetcomplete?mode=vehicles' \
+--          -H 'apikey: <anon>' -H 'Authorization: Bearer <anon>'
+--   4. Uncomment the cron.schedule call below and re-apply this migration.
+--
+-- Cadence rationale: hourly runs at :05 (no clash with the QBO syncs
+-- 09:00-09:50 or kpi_daily 11:00). Vehicles + trips don't change often;
+-- hourly is generous. Tighten to every 30 min later if needed.
+
+-- Uncomment to enable:
+--
+-- SELECT cron.schedule('hourly-sync-fleetcomplete', '5 * * * *', $$
+--   SELECT net.http_post(
+--     url := 'https://gfsdpwiqzshhexkofiif.supabase.co/functions/v1/sync-fleetcomplete',
+--     body := '{}'::jsonb,
+--     timeout_milliseconds := 120000
+--   );
+-- $$);
+
+-- This migration intentionally has no DDL effect when applied with the
+-- cron commented out — it exists so the cron schedule lives in a
+-- migration file (auditable + replayable) rather than as an out-of-band
+-- pg_cron registration. To enable: uncomment, apply via MCP / CLI /
+-- Studio.
+SELECT 1 AS sync_fleetcomplete_cron_disabled;


### PR DESCRIPTION
## Summary

Closes the FleetComplete / Unity integration. CLAUDE.md (§3.C) flagged this as "the ONLY integration that needs full API review from scratch" — Sky shared the auth + GraphQL contract today and this PR turns that into a working edge function.

## Contract (Unity by Powerfleet, base `https://api.fleetcomplete.com/`)

| Step | Endpoint | What |
|---|---|---|
| Login | `POST /login/token` (form: `username` + `password`) | Returns `access_token` (5 min) + `refresh_token` (12 hr) |
| Refresh | `POST /login/refresh` (form: `refreshToken`) | Returns new `access_token`, sometimes a rotated `refresh_token` |
| Identity | `GET /login/userinfo` (Bearer) | Returns `[{ userName, userId, fleetName, fleetId }, ...]` |
| Data | `POST /graphql` (Bearer + `userId` header) | GraphQL queries |

**Rate limit:** 1 active request per user. Sequential calls, retry once on 429.

## What's added

### `supabase/migrations/20260506g_fc_token_cache_oauth_columns.sql`

Extends `ops.fc_token_cache` with `refresh_token` + `access_token_expires_at` + `refresh_token_expires_at` + `fleet_id` columns. Seeds the singleton row with `base_url=https://api.fleetcomplete.com/` and APBG's user/fleet UUIDs from Sky's `/login/userinfo` response. **Already applied to live via MCP.**

### `supabase/functions/sync-fleetcomplete/index.ts`

- **Full token lifecycle**: cache hit → use; access expired but refresh valid → refresh; both expired → full login. Persists rotation back to `fc_token_cache`.
- **GraphQL client**: sequential requests, 429 retry with 2-second backoff.
- **Vehicles sync (IMPLEMENTED)**: `getVehicles { vin id name assignedGroups{...} assignedDevices{...} }` → upsert into `fleet_vehicles` via `UNIQUE(fc_asset_id)`.
- **Trips / fuel / maintenance (STUBBED)**: clear TODO comments enumerating exactly which `ops.fleet_*` columns to populate once the corresponding GraphQL queries are confirmed via GraphiQL IDE.

### `supabase/functions/sync-fleetcomplete/README.md`

Setup steps (set `FC_USERNAME` / `FC_PASSWORD` secrets via `supabase secrets set` or Studio, deploy, verify, enable cron) + how to fill in the trips/fuel/maintenance stubs.

### `supabase/migrations/20260506h_sync_fleetcomplete_cron.sql`

Hourly `:05` cron schedule — **commented out** until secrets are configured + a manual run verifies. Uncomment + re-apply to enable.

### `architecture/sync-manifest.json`

`sync-fleetcomplete` now claims `fc_token_cache` + the four `fleet_*` resource tables. `fleet_daily` stays orphan (separate aggregator, not in this PR). Lint clean: **19 writers, 9 orphans (was 14), 58 tables.**

## Setup steps for you

1. **Set secrets** (Supabase CLI or Studio Settings → Edge Functions):
   ```bash
   supabase secrets set FC_USERNAME=skypace@brixbev.com
   supabase secrets set FC_PASSWORD='your-password'
   ```
2. **Deploy** the edge function (CLI):
   ```bash
   supabase functions deploy sync-fleetcomplete
   ```
3. **Verify** with `?mode=vehicles`:
   ```bash
   curl 'https://gfsdpwiqzshhexkofiif.supabase.co/functions/v1/sync-fleetcomplete?mode=vehicles' \
     -H 'apikey: <anon>' -H 'Authorization: Bearer <anon>'
   ```
4. **Enable cron** by uncommenting the `cron.schedule` block in `20260506h_sync_fleetcomplete_cron.sql` and re-applying.
5. **Fill in stubs**: open the GraphiQL IDE at `https://api.fleetcomplete.com/graphiql?path=/graphql`, find `getTrips` / `getFuelTransactions` / `getMaintenance` (names are guesses; autocomplete will show the truth), copy working query strings into the corresponding stub functions.

## Test plan

- [ ] After secrets are set, manual `?mode=vehicles` call returns `{ ok: true, vehicles: { count: N } }` with `N > 0`.
- [ ] `ops.fleet_vehicles` has rows with non-null `fc_asset_id`, `vehicle_name`, `vin`.
- [ ] Subsequent runs reuse cached tokens (check `ops.fc_token_cache.access_token_expires_at` advances, no re-login spam).
- [ ] Once cron enabled, `pg_cron` shows `hourly-sync-fleetcomplete` running on the :05 minute.

https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL

---
_Generated by [Claude Code](https://claude.ai/code/session_015Nr4tRqjUM5KQHaadqfHCL)_