### PR TITLE
feat(margin): product_family + product_type taxonomies with auto-match

### DIFF
--- a/app-expense/src/vite-env.d.ts
+++ b/app-expense/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/app/src/components/MarginGrid.tsx
+++ b/app/src/components/MarginGrid.tsx
@@ -9,6 +9,7 @@ import { Sparkline } from './Sparkline';
 const DIM_HEADER: Record<Dim, string> = {
   category: 'Category', item: 'Item', customer: 'Customer', month: 'Month',
   entity: 'Entity', account: 'Account', segment: 'Segment', channel: 'Channel',
+  product_family: 'Family', product_type: 'Type',
 };
 
 interface Props {

--- a/app/src/components/PivotTable.tsx
+++ b/app/src/components/PivotTable.tsx
@@ -32,6 +32,8 @@ const DIM_HEADER: Record<Dim, string> = {
   account: 'Account',
   segment: 'Segment',
   channel: 'Channel',
+  product_family: 'Family',
+  product_type: 'Type',
 };
 
 function isComparison(r: SalesPivotRow | ComparisonRow): r is ComparisonRow {

--- a/app/src/lib/inventory.ts
+++ b/app/src/lib/inventory.ts
@@ -42,6 +42,9 @@ export interface InventoryHealthRow {
   product_family_label: string | null;
   product_type_code: string | null;
   product_type_label: string | null;
+  segment_code: string | null;
+  segment_label: string | null;
+  segment_source: 'item' | 'category' | null;
 }
 
 export interface InventorySettingsRow {
@@ -216,12 +219,16 @@ export function fetchCategoryList() {
 
 export interface ProductFamily { family_code: string; label: string; sort_order: number }
 export interface ProductType   { type_code:   string; label: string; sort_order: number }
+export interface SegmentOption { segment_code: string; label: string; sort_order: number }
 
 export function fetchProductFamilies() {
   return sbrpc<ProductFamily[]>('fn_list_product_families', {});
 }
 export function fetchProductTypes() {
   return sbrpc<ProductType[]>('fn_list_product_types', {});
+}
+export function fetchSegmentOptions() {
+  return sbrpc<SegmentOption[]>('fn_list_segments_for_items', {});
 }
 
 export function setItemProductFamily(qbo_item_id: string, family_code: string | null) {
@@ -236,6 +243,12 @@ export function setItemProductType(qbo_item_id: string, type_code: string | null
     p_type_code:   type_code,
   });
 }
+export function setItemSegment(qbo_item_id: string, segment_code: string | null) {
+  return sbrpc<void>('fn_set_item_segment', {
+    p_qbo_item_id:  qbo_item_id,
+    p_segment_code: segment_code,
+  });
+}
 export function bulkSetItemProductFamily(qbo_item_ids: string[], family_code: string | null) {
   return sbrpc<number>('fn_bulk_set_item_product_family', {
     p_qbo_item_ids: qbo_item_ids,
@@ -246,6 +259,12 @@ export function bulkSetItemProductType(qbo_item_ids: string[], type_code: string
   return sbrpc<number>('fn_bulk_set_item_product_type', {
     p_qbo_item_ids: qbo_item_ids,
     p_type_code:    type_code,
+  });
+}
+export function bulkSetItemSegment(qbo_item_ids: string[], segment_code: string | null) {
+  return sbrpc<number>('fn_bulk_set_item_segment', {
+    p_qbo_item_ids: qbo_item_ids,
+    p_segment_code: segment_code,
   });
 }
 

--- a/app/src/lib/inventory.ts
+++ b/app/src/lib/inventory.ts
@@ -38,6 +38,10 @@ export interface InventoryHealthRow {
   suggested_order_qty: number | null;
   suggested_order_cycle_days: number | null;
   status: string;
+  product_family_code: string | null;
+  product_family_label: string | null;
+  product_type_code: string | null;
+  product_type_label: string | null;
 }
 
 export interface InventorySettingsRow {
@@ -208,6 +212,41 @@ export async function bulkSyncCategoriesToQbo(commit = false): Promise<QboCatego
 
 export function fetchCategoryList() {
   return sbrpc<CategoryOption[]>('fn_list_category_options', {});
+}
+
+export interface ProductFamily { family_code: string; label: string; sort_order: number }
+export interface ProductType   { type_code:   string; label: string; sort_order: number }
+
+export function fetchProductFamilies() {
+  return sbrpc<ProductFamily[]>('fn_list_product_families', {});
+}
+export function fetchProductTypes() {
+  return sbrpc<ProductType[]>('fn_list_product_types', {});
+}
+
+export function setItemProductFamily(qbo_item_id: string, family_code: string | null) {
+  return sbrpc<void>('fn_set_item_product_family', {
+    p_qbo_item_id: qbo_item_id,
+    p_family_code: family_code,
+  });
+}
+export function setItemProductType(qbo_item_id: string, type_code: string | null) {
+  return sbrpc<void>('fn_set_item_product_type', {
+    p_qbo_item_id: qbo_item_id,
+    p_type_code:   type_code,
+  });
+}
+export function bulkSetItemProductFamily(qbo_item_ids: string[], family_code: string | null) {
+  return sbrpc<number>('fn_bulk_set_item_product_family', {
+    p_qbo_item_ids: qbo_item_ids,
+    p_family_code:  family_code,
+  });
+}
+export function bulkSetItemProductType(qbo_item_ids: string[], type_code: string | null) {
+  return sbrpc<number>('fn_bulk_set_item_product_type', {
+    p_qbo_item_ids: qbo_item_ids,
+    p_type_code:    type_code,
+  });
 }
 
 export function fetchItemPlAudit(min_account_items = 3) {

--- a/app/src/lib/plans.ts
+++ b/app/src/lib/plans.ts
@@ -19,10 +19,15 @@ export interface SalesPlanLine {
   line_type: string;
   qbo_item_id: string | null;
   item_name: string | null;
+  qbo_customer_id: string | null;
+  customer_name: string | null;
   qbo_account_id: string | null;
   account_name: string | null;
   notes: string | null;
   amounts: number[];
+  qty: number[] | null;
+  unit_price: number[] | null;
+  unit_cost: number[] | null;
   sort_order: number;
   updated_at: string;
 }

--- a/app/src/lib/sales.ts
+++ b/app/src/lib/sales.ts
@@ -10,7 +10,9 @@ export type Dim =
   | 'entity'
   | 'account'
   | 'segment'
-  | 'channel';
+  | 'channel'
+  | 'product_family'
+  | 'product_type';
 
 export interface SalesPivotRow {
   dim_label: string;
@@ -51,18 +53,22 @@ export interface SalesFilters {
   items?: string[] | null;
   channels?: string[] | null;
   segments?: string[] | null;
+  product_families?: string[] | null;
+  product_types?: string[] | null;
 }
 
 export function rpcArgs(f: SalesFilters) {
   return {
     p_start: f.start,
     p_end: f.end,
-    p_entities:   f.entities   && f.entities.length   ? f.entities   : null,
-    p_categories: f.categories && f.categories.length ? f.categories : null,
-    p_customers:  f.customers  && f.customers.length  ? f.customers  : null,
-    p_items:      f.items      && f.items.length      ? f.items      : null,
-    p_channels:   f.channels   && f.channels.length   ? f.channels   : null,
-    p_segments:   f.segments   && f.segments.length   ? f.segments   : null,
+    p_entities:         f.entities         && f.entities.length         ? f.entities         : null,
+    p_categories:       f.categories       && f.categories.length       ? f.categories       : null,
+    p_customers:        f.customers        && f.customers.length        ? f.customers        : null,
+    p_items:            f.items            && f.items.length            ? f.items            : null,
+    p_channels:         f.channels         && f.channels.length         ? f.channels         : null,
+    p_segments:         f.segments         && f.segments.length         ? f.segments         : null,
+    p_product_families: f.product_families && f.product_families.length ? f.product_families : null,
+    p_product_types:    f.product_types    && f.product_types.length    ? f.product_types    : null,
   };
 }
 

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -47,6 +47,55 @@ export const updateSegment = (code: string, patch: Partial<Segment>) =>
 export const deleteSegment = (code: string) =>
   sbDelete('segments', 'segment_code=eq.' + encodeURIComponent(code));
 
+// ----- Product Families taxonomy (CRUD via direct table) -----------------
+export interface ProductFamilyRow {
+  family_code: string;
+  label: string;
+  sort_order: number | null;
+  is_active: boolean;
+}
+export const fetchProductFamilies = () =>
+  sbq<ProductFamilyRow>('product_families', 'select=*&order=sort_order,label');
+export const insertProductFamily = (row: ProductFamilyRow) =>
+  sbInsert<ProductFamilyRow>('product_families', row);
+export const updateProductFamily = (code: string, patch: Partial<ProductFamilyRow>) =>
+  sbUpdate<ProductFamilyRow>('product_families', 'family_code=eq.' + encodeURIComponent(code), patch);
+export const deleteProductFamily = (code: string) =>
+  sbDelete('product_families', 'family_code=eq.' + encodeURIComponent(code));
+
+// ----- Product Types taxonomy (CRUD via direct table) --------------------
+export interface ProductTypeRow {
+  type_code: string;
+  label: string;
+  sort_order: number | null;
+  is_active: boolean;
+}
+export const fetchProductTypes = () =>
+  sbq<ProductTypeRow>('product_types', 'select=*&order=sort_order,label');
+export const insertProductType = (row: ProductTypeRow) =>
+  sbInsert<ProductTypeRow>('product_types', row);
+export const updateProductType = (code: string, patch: Partial<ProductTypeRow>) =>
+  sbUpdate<ProductTypeRow>('product_types', 'type_code=eq.' + encodeURIComponent(code), patch);
+export const deleteProductType = (code: string) =>
+  sbDelete('product_types', 'type_code=eq.' + encodeURIComponent(code));
+
+// ----- Account active/inactive -------------------------------------------
+export interface AccountSettingRow {
+  account_name: string;
+  item_count: number;
+  active_item_count: number;
+  is_active: boolean;
+  notes: string | null;
+  set_at: string | null;
+}
+export const fetchAccountSettings = () =>
+  sbrpc<AccountSettingRow[]>('fn_list_accounts_for_settings', {});
+export const setAccountActive = (account_name: string, is_active: boolean) =>
+  sbrpc<void>('fn_set_account_active', {
+    p_account_name: account_name,
+    p_is_active:    is_active,
+  });
+
 export const fetchItemSets = () =>
   sbq<ItemSet>('item_sets', 'select=*&order=sort_order,label');
 export const insertItemSet = (row: Partial<ItemSet>) => sbInsert<ItemSet>('item_sets', row as ItemSet);

--- a/app/src/pages/MarginPage.tsx
+++ b/app/src/pages/MarginPage.tsx
@@ -55,6 +55,7 @@ const DIMS: { id: Dim; label: string }[] = [
   { id: 'customer', label: 'Customer' }, { id: 'month', label: 'Month' },
   { id: 'entity', label: 'Entity' }, { id: 'account', label: 'Account' },
   { id: 'segment', label: 'Segment' }, { id: 'channel', label: 'Channel' },
+  { id: 'product_family', label: 'Family' }, { id: 'product_type', label: 'Type' },
 ];
 
 // Fallback list when the live RPC returns empty. Real entities now come from
@@ -62,11 +63,13 @@ const DIMS: { id: Dim; label: string }[] = [
 const FALLBACK_ENTITIES = ['brix', 'AS', 'freeflow', 'shared'];
 
 const FILTER_DIMS: { dim: Dim; key: keyof SalesFilters; label: string }[] = [
-  { dim: 'category', key: 'categories', label: 'Category' },
-  { dim: 'customer', key: 'customers',  label: 'Customer' },
-  { dim: 'item',     key: 'items',      label: 'Item' },
-  { dim: 'channel',  key: 'channels',   label: 'Channel' },
-  { dim: 'segment',  key: 'segments',   label: 'Segment' },
+  { dim: 'category',       key: 'categories',       label: 'Category' },
+  { dim: 'customer',       key: 'customers',        label: 'Customer' },
+  { dim: 'item',           key: 'items',            label: 'Item' },
+  { dim: 'channel',        key: 'channels',         label: 'Channel' },
+  { dim: 'segment',        key: 'segments',         label: 'Segment' },
+  { dim: 'product_family', key: 'product_families', label: 'Family' },
+  { dim: 'product_type',   key: 'product_types',    label: 'Type' },
 ];
 
 const GROUPING_BY_DIM: Partial<Record<Dim, {
@@ -80,10 +83,12 @@ const GROUPING_BY_DIM: Partial<Record<Dim, {
 const DRILL_FILTER: Partial<Record<Dim, keyof SalesFilters>> = {
   category: 'categories', customer: 'customers', item: 'items',
   channel: 'channels', segment: 'segments', entity: 'entities',
+  product_family: 'product_families', product_type: 'product_types',
 };
 const DRILL_NEXT: Partial<Record<Dim, Dim>> = {
   category: 'item', segment: 'item', channel: 'customer',
   customer: 'item', entity: 'category',
+  product_family: 'product_type', product_type: 'item',
 };
 
 type CompareMode = 'off' | 'prior_period' | 'prior_year';

--- a/app/src/pages/SettingsPage.tsx
+++ b/app/src/pages/SettingsPage.tsx
@@ -11,18 +11,22 @@ import { SalesRepsEditor } from './settings/SalesRepsEditor';
 import { ChainModifiersEditor } from './settings/ChainModifiersEditor';
 import { EntityDefaultsEditor } from './settings/EntityDefaultsEditor';
 import { TaxonomyRulesEditor } from './settings/TaxonomyRulesEditor';
+import { AccountsEditor } from './settings/AccountsEditor';
 import {
   deleteChannel, deleteSegment,
   fetchChannels, fetchSegments,
   insertChannel, insertSegment,
   updateChannel, updateSegment,
+  fetchProductFamilies, insertProductFamily, updateProductFamily, deleteProductFamily,
+  fetchProductTypes,    insertProductType,   updateProductType,   deleteProductType,
 } from '../lib/settings';
 
 type Tab =
   | 'channels' | 'segments' | 'sales_reps'
   | 'rollups' | 'entity_defaults' | 'taxonomy'
   | 'item_sets' | 'items' | 'customers' | 'digest'
-  | 'expense_buckets' | 'users' | 'fleet_drivers';
+  | 'expense_buckets' | 'users' | 'fleet_drivers'
+  | 'product_families' | 'product_types' | 'accounts';
 
 const TABS: { id: Tab; label: string; group: string }[] = [
   { id: 'rollups',         label: 'Chain Rollups',           group: 'Filters & Taxonomy' },
@@ -30,8 +34,11 @@ const TABS: { id: Tab; label: string; group: string }[] = [
   { id: 'taxonomy',        label: 'Item & Customer Groups',  group: 'Filters & Taxonomy' },
   { id: 'customers',       label: 'Customers (master)',      group: 'Customer & Item' },
   { id: 'items',           label: 'Items (master)',          group: 'Customer & Item' },
+  { id: 'accounts',        label: 'P&L Accounts',            group: 'Customer & Item' },
   { id: 'channels',        label: 'Channels',                group: 'Customer & Item' },
   { id: 'segments',        label: 'Segments',                group: 'Customer & Item' },
+  { id: 'product_families',label: 'Product Families',        group: 'Customer & Item' },
+  { id: 'product_types',   label: 'Product Types',           group: 'Customer & Item' },
   { id: 'sales_reps',      label: 'Sales Reps',              group: 'Customer & Item' },
   { id: 'item_sets',       label: 'Item Sets',               group: 'Customer & Item' },
   { id: 'expense_buckets', label: 'Expense Buckets / Overhead', group: 'Operations' },
@@ -110,6 +117,31 @@ export function SettingsPage() {
           codeLabel="Segment Code"
         />
       )}
+      {tab === 'product_families' && (
+        <TaxonomyEditor
+          title="PRODUCT FAMILIES"
+          description="Form factor — Bag in Box, Can, Bottle, Melt Equipment, Service, etc. Each item picks one family on the Items master."
+          fetchAll={fetchProductFamilies}
+          insert={(row) => insertProductFamily({ family_code: row.code, label: row.label, sort_order: row.sort_order, is_active: row.is_active })}
+          update={(code, patch) => updateProductFamily(code, patch as Parameters<typeof updateProductFamily>[1])}
+          remove={deleteProductFamily}
+          codeKey="family_code"
+          codeLabel="Family Code"
+        />
+      )}
+      {tab === 'product_types' && (
+        <TaxonomyEditor
+          title="PRODUCT TYPES"
+          description="Product nature — Carbonated Soft Drink, Juice, Tea, Hardware, Labor, etc. Cross-cuts segment + family for margin reports."
+          fetchAll={fetchProductTypes}
+          insert={(row) => insertProductType({ type_code: row.code, label: row.label, sort_order: row.sort_order, is_active: row.is_active })}
+          update={(code, patch) => updateProductType(code, patch as Parameters<typeof updateProductType>[1])}
+          remove={deleteProductType}
+          codeKey="type_code"
+          codeLabel="Type Code"
+        />
+      )}
+      {tab === 'accounts' && <AccountsEditor />}
 
       {tab === 'sales_reps'      && <SalesRepsEditor />}
       {tab === 'item_sets'       && <ItemSetsEditor />}

--- a/app/src/pages/plans/PlanEditor.tsx
+++ b/app/src/pages/plans/PlanEditor.tsx
@@ -19,6 +19,17 @@ import { PlanVsActuals } from './PlanVsActuals';
 import { PlanForecast } from './PlanForecast';
 
 type Mode = 'lines' | 'rollup' | 'vs_actuals' | 'forecast';
+type ViewMode = 'revenue' | 'qty' | 'price' | 'cost';
+
+const VIEW_MODES: { id: ViewMode; label: string }[] = [
+  { id: 'revenue', label: 'Revenue ($)' },
+  { id: 'qty',     label: 'Qty' },
+  { id: 'price',   label: 'Price ($/unit)' },
+  { id: 'cost',    label: 'Cost ($/unit)' },
+];
+
+const ZEROS = (): number[] => [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+const round2 = (n: number) => Math.round(n * 100) / 100;
 
 interface Props {
   plan: SalesPlan;
@@ -32,6 +43,7 @@ export function PlanEditor({ plan, onBack }: Props) {
   const [itemOpts, setItemOpts] = useState<QboItemOption[]>([]);
   const [actualsByItem, setActualsByItem] = useState<Record<string, { amounts: number[]; total: number }> | null>(null);
   const [mode, setMode] = useState<Mode>('lines');
+  const [viewMode, setViewMode] = useState<ViewMode>('revenue');
 
   function load() {
     Promise.all([fetchPlanLines(plan.id), fetchPlanAccountRollup(plan.id)])
@@ -78,20 +90,70 @@ export function PlanEditor({ plan, onBack }: Props) {
       item_name: it.fully_qualified_name || it.name,
       qbo_account_id: it.income_account_ref_id,
       account_name: it.income_account_name,
-      amounts: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      amounts: ZEROS(),
+      qty: ZEROS(),
+      unit_price: ZEROS(),
+      unit_cost: ZEROS(),
     } as Partial<SalesPlanLine>).then(() => {
       setPickerOpen(false);
       load();
     });
   }
 
-  function setAmount(line: SalesPlanLine, monthIdx: number, value: string) {
-    const next = (line.amounts ?? Array(12).fill(0)).slice();
-    next[monthIdx] = Number(value) || 0;
-    sbUpdate<SalesPlanLine>('sales_plan_lines', 'id=eq.' + line.id, {
-      amounts: next,
-      updated_at: new Date().toISOString(),
-    } as Partial<SalesPlanLine>).then(load);
+  function arrayFor(line: SalesPlanLine, mode: ViewMode): number[] {
+    switch (mode) {
+      case 'revenue': return line.amounts    ?? ZEROS();
+      case 'qty':     return line.qty        ?? ZEROS();
+      case 'price':   return line.unit_price ?? ZEROS();
+      case 'cost':    return line.unit_cost  ?? ZEROS();
+    }
+  }
+
+  function setCell(line: SalesPlanLine, monthIdx: number, value: string) {
+    const v = Number(value) || 0;
+    const patch: Partial<SalesPlanLine> = { updated_at: new Date().toISOString() };
+    if (viewMode === 'revenue') {
+      const amounts = (line.amounts ?? ZEROS()).slice();
+      amounts[monthIdx] = round2(v);
+      patch.amounts = amounts;
+    } else if (viewMode === 'qty') {
+      const qty = (line.qty ?? ZEROS()).slice();
+      qty[monthIdx] = round2(v);
+      const price = line.unit_price ?? ZEROS();
+      const amounts = (line.amounts ?? ZEROS()).slice();
+      amounts[monthIdx] = round2(v * Number(price[monthIdx] || 0));
+      patch.qty = qty;
+      patch.amounts = amounts;
+    } else if (viewMode === 'price') {
+      const price = (line.unit_price ?? ZEROS()).slice();
+      price[monthIdx] = round2(v);
+      const qty = line.qty ?? ZEROS();
+      const amounts = (line.amounts ?? ZEROS()).slice();
+      amounts[monthIdx] = round2(Number(qty[monthIdx] || 0) * v);
+      patch.unit_price = price;
+      patch.amounts = amounts;
+    } else {
+      const cost = (line.unit_cost ?? ZEROS()).slice();
+      cost[monthIdx] = round2(v);
+      patch.unit_cost = cost;
+    }
+    sbUpdate<SalesPlanLine>('sales_plan_lines', 'id=eq.' + line.id, patch).then(load);
+  }
+
+  function totalFor(line: SalesPlanLine, mode: ViewMode): number {
+    if (mode === 'revenue') return (line.amounts ?? []).reduce((s, v) => s + Number(v || 0), 0);
+    if (mode === 'qty')     return (line.qty     ?? []).reduce((s, v) => s + Number(v || 0), 0);
+    if (mode === 'price') {
+      const qSum = (line.qty     ?? []).reduce((s, v) => s + Number(v || 0), 0);
+      const aSum = (line.amounts ?? []).reduce((s, v) => s + Number(v || 0), 0);
+      return qSum > 0 ? aSum / qSum : 0;
+    }
+    // cost: extended annual cost = sum(qty[i] * unit_cost[i])
+    const q = line.qty       ?? ZEROS();
+    const c = line.unit_cost ?? ZEROS();
+    let t = 0;
+    for (let i = 0; i < 12; i++) t += Number(q[i] || 0) * Number(c[i] || 0);
+    return t;
   }
 
   function deleteLine(id: string) {
@@ -238,7 +300,24 @@ export function PlanEditor({ plan, onBack }: Props) {
             }}
           >
             <div className="ct" style={{ margin: 0 }}>PLAN LINES — {lines.length}</div>
-            <button onClick={() => setPickerOpen(!pickerOpen)} style={btnSecondary()}>+ ADD ITEM</button>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 10, color: 'var(--mt)', letterSpacing: 0.6, textTransform: 'uppercase' }}>View</span>
+              <div style={{ display: 'flex', border: '1px solid var(--bd)', borderRadius: 4, overflow: 'hidden' }}>
+                {VIEW_MODES.map((v) => (
+                  <button
+                    key={v.id}
+                    onClick={() => setViewMode(v.id)}
+                    style={{
+                      padding: '4px 10px', fontSize: 10, fontWeight: 600,
+                      background: viewMode === v.id ? 'rgba(91,181,240,0.18)' : 'transparent',
+                      color:      viewMode === v.id ? 'var(--ac)' : 'var(--tx2)',
+                      border: 'none', borderRight: '1px solid var(--bd)', cursor: 'pointer',
+                    }}
+                  >{v.label}</button>
+                ))}
+              </div>
+              <button onClick={() => setPickerOpen(!pickerOpen)} style={btnSecondary()}>+ ADD ITEM</button>
+            </div>
           </div>
           {pickerOpen && (
             <div style={{ padding: '10px 14px', borderBottom: '1px solid var(--bd)' }}>
@@ -274,14 +353,25 @@ export function PlanEditor({ plan, onBack }: Props) {
                     {MONTHS_SHORT.map((m) => (
                       <th key={m} style={{ textAlign: 'right', fontSize: 9 }}>{m}</th>
                     ))}
-                    <th style={{ textAlign: 'right' }}>Total</th>
+                    <th style={{ textAlign: 'right' }} title={
+                      viewMode === 'revenue' ? 'Annual revenue (sum of months)'
+                      : viewMode === 'qty'     ? 'Annual units (sum of months)'
+                      : viewMode === 'price'   ? 'Blended avg price = annual revenue ÷ annual units'
+                      :                          'Extended annual cost = Σ qty[i] × cost[i]'
+                    }>
+                      {viewMode === 'revenue' ? 'Annual Rev'
+                       : viewMode === 'qty'    ? 'Annual Qty'
+                       : viewMode === 'price'  ? 'Avg Price'
+                       :                          'Annual Cost'}
+                    </th>
                     <th></th>
                   </tr>
                 </thead>
                 <tbody>
                   {lines.map((l) => {
-                    const amounts = l.amounts ?? Array(12).fill(0);
-                    const total = amounts.reduce((s, v) => s + Number(v || 0), 0);
+                    const arr = arrayFor(l, viewMode);
+                    const total = totalFor(l, viewMode);
+                    const isMoney = viewMode !== 'qty';
                     return (
                       <tr key={l.id}>
                         <td
@@ -297,26 +387,31 @@ export function PlanEditor({ plan, onBack }: Props) {
                           {l.item_name ?? '—'}
                         </td>
                         <td style={{ fontSize: 10, color: 'var(--mt)' }}>{l.account_name ?? '—'}</td>
-                        {amounts.map((v, idx) => (
+                        {arr.map((v, idx) => (
                           <td key={idx} style={{ textAlign: 'right', padding: '2px 4px' }}>
                             <input
                               type="number"
+                              step={viewMode === 'qty' ? 1 : 0.01}
                               defaultValue={v ?? 0}
                               onBlur={(e) => {
-                                if (Number(e.target.value) !== Number(v)) setAmount(l, idx, e.target.value);
+                                if (Number(e.target.value) !== Number(v)) setCell(l, idx, e.target.value);
                               }}
                               style={{ ...inp(), width: 72, textAlign: 'right', fontSize: 10, padding: '3px 4px' }}
                             />
                           </td>
                         ))}
-                        <td className="mn" style={{ textAlign: 'right', fontWeight: 600 }}>{fm(total)}</td>
+                        <td className="mn" style={{ textAlign: 'right', fontWeight: 600 }}>
+                          {isMoney ? fm(total) : Math.round(total).toLocaleString()}
+                        </td>
                         <td style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
                           <button
                             onClick={() => {
-                              const v = prompt('Annual total to spread across 12 months:', String(Math.round(total)));
+                              const annualRev = (l.amounts ?? []).reduce((s, v) => s + Number(v || 0), 0);
+                              const v = prompt('Annual revenue total to spread across 12 months:', String(Math.round(annualRev)));
                               if (v != null) fillFlat(l, v);
                             }}
                             style={{ ...btnSecondary(), fontSize: 9, padding: '2px 6px' }}
+                            title="Spread an annual revenue total flat across 12 months"
                           >
                             ÷12
                           </button>

--- a/app/src/pages/settings/AccountsEditor.tsx
+++ b/app/src/pages/settings/AccountsEditor.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react';
+import { btnSecondary, inp } from '../../lib/styles';
+import { fetchAccountSettings, setAccountActive, type AccountSettingRow } from '../../lib/settings';
+import { useToast } from '../../lib/toast';
+
+// Accounts come from QBO (read-only naming). The user can only toggle each
+// P&L account active or inactive — toggling inactive hides every item
+// attached to that account from the Items master grid. Historical sales
+// data on v_sales_lines stays unaffected.
+
+export function AccountsEditor() {
+  const [rows, setRows] = useState<AccountSettingRow[] | null>(null);
+  const [search, setSearch] = useState('');
+  const [showInactive, setShowInactive] = useState(true);
+  const toast = useToast();
+
+  function load() {
+    fetchAccountSettings()
+      .then((rs) => setRows(rs))
+      .catch((e) => { toast.error('Load failed: ' + (e as Error).message); setRows([]); });
+  }
+  useEffect(load, []);
+
+  async function toggle(name: string, next: boolean) {
+    try {
+      await setAccountActive(name, next);
+      setRows((cur) => cur?.map((r) =>
+        r.account_name === name ? { ...r, is_active: next } : r,
+      ) ?? cur);
+    } catch (e) {
+      toast.error('Save failed: ' + (e as Error).message);
+      load();
+    }
+  }
+
+  if (!rows) return <div className="ld">Loading accounts…</div>;
+
+  const q = search.trim().toLowerCase();
+  const filtered = rows.filter((r) => {
+    if (q && !r.account_name.toLowerCase().includes(q)) return false;
+    if (!showInactive && !r.is_active) return false;
+    return true;
+  });
+
+  const activeCount   = rows.filter((r) => r.is_active).length;
+  const inactiveCount = rows.length - activeCount;
+  const hiddenItems   = rows.filter((r) => !r.is_active).reduce((s, r) => s + r.item_count, 0);
+
+  return (
+    <div>
+      <div className="cd" style={{ padding: '12px 14px', marginBottom: 12 }}>
+        <div className="ct" style={{ margin: 0, marginBottom: 4 }}>P&amp;L ACCOUNTS — {rows.length}</div>
+        <div style={{ fontSize: 11, color: 'var(--mt)', lineHeight: 1.4 }}>
+          One row per income account from QBO. Toggle an account inactive to hide every item
+          attached to it from the Items master. Historical sales / margin data stays intact —
+          if you want to exclude an account from a margin report, use the Account filter
+          on the Margin page instead.
+        </div>
+      </div>
+
+      <div className="gr g4" style={{ marginBottom: 12 }}>
+        <div className="kpi-card">
+          <div className="kpi-label">ACTIVE</div>
+          <div className="kpi-value">{activeCount}</div>
+        </div>
+        <div className="kpi-card">
+          <div className="kpi-label">INACTIVE</div>
+          <div className="kpi-value" style={{ color: inactiveCount > 0 ? 'var(--am)' : undefined }}>
+            {inactiveCount}
+          </div>
+        </div>
+        <div className="kpi-card">
+          <div className="kpi-label">ITEMS HIDDEN</div>
+          <div className="kpi-value" style={{ color: hiddenItems > 0 ? 'var(--am)' : undefined }}>
+            {hiddenItems}
+          </div>
+        </div>
+        <div className="kpi-card">
+          <div className="kpi-label">TOTAL ITEMS</div>
+          <div className="kpi-value">{rows.reduce((s, r) => s + r.item_count, 0)}</div>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', gap: 12, alignItems: 'center', marginBottom: 10 }}>
+        <input
+          type="text" placeholder="Search account name…"
+          value={search} onChange={(e) => setSearch(e.target.value)}
+          style={{ ...inp(), flex: 1, maxWidth: 400 }}
+        />
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'var(--tx2)' }}>
+          <input type="checkbox" checked={showInactive}
+            onChange={(e) => setShowInactive(e.target.checked)} />
+          Show inactive
+        </label>
+        <button onClick={load} style={btnSecondary()}>Refresh</button>
+      </div>
+
+      <div className="cd" style={{ padding: 0 }}>
+        <div style={{ maxHeight: '60vh', overflow: 'auto' }}>
+          <table>
+            <thead style={{ position: 'sticky', top: 0, background: 'var(--sf)', zIndex: 1 }}>
+              <tr>
+                <th style={{ textAlign: 'left' }}>Account name</th>
+                <th style={{ textAlign: 'right' }}>Items</th>
+                <th style={{ textAlign: 'right' }}>Active items</th>
+                <th style={{ textAlign: 'center', width: 110 }}>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.length === 0 ? (
+                <tr><td colSpan={4} style={{ padding: 14, color: 'var(--mt)' }}>No accounts match.</td></tr>
+              ) : (
+                filtered.map((r) => (
+                  <tr key={r.account_name} style={{ opacity: r.is_active ? 1 : 0.55 }}>
+                    <td style={{ fontSize: 12 }}>{r.account_name}</td>
+                    <td className="mn" style={{ textAlign: 'right' }}>{r.item_count}</td>
+                    <td className="mn" style={{ textAlign: 'right' }}>{r.active_item_count}</td>
+                    <td style={{ textAlign: 'center' }}>
+                      <label style={{
+                        display: 'inline-flex', alignItems: 'center', gap: 6,
+                        cursor: 'pointer', fontSize: 11,
+                        color: r.is_active ? 'var(--gn)' : 'var(--am)',
+                        fontWeight: 600,
+                      }}>
+                        <input type="checkbox" checked={r.is_active}
+                          onChange={(e) => toggle(r.account_name, e.target.checked)} />
+                        {r.is_active ? 'Active' : 'Hidden'}
+                      </label>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/pages/settings/ItemsSettingsEditor.tsx
+++ b/app/src/pages/settings/ItemsSettingsEditor.tsx
@@ -19,12 +19,12 @@ import {
   bulkSyncCategoriesToQbo,
   fetchItemHygieneSummary,
   alignCategoriesToPl,
-  fetchProductFamilies, fetchProductTypes,
-  setItemProductFamily, setItemProductType,
-  bulkSetItemProductFamily, bulkSetItemProductType,
+  fetchProductFamilies, fetchProductTypes, fetchSegmentOptions,
+  setItemProductFamily, setItemProductType, setItemSegment,
+  bulkSetItemProductFamily, bulkSetItemProductType, bulkSetItemSegment,
   type CategoryOption, type ItemPlAuditRow, type AlignmentStatus,
   type ItemHygieneRow, type HygieneBucket,
-  type ProductFamily, type ProductType,
+  type ProductFamily, type ProductType, type SegmentOption,
 } from '../../lib/inventory';
 
 interface ItemMasterRow {
@@ -57,6 +57,9 @@ interface ItemMasterRow {
   product_family_label: string | null;
   product_type_code: string | null;
   product_type_label: string | null;
+  segment_code: string | null;
+  segment_label: string | null;
+  segment_source: 'item' | 'category' | null;
 }
 
 // GridRow combines the typed item shape with GridValidRowModel's loose
@@ -182,9 +185,11 @@ export function ItemsSettingsEditor() {
   const [hygieneFilter, setHygieneFilter] = useState<HygieneBucket | null>(null);
   const [families, setFamilies] = useState<ProductFamily[]>([]);
   const [productTypes, setProductTypes] = useState<ProductType[]>([]);
+  const [segmentOpts, setSegmentOpts] = useState<SegmentOption[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [bulkFamily, setBulkFamily] = useState<string>('');
   const [bulkType, setBulkType] = useState<string>('');
+  const [bulkSegment, setBulkSegment] = useState<string>('');
 
   function load() {
     setRows(null);
@@ -195,8 +200,9 @@ export function ItemsSettingsEditor() {
       fetchItemHygieneSummary(),
       fetchProductFamilies(),
       fetchProductTypes(),
+      fetchSegmentOptions(),
     ])
-      .then(([rs, cs, audit, hy, fams, types]) => {
+      .then(([rs, cs, audit, hy, fams, types, segs]) => {
         setRows([...rs].sort(sortRows));
         setCategories(cs);
         const m = new Map<string, ItemPlAuditRow>();
@@ -205,6 +211,7 @@ export function ItemsSettingsEditor() {
         setHygiene(hy ?? []);
         setFamilies(fams);
         setProductTypes(types);
+        setSegmentOpts(segs);
       })
       .catch((e) => { toast.error('Load failed: ' + (e as Error).message); setRows([]); });
   }
@@ -335,6 +342,22 @@ export function ItemsSettingsEditor() {
     } catch (e) { toast.error('Save failed: ' + (e as Error).message); load(); }
   }
 
+  async function patchSegment(qbo_item_id: string, segment_code: string | null) {
+    if (!qbo_item_id) return;
+    try {
+      await setItemSegment(qbo_item_id, segment_code);
+      // Setting to null falls back to category default — easier to reload than
+      // try to derive the new effective label on the client.
+      if (!segment_code) { load(); return; }
+      const label = segmentOpts.find((s) => s.segment_code === segment_code)?.label ?? null;
+      setRows((cur) => cur?.map((r) =>
+        r.qbo_item_id === qbo_item_id
+          ? { ...r, segment_code, segment_label: label, segment_source: 'item' }
+          : r,
+      ) ?? cur);
+    } catch (e) { toast.error('Save failed: ' + (e as Error).message); load(); }
+  }
+
   async function applyBulkFamily() {
     if (!selectedIds.length || !bulkFamily) return;
     try {
@@ -351,6 +374,16 @@ export function ItemsSettingsEditor() {
       const n = await bulkSetItemProductType(selectedIds, bulkType);
       toast.success(`Set type on ${n} item${n === 1 ? '' : 's'}.`);
       setBulkType('');
+      load();
+    } catch (e) { toast.error('Bulk save failed: ' + (e as Error).message); }
+  }
+
+  async function applyBulkSegment() {
+    if (!selectedIds.length || !bulkSegment) return;
+    try {
+      const n = await bulkSetItemSegment(selectedIds, bulkSegment);
+      toast.success(`Set segment on ${n} item${n === 1 ? '' : 's'}.`);
+      setBulkSegment('');
       load();
     } catch (e) { toast.error('Bulk save failed: ' + (e as Error).message); }
   }
@@ -533,6 +566,38 @@ export function ItemsSettingsEditor() {
               sx={CAT_AC_SX} slotProps={CAT_AC_PAPER}
               renderInput={(params) => <TextField {...params} placeholder={inherited ?? 'set category'} />}
             />
+          );
+        },
+      },
+      {
+        field: 'segment_label', headerName: 'Segment', width: 180, sortable: true,
+        renderCell: (p) => {
+          if (p.rowNode.type === 'group') return null;
+          const curCode = p.row.segment_code as string | null;
+          const curLabel = p.row.segment_label as string | null;
+          const source = p.row.segment_source as 'item' | 'category' | null;
+          const selected = curCode ? (segmentOpts.find((s) => s.segment_code === curCode) ?? null) : null;
+          return (
+            <div style={{ display: 'flex', alignItems: 'center', width: '100%', gap: 4 }}>
+              <Autocomplete<SegmentOption, false, false, false>
+                size="small"
+                options={segmentOpts}
+                value={selected}
+                getOptionLabel={(o) => o.label}
+                isOptionEqualToValue={(a, b) => a.segment_code === b.segment_code}
+                onChange={(_, v) => {
+                  const next = v?.segment_code ?? null;
+                  if (next !== (curCode ?? null)) patchSegment(p.row.qbo_item_id, next);
+                }}
+                sx={{ ...CAT_AC_SX, flex: 1 }} slotProps={CAT_AC_PAPER}
+                renderInput={(params) => <TextField {...params} placeholder={curLabel ?? 'set segment'} />}
+              />
+              {source === 'category' && (
+                <span title="Inherited from category default (no per-item override)" style={{
+                  fontSize: 9, color: 'var(--mt)', letterSpacing: 0.4,
+                }}>cat</span>
+              )}
+            </div>
           );
         },
       },
@@ -743,7 +808,7 @@ export function ItemsSettingsEditor() {
     );
 
     return cols;
-  }, [categoryLabels, showAlignment, families, productTypes]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [categoryLabels, showAlignment, families, productTypes, segmentOpts]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const groupingColDef = useMemo(() => ({
     headerName: 'Category / Item', width: 360, hideDescendantCount: false,
@@ -929,6 +994,16 @@ export function ItemsSettingsEditor() {
           <span style={{ color: 'var(--mt)', fontSize: 10, letterSpacing: 1, textTransform: 'uppercase', fontWeight: 600 }}>
             Bulk assign · {selectedIds.length} selected
           </span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ color: 'var(--mt)' }}>segment:</span>
+            <select value={bulkSegment} onChange={(e) => setBulkSegment(e.target.value)}
+              style={{ ...inp(), padding: '4px 6px', minWidth: 180 }}>
+              <option value="">— pick —</option>
+              {segmentOpts.map((s) => <option key={s.segment_code} value={s.segment_code}>{s.label}</option>)}
+            </select>
+            <button className="tb-btn tb-btn--primary" onClick={applyBulkSegment}
+              disabled={!bulkSegment}>Apply</button>
+          </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
             <span style={{ color: 'var(--mt)' }}>family:</span>
             <select value={bulkFamily} onChange={(e) => setBulkFamily(e.target.value)}

--- a/app/src/pages/settings/ItemsSettingsEditor.tsx
+++ b/app/src/pages/settings/ItemsSettingsEditor.tsx
@@ -19,8 +19,12 @@ import {
   bulkSyncCategoriesToQbo,
   fetchItemHygieneSummary,
   alignCategoriesToPl,
+  fetchProductFamilies, fetchProductTypes,
+  setItemProductFamily, setItemProductType,
+  bulkSetItemProductFamily, bulkSetItemProductType,
   type CategoryOption, type ItemPlAuditRow, type AlignmentStatus,
   type ItemHygieneRow, type HygieneBucket,
+  type ProductFamily, type ProductType,
 } from '../../lib/inventory';
 
 interface ItemMasterRow {
@@ -49,6 +53,10 @@ interface ItemMasterRow {
   daily_velocity: number | null;
   days_of_supply: number | null;
   status: string;
+  product_family_code: string | null;
+  product_family_label: string | null;
+  product_type_code: string | null;
+  product_type_label: string | null;
 }
 
 // GridRow combines the typed item shape with GridValidRowModel's loose
@@ -172,6 +180,11 @@ export function ItemsSettingsEditor() {
   const [aligning, setAligning] = useState(false);
   const [hygiene, setHygiene] = useState<ItemHygieneRow[]>([]);
   const [hygieneFilter, setHygieneFilter] = useState<HygieneBucket | null>(null);
+  const [families, setFamilies] = useState<ProductFamily[]>([]);
+  const [productTypes, setProductTypes] = useState<ProductType[]>([]);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [bulkFamily, setBulkFamily] = useState<string>('');
+  const [bulkType, setBulkType] = useState<string>('');
 
   function load() {
     setRows(null);
@@ -180,14 +193,18 @@ export function ItemsSettingsEditor() {
       fetchCategoryList(),
       fetchItemPlAudit(3),
       fetchItemHygieneSummary(),
+      fetchProductFamilies(),
+      fetchProductTypes(),
     ])
-      .then(([rs, cs, audit, hy]) => {
+      .then(([rs, cs, audit, hy, fams, types]) => {
         setRows([...rs].sort(sortRows));
         setCategories(cs);
         const m = new Map<string, ItemPlAuditRow>();
         for (const a of audit) m.set(a.qbo_item_id, a);
         setAuditByItem(m);
         setHygiene(hy ?? []);
+        setFamilies(fams);
+        setProductTypes(types);
       })
       .catch((e) => { toast.error('Load failed: ' + (e as Error).message); setRows([]); });
   }
@@ -290,6 +307,52 @@ export function ItemsSettingsEditor() {
       setAuditByItem(m);
     }).catch(() => undefined);
     toast.success('Applied: ' + suggested);
+  }
+
+  async function patchFamily(qbo_item_id: string, family_code: string | null) {
+    if (!qbo_item_id) return;
+    try {
+      await setItemProductFamily(qbo_item_id, family_code);
+      const label = family_code ? (families.find((f) => f.family_code === family_code)?.label ?? null) : null;
+      setRows((cur) => cur?.map((r) =>
+        r.qbo_item_id === qbo_item_id
+          ? { ...r, product_family_code: family_code, product_family_label: label }
+          : r,
+      ) ?? cur);
+    } catch (e) { toast.error('Save failed: ' + (e as Error).message); load(); }
+  }
+
+  async function patchType(qbo_item_id: string, type_code: string | null) {
+    if (!qbo_item_id) return;
+    try {
+      await setItemProductType(qbo_item_id, type_code);
+      const label = type_code ? (productTypes.find((t) => t.type_code === type_code)?.label ?? null) : null;
+      setRows((cur) => cur?.map((r) =>
+        r.qbo_item_id === qbo_item_id
+          ? { ...r, product_type_code: type_code, product_type_label: label }
+          : r,
+      ) ?? cur);
+    } catch (e) { toast.error('Save failed: ' + (e as Error).message); load(); }
+  }
+
+  async function applyBulkFamily() {
+    if (!selectedIds.length || !bulkFamily) return;
+    try {
+      const n = await bulkSetItemProductFamily(selectedIds, bulkFamily);
+      toast.success(`Set family on ${n} item${n === 1 ? '' : 's'}.`);
+      setBulkFamily('');
+      load();
+    } catch (e) { toast.error('Bulk save failed: ' + (e as Error).message); }
+  }
+
+  async function applyBulkType() {
+    if (!selectedIds.length || !bulkType) return;
+    try {
+      const n = await bulkSetItemProductType(selectedIds, bulkType);
+      toast.success(`Set type on ${n} item${n === 1 ? '' : 's'}.`);
+      setBulkType('');
+      load();
+    } catch (e) { toast.error('Bulk save failed: ' + (e as Error).message); }
   }
 
   async function runBulkAutoCategorize() {
@@ -473,6 +536,54 @@ export function ItemsSettingsEditor() {
           );
         },
       },
+      {
+        field: 'product_family_label', headerName: 'Family', width: 170, sortable: true,
+        renderCell: (p) => {
+          if (p.rowNode.type === 'group') return null;
+          const curCode = p.row.product_family_code as string | null;
+          const curLabel = p.row.product_family_label as string | null;
+          const selected = curCode ? (families.find((f) => f.family_code === curCode) ?? null) : null;
+          return (
+            <Autocomplete<ProductFamily, false, false, false>
+              size="small"
+              options={families}
+              value={selected}
+              getOptionLabel={(o) => o.label}
+              isOptionEqualToValue={(a, b) => a.family_code === b.family_code}
+              onChange={(_, v) => {
+                const next = v?.family_code ?? null;
+                if (next !== (curCode ?? null)) patchFamily(p.row.qbo_item_id, next);
+              }}
+              sx={CAT_AC_SX} slotProps={CAT_AC_PAPER}
+              renderInput={(params) => <TextField {...params} placeholder={curLabel ?? 'set family'} />}
+            />
+          );
+        },
+      },
+      {
+        field: 'product_type_label', headerName: 'Type', width: 160, sortable: true,
+        renderCell: (p) => {
+          if (p.rowNode.type === 'group') return null;
+          const curCode = p.row.product_type_code as string | null;
+          const curLabel = p.row.product_type_label as string | null;
+          const selected = curCode ? (productTypes.find((t) => t.type_code === curCode) ?? null) : null;
+          return (
+            <Autocomplete<ProductType, false, false, false>
+              size="small"
+              options={productTypes}
+              value={selected}
+              getOptionLabel={(o) => o.label}
+              isOptionEqualToValue={(a, b) => a.type_code === b.type_code}
+              onChange={(_, v) => {
+                const next = v?.type_code ?? null;
+                if (next !== (curCode ?? null)) patchType(p.row.qbo_item_id, next);
+              }}
+              sx={CAT_AC_SX} slotProps={CAT_AC_PAPER}
+              renderInput={(params) => <TextField {...params} placeholder={curLabel ?? 'set type'} />}
+            />
+          );
+        },
+      },
     ];
 
     if (showAlignment) {
@@ -632,7 +743,7 @@ export function ItemsSettingsEditor() {
     );
 
     return cols;
-  }, [categoryLabels, showAlignment]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [categoryLabels, showAlignment, families, productTypes]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const groupingColDef = useMemo(() => ({
     headerName: 'Category / Item', width: 360, hideDescendantCount: false,
@@ -794,6 +905,10 @@ export function ItemsSettingsEditor() {
             treeData getTreeDataPath={getTreeDataPath}
             groupingColDef={groupingColDef}
             density="compact" pagination disableRowSelectionOnClick
+            checkboxSelection
+            onRowSelectionModelChange={(model) => {
+              setSelectedIds(model.map(String).filter((id) => !id.startsWith('auto-generated-row-')));
+            }}
             pageSizeOptions={[20, 40, 60, 100, 250, { value: -1, label: 'All' }]}
             defaultGroupingExpansionDepth={1}
             initialState={{
@@ -805,6 +920,37 @@ export function ItemsSettingsEditor() {
           />
         )}
       </div>
+
+      {selectedIds.length > 0 && (
+        <div className="cd" style={{
+          padding: '10px 12px', marginTop: 10, display: 'flex',
+          gap: 12, alignItems: 'center', flexWrap: 'wrap', fontSize: 11,
+        }}>
+          <span style={{ color: 'var(--mt)', fontSize: 10, letterSpacing: 1, textTransform: 'uppercase', fontWeight: 600 }}>
+            Bulk assign · {selectedIds.length} selected
+          </span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ color: 'var(--mt)' }}>family:</span>
+            <select value={bulkFamily} onChange={(e) => setBulkFamily(e.target.value)}
+              style={{ ...inp(), padding: '4px 6px', minWidth: 160 }}>
+              <option value="">— pick —</option>
+              {families.map((f) => <option key={f.family_code} value={f.family_code}>{f.label}</option>)}
+            </select>
+            <button className="tb-btn tb-btn--primary" onClick={applyBulkFamily}
+              disabled={!bulkFamily}>Apply</button>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ color: 'var(--mt)' }}>type:</span>
+            <select value={bulkType} onChange={(e) => setBulkType(e.target.value)}
+              style={{ ...inp(), padding: '4px 6px', minWidth: 160 }}>
+              <option value="">— pick —</option>
+              {productTypes.map((t) => <option key={t.type_code} value={t.type_code}>{t.label}</option>)}
+            </select>
+            <button className="tb-btn tb-btn--primary" onClick={applyBulkType}
+              disabled={!bulkType}>Apply</button>
+          </div>
+        </div>
+      )}
 
       <div style={{ fontSize: 10, color: 'var(--mt)', marginTop: 8, lineHeight: 1.4 }}>
         <strong style={{ color: 'var(--tx)' }}>P&amp;L alignment.</strong> Each item flows revenue into a

--- a/app/src/pages/settings/ItemsSettingsEditor.tsx
+++ b/app/src/pages/settings/ItemsSettingsEditor.tsx
@@ -237,6 +237,9 @@ export function ItemsSettingsEditor() {
     qbo_item_id: string,
     patchData: Partial<Pick<ItemMasterRow, 'is_managed' | 'is_planner' | 'target_days_supply' | 'lead_time_days' | 'reorder_point' | 'min_order_qty' | 'notes' | 'category_override'>>,
   ) {
+    // The grid is tree-grouped by category; group rows have no qbo_item_id.
+    // If a control on a group row fires this, silently ignore.
+    if (!qbo_item_id) return;
     try {
       await sbrpc<void>('fn_set_inventory_settings', {
         p_qbo_item_id:        qbo_item_id,
@@ -267,6 +270,7 @@ export function ItemsSettingsEditor() {
   }
 
   async function patchActive(qbo_item_id: string, active: boolean) {
+    if (!qbo_item_id) return;
     try {
       await setItemActive(qbo_item_id, active);
       setRows((cur) => cur?.map((r) =>
@@ -406,37 +410,47 @@ export function ItemsSettingsEditor() {
     const cols: GridColDef[] = [
       {
         field: 'active', headerName: 'Active', width: 70, sortable: true,
-        renderCell: (p) => (
-          <Toggle
-            checked={!!p.value}
-            onChange={(v) => patchActive(p.row.qbo_item_id, v)}
-            title="Active in QBO. Toggling here pushes to QuickBooks via push-qbo-item edge function."
-          />
-        ),
+        renderCell: (p) => {
+          if (p.rowNode.type === 'group') return null;
+          return (
+            <Toggle
+              checked={!!p.value}
+              onChange={(v) => patchActive(p.row.qbo_item_id, v)}
+              title="Active in QBO. Toggling here pushes to QuickBooks via push-qbo-item edge function."
+            />
+          );
+        },
       },
       {
         field: 'is_managed', headerName: 'Managed', width: 90, sortable: true,
-        renderCell: (p) => (
-          <Toggle
-            checked={!!p.value}
-            onChange={(v) => patchSettings(p.row.qbo_item_id, { is_managed: v })}
-            title="If on, this item appears in the Inventory health view with velocity, reorder, days-of-supply."
-          />
-        ),
+        renderCell: (p) => {
+          if (p.rowNode.type === 'group') return null;
+          return (
+            <Toggle
+              checked={!!p.value}
+              onChange={(v) => patchSettings(p.row.qbo_item_id, { is_managed: v })}
+              title="If on, this item appears in the Inventory health view with velocity, reorder, days-of-supply."
+            />
+          );
+        },
       },
       {
         field: 'is_planner', headerName: 'In planner', width: 90, sortable: true,
-        renderCell: (p) => (
-          <Toggle
-            checked={!!p.value}
-            onChange={(v) => patchSettings(p.row.qbo_item_id, { is_planner: v })}
-            title="If on, this item appears in the Plan Builder (item × customer × month grid). Use for SKUs you actively budget."
-          />
-        ),
+        renderCell: (p) => {
+          if (p.rowNode.type === 'group') return null;
+          return (
+            <Toggle
+              checked={!!p.value}
+              onChange={(v) => patchSettings(p.row.qbo_item_id, { is_planner: v })}
+              title="If on, this item appears in the Plan Builder (item × customer × month grid). Use for SKUs you actively budget."
+            />
+          );
+        },
       },
       {
         field: 'category_override', headerName: 'Category', width: 220,
         renderCell: (p) => {
+          if (p.rowNode.type === 'group') return null;
           const cur = p.row.category_override as string | null;
           const inherited = p.row.category_path as string | null;
           const value = cur ?? '';
@@ -481,6 +495,7 @@ export function ItemsSettingsEditor() {
         {
           field: 'suggested_category', headerName: 'Suggested', flex: 1, minWidth: 220,
           renderCell: (p) => {
+            if (p.rowNode.type === 'group') return null;
             const s = p.value as string | null | undefined;
             if (!s) {
               const dom = p.row.dominant_category_for_account as string | null | undefined;
@@ -542,62 +557,77 @@ export function ItemsSettingsEditor() {
       },
       {
         field: 'target_days_supply', headerName: 'Target Days', type: 'number', width: 100, cellClassName: 'mn',
-        renderCell: (p) => (
-          <input type="number" defaultValue={p.value ?? 30}
-            onBlur={(e) => {
-              const v = Number(e.target.value);
-              if (v !== p.value) patchSettings(p.row.qbo_item_id, { target_days_supply: v });
-            }}
-            style={{ ...inp(), width: 60, textAlign: 'right' }} />
-        ),
+        renderCell: (p) => {
+          if (p.rowNode.type === 'group') return null;
+          return (
+            <input type="number" defaultValue={p.value ?? 30}
+              onBlur={(e) => {
+                const v = Number(e.target.value);
+                if (v !== p.value) patchSettings(p.row.qbo_item_id, { target_days_supply: v });
+              }}
+              style={{ ...inp(), width: 60, textAlign: 'right' }} />
+          );
+        },
       },
       {
         field: 'lead_time_days', headerName: 'Lead Time', type: 'number', width: 100, cellClassName: 'mn',
-        renderCell: (p) => (
-          <input type="number" defaultValue={p.value ?? 7}
-            onBlur={(e) => {
-              const v = Number(e.target.value);
-              if (v !== p.value) patchSettings(p.row.qbo_item_id, { lead_time_days: v });
-            }}
-            style={{ ...inp(), width: 60, textAlign: 'right' }} />
-        ),
+        renderCell: (p) => {
+          if (p.rowNode.type === 'group') return null;
+          return (
+            <input type="number" defaultValue={p.value ?? 7}
+              onBlur={(e) => {
+                const v = Number(e.target.value);
+                if (v !== p.value) patchSettings(p.row.qbo_item_id, { lead_time_days: v });
+              }}
+              style={{ ...inp(), width: 60, textAlign: 'right' }} />
+          );
+        },
       },
       {
         field: 'reorder_point', headerName: 'Reorder Pt', type: 'number', width: 110, cellClassName: 'mn',
-        renderCell: (p) => (
-          <input type="number" defaultValue={p.value ?? ''}
-            placeholder="auto"
-            onBlur={(e) => {
-              const v = e.target.value === '' ? null : Number(e.target.value);
-              if (v !== p.value) patchSettings(p.row.qbo_item_id, { reorder_point: v });
-            }}
-            style={{ ...inp(), width: 70, textAlign: 'right' }} />
-        ),
+        renderCell: (p) => {
+          if (p.rowNode.type === 'group') return null;
+          return (
+            <input type="number" defaultValue={p.value ?? ''}
+              placeholder="auto"
+              onBlur={(e) => {
+                const v = e.target.value === '' ? null : Number(e.target.value);
+                if (v !== p.value) patchSettings(p.row.qbo_item_id, { reorder_point: v });
+              }}
+              style={{ ...inp(), width: 70, textAlign: 'right' }} />
+          );
+        },
       },
       {
         field: 'min_order_qty', headerName: 'Min Order', type: 'number', width: 100, cellClassName: 'mn',
-        renderCell: (p) => (
-          <input type="number" defaultValue={p.value ?? ''}
-            onBlur={(e) => {
-              const v = e.target.value === '' ? null : Number(e.target.value);
-              if (v !== p.value) patchSettings(p.row.qbo_item_id, { min_order_qty: v });
-            }}
-            style={{ ...inp(), width: 70, textAlign: 'right' }} />
-        ),
+        renderCell: (p) => {
+          if (p.rowNode.type === 'group') return null;
+          return (
+            <input type="number" defaultValue={p.value ?? ''}
+              onBlur={(e) => {
+                const v = e.target.value === '' ? null : Number(e.target.value);
+                if (v !== p.value) patchSettings(p.row.qbo_item_id, { min_order_qty: v });
+              }}
+              style={{ ...inp(), width: 70, textAlign: 'right' }} />
+          );
+        },
       },
       { field: 'sold_revenue', headerName: 'Rev 90d', type: 'number', width: 110, cellClassName: 'mn',
         valueFormatter: (v) => fm(Number(v ?? 0)) },
       {
         field: 'notes', headerName: 'Notes', flex: 1, minWidth: 200,
-        renderCell: (p) => (
-          <input type="text" defaultValue={p.value ?? ''}
-            placeholder="—"
-            onBlur={(e) => {
-              const v = e.target.value;
-              if (v !== (p.value ?? '')) patchSettings(p.row.qbo_item_id, { notes: v || null });
-            }}
-            style={{ ...inp(), width: '100%', fontSize: 11 }} />
-        ),
+        renderCell: (p) => {
+          if (p.rowNode.type === 'group') return null;
+          return (
+            <input type="text" defaultValue={p.value ?? ''}
+              placeholder="—"
+              onBlur={(e) => {
+                const v = e.target.value;
+                if (v !== (p.value ?? '')) patchSettings(p.row.qbo_item_id, { notes: v || null });
+              }}
+              style={{ ...inp(), width: '100%', fontSize: 11 }} />
+          );
+        },
       },
     );
 

--- a/supabase/migrations/20260512a_fix_set_customer_channels_ambiguity.sql
+++ b/supabase/migrations/20260512a_fix_set_customer_channels_ambiguity.sql
@@ -1,0 +1,66 @@
+-- Hotfix: ops.fn_set_customer_channels was raising
+--   42702 column reference "channel_code" is ambiguous
+-- when called from Settings → Customer Classification.
+--
+-- The function declares RETURNS TABLE (channel_code text, is_primary boolean),
+-- which makes those names PL/pgSQL OUT variables. They collide with the
+-- ops.customer_channels columns of the same name in the DELETE WHERE clause
+-- and ON CONFLICT clause. Add #variable_conflict use_column so PostgreSQL
+-- prefers the column when names collide (we never assign to the OUT vars
+-- explicitly — RETURN QUERY supplies them), and qualify column references
+-- defensively.
+
+CREATE OR REPLACE FUNCTION ops.fn_set_customer_channels(
+  p_qbo_customer_id text,
+  p_channel_labels  text[],
+  p_primary_label   text DEFAULT NULL,
+  p_set_by          text DEFAULT 'dashboard'
+) RETURNS TABLE (channel_code text, is_primary boolean)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ops, public
+AS $$
+#variable_conflict use_column
+DECLARE
+  v_codes text[];
+  v_primary_code text;
+BEGIN
+  IF p_qbo_customer_id IS NULL THEN RAISE EXCEPTION 'customer id required'; END IF;
+
+  SELECT array_agg(c.channel_code)
+    INTO v_codes
+    FROM ops.channels c
+   WHERE c.label = ANY(COALESCE(p_channel_labels, ARRAY[]::text[]));
+  IF v_codes IS NULL THEN v_codes := ARRAY[]::text[]; END IF;
+
+  IF p_primary_label IS NOT NULL THEN
+    SELECT c.channel_code INTO v_primary_code
+      FROM ops.channels c WHERE c.label = p_primary_label;
+    IF v_primary_code IS NOT NULL AND NOT v_primary_code = ANY(v_codes) THEN
+      v_primary_code := NULL;
+    END IF;
+  END IF;
+
+  DELETE FROM ops.customer_channels cc
+   WHERE cc.qbo_customer_id = p_qbo_customer_id
+     AND NOT cc.channel_code = ANY(v_codes);
+
+  UPDATE ops.customer_channels cc
+     SET is_primary = false
+   WHERE cc.qbo_customer_id = p_qbo_customer_id;
+
+  INSERT INTO ops.customer_channels AS cc (qbo_customer_id, channel_code, is_primary, set_by, set_at)
+  SELECT p_qbo_customer_id, code, (code = v_primary_code), p_set_by, now()
+    FROM unnest(v_codes) AS code
+  ON CONFLICT (qbo_customer_id, channel_code) DO UPDATE
+     SET is_primary = EXCLUDED.is_primary,
+         set_by     = EXCLUDED.set_by,
+         set_at     = EXCLUDED.set_at;
+
+  RETURN QUERY
+    SELECT cc.channel_code, cc.is_primary
+      FROM ops.customer_channels cc
+     WHERE cc.qbo_customer_id = p_qbo_customer_id
+     ORDER BY cc.is_primary DESC, cc.channel_code;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION ops.fn_set_customer_channels(text, text[], text, text) TO authenticated;

--- a/supabase/migrations/20260512b_restore_sales_reps_write_grants.sql
+++ b/supabase/migrations/20260512b_restore_sales_reps_write_grants.sql
@@ -1,0 +1,19 @@
+-- Hotfix: sales-rep saves were failing with
+--   42501 permission denied for table customer_sales_reps
+-- (and the same on ops.sales_reps).
+--
+-- Both tables exist in live and are queried via fn_customers_master, but the
+-- INSERT/UPDATE/DELETE grants that 20260503f originally set up for the
+-- authenticated role were missing. The May-5 "drop rep tables" migration
+-- (20260505d) was apparently never applied — or the tables were recreated
+-- afterward without re-establishing write privileges. Either way the UI
+-- (Customers settings → primary sales rep dropdown, and the Sales Reps CRUD
+-- page) does direct PostgREST writes, which require these grants.
+--
+-- We don't re-enable RLS here. RLS is currently disabled on both tables, and
+-- the original policies were unconstrained (USING (true)) — functionally
+-- equivalent to RLS-off. Keeping RLS-off until/unless a real row-level
+-- restriction is needed.
+
+GRANT INSERT, UPDATE, DELETE ON ops.sales_reps          TO authenticated;
+GRANT INSERT, UPDATE, DELETE ON ops.customer_sales_reps TO authenticated;

--- a/supabase/migrations/20260512c_fix_align_categories_to_pl_ambiguity.sql
+++ b/supabase/migrations/20260512c_fix_align_categories_to_pl_ambiguity.sql
@@ -1,0 +1,85 @@
+-- Hotfix: ops.fn_align_categories_to_pl was raising
+--   42702 column reference "qbo_item_id" is ambiguous
+-- when called from the Items master "Align to P&L" action.
+--
+-- The function declares RETURNS TABLE(qbo_item_id text, ...) which makes
+-- that an OUT variable, then references the same name as a column in the
+-- INSERT ... ON CONFLICT (qbo_item_id) clause. Add #variable_conflict
+-- use_column so PostgreSQL prefers the column on conflict — the OUT
+-- variables are only assigned via `:=` (which is unambiguous PL/pgSQL
+-- syntax, unaffected by use_column).
+
+CREATE OR REPLACE FUNCTION ops.fn_align_categories_to_pl(
+  p_commit boolean DEFAULT false
+)
+RETURNS TABLE(
+  qbo_item_id         text,
+  item_name           text,
+  income_account_name text,
+  from_category       text,
+  to_category         text,
+  status              text,
+  applied             boolean
+)
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'ops', 'public'
+AS $$
+#variable_conflict use_column
+DECLARE
+  rec RECORD;
+BEGIN
+  FOR rec IN
+    SELECT
+      it.qbo_item_id,
+      COALESCE(it.name, it.fully_qualified_name) AS item_name,
+      it.income_account_name,
+      COALESCE(s.category_override, it.category_path, 'Uncategorized') AS current_category
+    FROM ops.qbo_items it
+    LEFT JOIN ops.inventory_settings s ON s.qbo_item_id = it.qbo_item_id
+    WHERE COALESCE(it.active, true) = true
+  LOOP
+    IF rec.income_account_name IS NULL OR rec.income_account_name = '' THEN
+      qbo_item_id         := rec.qbo_item_id;
+      item_name           := rec.item_name;
+      income_account_name := rec.income_account_name;
+      from_category       := rec.current_category;
+      to_category         := NULL;
+      status              := 'skipped_no_account';
+      applied             := false;
+      RETURN NEXT;
+      CONTINUE;
+    END IF;
+
+    IF rec.current_category = rec.income_account_name THEN
+      qbo_item_id         := rec.qbo_item_id;
+      item_name           := rec.item_name;
+      income_account_name := rec.income_account_name;
+      from_category       := rec.current_category;
+      to_category         := rec.income_account_name;
+      status              := 'already_aligned';
+      applied             := false;
+      RETURN NEXT;
+      CONTINUE;
+    END IF;
+
+    IF p_commit THEN
+      INSERT INTO ops.inventory_settings (qbo_item_id, category_override, updated_at)
+      VALUES (rec.qbo_item_id, rec.income_account_name, now())
+      ON CONFLICT (qbo_item_id) DO UPDATE
+        SET category_override = EXCLUDED.category_override,
+            updated_at        = now();
+    END IF;
+
+    qbo_item_id         := rec.qbo_item_id;
+    item_name           := rec.item_name;
+    income_account_name := rec.income_account_name;
+    from_category       := rec.current_category;
+    to_category         := rec.income_account_name;
+    status              := 'updated';
+    applied             := p_commit;
+    RETURN NEXT;
+  END LOOP;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION ops.fn_align_categories_to_pl(boolean) TO authenticated;

--- a/supabase/migrations/20260512d_product_families_and_types.sql
+++ b/supabase/migrations/20260512d_product_families_and_types.sql
@@ -33,6 +33,7 @@ INSERT INTO ops.product_families (family_code, label, sort_order) VALUES
   ('melt_equip',  'Melt Equipment',      40),
   ('bev_equip',   'Beverage Equipment',  50),
   ('service',     'Service',             60),
+  ('pm',          'Preventative Maintenance', 65),
   ('gas',         'Gas',                 70),
   ('rental',      'Rental',              80),
   ('parts',       'Parts',               85),
@@ -140,6 +141,9 @@ ON CONFLICT (item_name) DO UPDATE
   WHERE ops.item_segments.set_by LIKE 'auto-match%' OR ops.item_segments.set_by IS NULL;
 
 -- ── 6. Auto-match: PRODUCT FAMILY ─────────────────────────────────────────
+-- PM family is name-driven (explicit "PM" in item name); the income account
+-- 'PM and Contract Service Income' mixes PM with general contract service,
+-- so we don't classify by income_account alone.
 INSERT INTO ops.item_product_families (qbo_item_id, family_code, set_by)
 SELECT it.qbo_item_id,
        CASE
@@ -150,6 +154,7 @@ SELECT it.qbo_item_id,
          WHEN it.income_account_name IN ('Packaged Beverage Income','Shopify Sales','Beverage Fee Income')
               OR it.name ~* '^(24P|12P|6P|12OZ|16OZ)'                              THEN 'can'
          WHEN it.income_account_name IN ('100% CO2','Mixed Gas and Nitro','Hazmat Del Fees','Gas COGS') THEN 'gas'
+         WHEN it.name ~* '\m(PM|PREVENTATIVE *MAINTENANCE)\M'                      THEN 'pm'
          WHEN it.income_account_name IN ('Service Income','PM and Contract Service Income','Freshpet Service Income') THEN 'service'
          WHEN it.income_account_name IN ('Equipment Rental Income','Tank Rental Income','Sublet Rental Income') THEN 'rental'
          WHEN it.income_account_name = 'Equipment Remanufacturing'                 THEN 'reman'

--- a/supabase/migrations/20260512d_product_families_and_types.sql
+++ b/supabase/migrations/20260512d_product_families_and_types.sql
@@ -1,0 +1,286 @@
+-- v0.9.33 — Product family + product type taxonomies.
+--
+-- Adds two orthogonal item-attribute dimensions so margin reports can slice
+-- by form factor (BIB, Can, Equipment, …) and by product nature (CSD, Juice,
+-- Tea, …) independently of segment. Auto-populates assignments from existing
+-- income_account_name + category_path + item-name patterns.
+--
+-- New segment: 'foodservice_equipment' (for Melt Equipment + non-bev kitchen
+-- equipment). The existing 'equipment_sales' segment stays as the parent
+-- bucket for non-foodservice equipment.
+
+-- ── 1. New segment ────────────────────────────────────────────────────────
+INSERT INTO ops.segments (segment_code, label, sort_order, is_active) VALUES
+  ('foodservice_equipment', 'Foodservice Equipment', 6, true),
+  ('rental',                'Rental',                85, true)
+ON CONFLICT (segment_code) DO UPDATE
+  SET label = EXCLUDED.label, sort_order = EXCLUDED.sort_order;
+
+-- ── 2. Product Families taxonomy ──────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS ops.product_families (
+  family_code text PRIMARY KEY,
+  label       text NOT NULL,
+  sort_order  int  NOT NULL DEFAULT 100,
+  is_active   boolean NOT NULL DEFAULT true,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+INSERT INTO ops.product_families (family_code, label, sort_order) VALUES
+  ('bib',         'Bag in Box',          10),
+  ('can',         'Can',                 20),
+  ('bottle',      'Bottle',              25),
+  ('postmix',     'Postmix',             30),
+  ('melt_equip',  'Melt Equipment',      40),
+  ('bev_equip',   'Beverage Equipment',  50),
+  ('service',     'Service',             60),
+  ('gas',         'Gas',                 70),
+  ('rental',      'Rental',              80),
+  ('parts',       'Parts',               85),
+  ('reman',       'Remanufacturing',     90),
+  ('scrap',       'Scrap',               95),
+  ('other',       'Other',               99)
+ON CONFLICT (family_code) DO UPDATE
+  SET label = EXCLUDED.label, sort_order = EXCLUDED.sort_order;
+
+ALTER TABLE ops.product_families ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS product_families_read  ON ops.product_families;
+DROP POLICY IF EXISTS product_families_write ON ops.product_families;
+CREATE POLICY product_families_read  ON ops.product_families FOR SELECT TO anon, authenticated USING (true);
+CREATE POLICY product_families_write ON ops.product_families FOR ALL    TO authenticated USING (true) WITH CHECK (true);
+GRANT SELECT ON ops.product_families TO anon;
+GRANT INSERT, UPDATE, DELETE ON ops.product_families TO authenticated;
+
+-- ── 3. Product Types taxonomy ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS ops.product_types (
+  type_code   text PRIMARY KEY,
+  label       text NOT NULL,
+  sort_order  int  NOT NULL DEFAULT 100,
+  is_active   boolean NOT NULL DEFAULT true,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+INSERT INTO ops.product_types (type_code, label, sort_order) VALUES
+  ('csd',         'Carbonated Soft Drink', 10),
+  ('juice',       'Juice',                 20),
+  ('tea',         'Tea',                   30),
+  ('lemonade',    'Lemonade',              40),
+  ('energy',      'Energy',                50),
+  ('mixer',       'Tonic / Mixer',         60),
+  ('water',       'Water',                 70),
+  ('coffee',      'Coffee',                75),
+  ('hardware',    'Hardware',              80),
+  ('consumable',  'Consumable',            85),
+  ('labor',       'Labor / Service',       90),
+  ('na',          'N/A',                   99)
+ON CONFLICT (type_code) DO UPDATE
+  SET label = EXCLUDED.label, sort_order = EXCLUDED.sort_order;
+
+ALTER TABLE ops.product_types ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS product_types_read  ON ops.product_types;
+DROP POLICY IF EXISTS product_types_write ON ops.product_types;
+CREATE POLICY product_types_read  ON ops.product_types FOR SELECT TO anon, authenticated USING (true);
+CREATE POLICY product_types_write ON ops.product_types FOR ALL    TO authenticated USING (true) WITH CHECK (true);
+GRANT SELECT ON ops.product_types TO anon;
+GRANT INSERT, UPDATE, DELETE ON ops.product_types TO authenticated;
+
+-- ── 4. Per-item assignment tables (keyed by qbo_item_id for stability) ────
+CREATE TABLE IF NOT EXISTS ops.item_product_families (
+  qbo_item_id text PRIMARY KEY,
+  family_code text NOT NULL REFERENCES ops.product_families(family_code) ON DELETE RESTRICT,
+  set_by      text,
+  set_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS ops.item_product_types (
+  qbo_item_id text PRIMARY KEY,
+  type_code   text NOT NULL REFERENCES ops.product_types(type_code) ON DELETE RESTRICT,
+  set_by      text,
+  set_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ipf_family ON ops.item_product_families(family_code);
+CREATE INDEX IF NOT EXISTS idx_ipt_type   ON ops.item_product_types(type_code);
+
+ALTER TABLE ops.item_product_families ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ops.item_product_types    ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS ipf_read  ON ops.item_product_families;
+DROP POLICY IF EXISTS ipf_write ON ops.item_product_families;
+DROP POLICY IF EXISTS ipt_read  ON ops.item_product_types;
+DROP POLICY IF EXISTS ipt_write ON ops.item_product_types;
+CREATE POLICY ipf_read  ON ops.item_product_families FOR SELECT TO anon, authenticated USING (true);
+CREATE POLICY ipf_write ON ops.item_product_families FOR ALL    TO authenticated USING (true) WITH CHECK (true);
+CREATE POLICY ipt_read  ON ops.item_product_types    FOR SELECT TO anon, authenticated USING (true);
+CREATE POLICY ipt_write ON ops.item_product_types    FOR ALL    TO authenticated USING (true) WITH CHECK (true);
+GRANT SELECT ON ops.item_product_families, ops.item_product_types TO anon;
+GRANT INSERT, UPDATE, DELETE ON ops.item_product_families, ops.item_product_types TO authenticated;
+
+-- ── 5. Auto-match: SEGMENTS (override existing category-level via item_segments)
+-- Order matters: later patterns can override earlier; we use ON CONFLICT DO UPDATE.
+INSERT INTO ops.item_segments (item_name, segment_code, set_by)
+SELECT it.name,
+       CASE
+         WHEN it.category_path = 'The Melt Equipment'                              THEN 'foodservice_equipment'
+         WHEN it.income_account_name IN ('Equipment Sales')                        THEN 'equipment_sales'
+         WHEN it.income_account_name IN ('BIB Income','3 Gallon','5 Gallon')       THEN 'fountain'
+         WHEN it.income_account_name IN ('Packaged Beverage Income','Shopify Sales','Beverage Fee Income') THEN 'packaged'
+         WHEN it.income_account_name IN ('100% CO2','Mixed Gas and Nitro','Hazmat Del Fees','Gas COGS') THEN 'foodservice_gas'
+         WHEN it.income_account_name IN ('Service Income','PM and Contract Service Income','Freshpet Service Income') THEN 'service'
+         WHEN it.income_account_name = 'Scrap Income'                              THEN 'scrapping'
+         WHEN it.income_account_name = 'Equipment Remanufacturing'                 THEN 'reman'
+         WHEN it.income_account_name IN ('Equipment Rental Income','Tank Rental Income','Sublet Rental Income') THEN 'rental'
+         ELSE 'other'
+       END,
+       'auto-match v0.9.33'
+FROM ops.qbo_items it
+WHERE it.active AND it.name IS NOT NULL
+ON CONFLICT (item_name) DO UPDATE
+  SET segment_code = EXCLUDED.segment_code,
+      set_by       = EXCLUDED.set_by,
+      set_at       = now()
+  WHERE ops.item_segments.set_by LIKE 'auto-match%' OR ops.item_segments.set_by IS NULL;
+
+-- ── 6. Auto-match: PRODUCT FAMILY ─────────────────────────────────────────
+INSERT INTO ops.item_product_families (qbo_item_id, family_code, set_by)
+SELECT it.qbo_item_id,
+       CASE
+         WHEN it.category_path = 'The Melt Equipment'                              THEN 'melt_equip'
+         WHEN it.income_account_name = 'Equipment Sales'                           THEN 'bev_equip'
+         WHEN it.income_account_name IN ('BIB Income','3 Gallon','5 Gallon')
+              OR it.name ~* '^([1-9]GSF|[1-9]GNS|[1-9]G)[0-9]'                     THEN 'bib'
+         WHEN it.income_account_name IN ('Packaged Beverage Income','Shopify Sales','Beverage Fee Income')
+              OR it.name ~* '^(24P|12P|6P|12OZ|16OZ)'                              THEN 'can'
+         WHEN it.income_account_name IN ('100% CO2','Mixed Gas and Nitro','Hazmat Del Fees','Gas COGS') THEN 'gas'
+         WHEN it.income_account_name IN ('Service Income','PM and Contract Service Income','Freshpet Service Income') THEN 'service'
+         WHEN it.income_account_name IN ('Equipment Rental Income','Tank Rental Income','Sublet Rental Income') THEN 'rental'
+         WHEN it.income_account_name = 'Equipment Remanufacturing'                 THEN 'reman'
+         WHEN it.income_account_name = 'Scrap Income'                              THEN 'scrap'
+         ELSE 'other'
+       END,
+       'auto-match v0.9.33'
+FROM ops.qbo_items it
+WHERE it.active AND it.qbo_item_id IS NOT NULL
+ON CONFLICT (qbo_item_id) DO UPDATE
+  SET family_code = EXCLUDED.family_code,
+      set_by      = EXCLUDED.set_by,
+      set_at      = now()
+  WHERE ops.item_product_families.set_by LIKE 'auto-match%' OR ops.item_product_families.set_by IS NULL;
+
+-- ── 7. Auto-match: PRODUCT TYPE ───────────────────────────────────────────
+-- For beverage SKUs (BIB/Can), classify by flavor keyword. For everything
+-- else assign a structural type (hardware/labor/consumable/na).
+INSERT INTO ops.item_product_types (qbo_item_id, type_code, set_by)
+SELECT it.qbo_item_id,
+       CASE
+         -- Equipment / parts / scrap / reman → hardware
+         WHEN it.category_path = 'The Melt Equipment'                              THEN 'hardware'
+         WHEN it.income_account_name IN ('Equipment Sales','Equipment Remanufacturing','Scrap Income','Equipment Rental Income','Tank Rental Income','Sublet Rental Income') THEN 'hardware'
+         -- Service / labor
+         WHEN it.income_account_name IN ('Service Income','PM and Contract Service Income','Freshpet Service Income') THEN 'labor'
+         -- Gas
+         WHEN it.income_account_name IN ('100% CO2','Mixed Gas and Nitro','Hazmat Del Fees','Gas COGS') THEN 'consumable'
+         -- Beverages — flavor keyword match
+         WHEN it.name ~* '\m(JUICE|APPLE|CRANBERRY|FRUIT PUNCH|PINEAPPLE|SWEET *& *SOUR|PEACH|OJ|ORANGE JUICE)\M' THEN 'juice'
+         WHEN it.name ~* '\mLEMONADE\M'                                            THEN 'lemonade'
+         WHEN it.name ~* '\mTEA\M'                                                 THEN 'tea'
+         WHEN it.name ~* '\mENERGY\M'                                              THEN 'energy'
+         WHEN it.name ~* '\m(TONIC|MIXER|CLUB SODA)\M'                             THEN 'mixer'
+         WHEN it.name ~* '\m(COFFEE)\M'                                            THEN 'coffee'
+         WHEN it.name ~* '\m(WATER|H2O)\M' AND it.name !~* 'CARBONATED'            THEN 'water'
+         WHEN it.name ~* '\m(COLA|ROOT *BEER|GINGER *ALE|LEMON.LIME|ORANGE|CREME|CRÈME|CHERRY|GRAPEFRUIT|GINGER *BEER|DOCTEUR *POIVRE|DR *POIVRE|DR *PEPPER|SODA|CSD)\M' THEN 'csd'
+         -- BIB/Can without keyword match → default CSD (most likely)
+         WHEN it.income_account_name IN ('BIB Income','3 Gallon','5 Gallon','Packaged Beverage Income','Shopify Sales')
+              OR it.name ~* '^([1-9]GSF|[1-9]GNS|[1-9]G|24P|12P|12OZ|16OZ)'        THEN 'csd'
+         ELSE 'na'
+       END,
+       'auto-match v0.9.33'
+FROM ops.qbo_items it
+WHERE it.active AND it.qbo_item_id IS NOT NULL
+ON CONFLICT (qbo_item_id) DO UPDATE
+  SET type_code = EXCLUDED.type_code,
+      set_by    = EXCLUDED.set_by,
+      set_at    = now()
+  WHERE ops.item_product_types.set_by LIKE 'auto-match%' OR ops.item_product_types.set_by IS NULL;
+
+-- ── 8. Expose product_family + product_type in v_sales_lines (append cols) ─
+-- CREATE OR REPLACE VIEW requires the existing columns to be preserved in the
+-- same order; we append product_family + product_type at the end.
+CREATE OR REPLACE VIEW ops.v_sales_lines AS
+WITH effective AS (
+  SELECT l.id, l.invoice_id, l.item_ref_id, l.item_name, l.revenue_line,
+         l.account_name, l.description, l.quantity, l.unit_price, l.amount,
+         l.department,
+         it.purchase_cost                            AS static_unit_cost,
+         ac.avg_unit_cost                            AS actual_unit_cost,
+         COALESCE(ac.avg_unit_cost, it.purchase_cost) AS effective_unit_cost,
+         CASE
+           WHEN ac.avg_unit_cost  IS NOT NULL THEN 'actual'
+           WHEN it.purchase_cost  IS NOT NULL THEN 'static'
+           ELSE 'none'
+         END                                          AS cost_source,
+         it.type                                      AS item_type,
+         it.income_account_name,
+         it.expense_account_name
+  FROM ops.qbo_invoice_lines l
+    LEFT JOIN ops.qbo_items           it ON it.qbo_item_id  = l.item_ref_id
+    LEFT JOIN ops.v_item_actual_cost  ac ON ac.item_ref_id  = l.item_ref_id
+)
+SELECT e.id                                           AS line_id,
+       e.invoice_id,
+       i.qbo_invoice_id,
+       i.doc_number,
+       i.txn_date,
+       date_trunc('month', i.txn_date::timestamptz)::date AS txn_month,
+       EXTRACT(year FROM i.txn_date)::integer            AS txn_year,
+       i.customer_ref_id,
+       i.customer_name,
+       i.entity,
+       i.department                                   AS invoice_department,
+       e.department                                   AS line_department,
+       e.item_ref_id,
+       e.item_name,
+       e.revenue_line                                 AS category,
+       COALESCE(s_item.label, s_cat.label)            AS segment,
+       e.account_name,
+       e.description,
+       e.quantity,
+       e.unit_price,
+       e.amount                                       AS revenue,
+       e.static_unit_cost                             AS purchase_cost,
+       e.actual_unit_cost,
+       e.effective_unit_cost,
+       e.cost_source,
+       e.item_type,
+       e.income_account_name,
+       e.expense_account_name,
+       CASE
+         WHEN e.effective_unit_cost IS NOT NULL AND e.quantity IS NOT NULL
+         THEN e.effective_unit_cost * e.quantity
+       END                                            AS est_cost,
+       CASE
+         WHEN e.effective_unit_cost IS NOT NULL AND e.quantity IS NOT NULL
+         THEN e.amount - e.effective_unit_cost * e.quantity
+       END                                            AS est_margin,
+       COALESCE(lc.channels, ARRAY[]::text[])         AS channels,
+       lc.primary_channel,
+       pf.label                                       AS product_family,
+       pt.label                                       AS product_type
+FROM effective e
+  JOIN      ops.qbo_invoices    i      ON i.id              = e.invoice_id
+  LEFT JOIN ops.item_segments   is_map ON is_map.item_name  = e.item_name
+  LEFT JOIN ops.segments        s_item ON s_item.segment_code = is_map.segment_code AND s_item.is_active
+  LEFT JOIN ops.category_segments cs   ON cs.category       = e.revenue_line
+  LEFT JOIN ops.segments        s_cat  ON s_cat.segment_code = cs.segment_code AND s_cat.is_active
+  LEFT JOIN ops.item_product_families ipf ON ipf.qbo_item_id = e.item_ref_id
+  LEFT JOIN ops.product_families       pf  ON pf.family_code  = ipf.family_code AND pf.is_active
+  LEFT JOIN ops.item_product_types    ipt ON ipt.qbo_item_id = e.item_ref_id
+  LEFT JOIN ops.product_types         pt  ON pt.type_code     = ipt.type_code  AND pt.is_active
+  LEFT JOIN LATERAL (
+    SELECT array_agg(c.label ORDER BY c.sort_order)        AS channels,
+           max(c.label) FILTER (WHERE cc.is_primary)       AS primary_channel
+    FROM ops.customer_channels cc
+      JOIN ops.channels c ON c.channel_code = cc.channel_code
+    WHERE cc.qbo_customer_id = i.customer_ref_id
+      AND c.is_active
+  ) lc ON true;
+
+GRANT SELECT ON ops.v_sales_lines TO anon, authenticated;

--- a/supabase/migrations/20260512e_add_pm_product_family.sql
+++ b/supabase/migrations/20260512e_add_pm_product_family.sql
@@ -1,0 +1,28 @@
+-- v0.9.33b — Add Preventative Maintenance product family.
+--
+-- PM has different margin economics (contract-based, scheduled, predictable
+-- revenue) than ad-hoc service labor, so it gets its own product family for
+-- margin reporting.
+--
+-- Auto-match is name-driven only (explicit "PM" in item name). The income
+-- account 'PM and Contract Service Income' lumps PM with general contract
+-- service work (SVC-CALL, SV-REPAIR01, PROJ-MAN, etc.), so income-account
+-- alone isn't a reliable signal.
+
+INSERT INTO ops.product_families (family_code, label, sort_order, is_active) VALUES
+  ('pm', 'Preventative Maintenance', 65, true)
+ON CONFLICT (family_code) DO UPDATE
+  SET label = EXCLUDED.label, sort_order = EXCLUDED.sort_order;
+
+-- Re-classify auto-tagged items whose name explicitly contains "PM" or
+-- "PREVENTATIVE MAINTENANCE". Manual edits (set_by NOT LIKE 'auto-match%')
+-- are preserved.
+UPDATE ops.item_product_families ipf
+   SET family_code = 'pm',
+       set_by      = 'auto-match v0.9.33 (pm)',
+       set_at      = now()
+  FROM ops.qbo_items it
+ WHERE it.qbo_item_id = ipf.qbo_item_id
+   AND it.name ~* '\m(PM|PREVENTATIVE *MAINTENANCE)\M'
+   AND ipf.family_code IN ('service','other')
+   AND (ipf.set_by LIKE 'auto-match%' OR ipf.set_by IS NULL);

--- a/supabase/migrations/20260512f_items_master_with_family_type.sql
+++ b/supabase/migrations/20260512f_items_master_with_family_type.sql
@@ -1,0 +1,239 @@
+-- v0.9.33c — Surface product_family + product_type in fn_items_master,
+-- plus per-item setter RPCs and list helpers for dropdowns.
+
+-- 1. List helpers ----------------------------------------------------------
+CREATE OR REPLACE FUNCTION ops.fn_list_product_families()
+RETURNS TABLE(family_code text, label text, sort_order int)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $$
+  SELECT family_code, label, sort_order
+    FROM ops.product_families
+   WHERE is_active
+   ORDER BY sort_order, label;
+$$;
+GRANT EXECUTE ON FUNCTION ops.fn_list_product_families() TO anon, authenticated;
+
+CREATE OR REPLACE FUNCTION ops.fn_list_product_types()
+RETURNS TABLE(type_code text, label text, sort_order int)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $$
+  SELECT type_code, label, sort_order
+    FROM ops.product_types
+   WHERE is_active
+   ORDER BY sort_order, label;
+$$;
+GRANT EXECUTE ON FUNCTION ops.fn_list_product_types() TO anon, authenticated;
+
+-- 2. Per-item setters ------------------------------------------------------
+CREATE OR REPLACE FUNCTION ops.fn_set_item_product_family(
+  p_qbo_item_id text,
+  p_family_code text,
+  p_set_by      text DEFAULT 'dashboard'
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ops, public
+AS $$
+BEGIN
+  IF p_qbo_item_id IS NULL THEN RAISE EXCEPTION 'qbo_item_id required'; END IF;
+  IF p_family_code IS NULL OR p_family_code = '' THEN
+    DELETE FROM ops.item_product_families WHERE qbo_item_id = p_qbo_item_id;
+    RETURN;
+  END IF;
+  INSERT INTO ops.item_product_families AS t (qbo_item_id, family_code, set_by, set_at)
+  VALUES (p_qbo_item_id, p_family_code, p_set_by, now())
+  ON CONFLICT (qbo_item_id) DO UPDATE
+    SET family_code = EXCLUDED.family_code,
+        set_by      = EXCLUDED.set_by,
+        set_at      = now();
+END;
+$$;
+GRANT EXECUTE ON FUNCTION ops.fn_set_item_product_family(text, text, text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION ops.fn_set_item_product_type(
+  p_qbo_item_id text,
+  p_type_code   text,
+  p_set_by      text DEFAULT 'dashboard'
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ops, public
+AS $$
+BEGIN
+  IF p_qbo_item_id IS NULL THEN RAISE EXCEPTION 'qbo_item_id required'; END IF;
+  IF p_type_code IS NULL OR p_type_code = '' THEN
+    DELETE FROM ops.item_product_types WHERE qbo_item_id = p_qbo_item_id;
+    RETURN;
+  END IF;
+  INSERT INTO ops.item_product_types AS t (qbo_item_id, type_code, set_by, set_at)
+  VALUES (p_qbo_item_id, p_type_code, p_set_by, now())
+  ON CONFLICT (qbo_item_id) DO UPDATE
+    SET type_code = EXCLUDED.type_code,
+        set_by    = EXCLUDED.set_by,
+        set_at    = now();
+END;
+$$;
+GRANT EXECUTE ON FUNCTION ops.fn_set_item_product_type(text, text, text) TO authenticated;
+
+-- 3. Bulk setters (for "apply to all filtered/selected" UX) ---------------
+CREATE OR REPLACE FUNCTION ops.fn_bulk_set_item_product_family(
+  p_qbo_item_ids text[],
+  p_family_code  text,
+  p_set_by       text DEFAULT 'dashboard-bulk'
+) RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ops, public
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  IF p_qbo_item_ids IS NULL OR cardinality(p_qbo_item_ids) = 0 THEN RETURN 0; END IF;
+  IF p_family_code IS NULL OR p_family_code = '' THEN
+    DELETE FROM ops.item_product_families WHERE qbo_item_id = ANY(p_qbo_item_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count;
+  END IF;
+  INSERT INTO ops.item_product_families AS t (qbo_item_id, family_code, set_by, set_at)
+  SELECT unnest(p_qbo_item_ids), p_family_code, p_set_by, now()
+  ON CONFLICT (qbo_item_id) DO UPDATE
+    SET family_code = EXCLUDED.family_code,
+        set_by      = EXCLUDED.set_by,
+        set_at      = now();
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION ops.fn_bulk_set_item_product_family(text[], text, text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION ops.fn_bulk_set_item_product_type(
+  p_qbo_item_ids text[],
+  p_type_code    text,
+  p_set_by       text DEFAULT 'dashboard-bulk'
+) RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ops, public
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  IF p_qbo_item_ids IS NULL OR cardinality(p_qbo_item_ids) = 0 THEN RETURN 0; END IF;
+  IF p_type_code IS NULL OR p_type_code = '' THEN
+    DELETE FROM ops.item_product_types WHERE qbo_item_id = ANY(p_qbo_item_ids);
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count;
+  END IF;
+  INSERT INTO ops.item_product_types AS t (qbo_item_id, type_code, set_by, set_at)
+  SELECT unnest(p_qbo_item_ids), p_type_code, p_set_by, now()
+  ON CONFLICT (qbo_item_id) DO UPDATE
+    SET type_code = EXCLUDED.type_code,
+        set_by    = EXCLUDED.set_by,
+        set_at    = now();
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION ops.fn_bulk_set_item_product_type(text[], text, text) TO authenticated;
+
+-- 4. fn_items_master — append product_family/product_type cols -------------
+-- DROP + recreate (RETURNS TABLE shape change requires it).
+DROP FUNCTION IF EXISTS ops.fn_items_master(integer, text, boolean);
+
+CREATE FUNCTION ops.fn_items_master(
+  p_lookback_days integer DEFAULT 90,
+  p_search        text    DEFAULT NULL,
+  p_managed_only  boolean DEFAULT false
+)
+RETURNS TABLE(
+  qbo_item_id text, item_name text, fully_qualified_name text, active boolean,
+  category_path text, category_override text, category_resolved text,
+  income_account_name text, expense_account_name text,
+  on_hand numeric, unit_price numeric, purchase_cost numeric,
+  is_managed boolean, is_planner boolean,
+  target_days_supply integer, lead_time_days integer,
+  reorder_point numeric, min_order_qty numeric, notes text,
+  sold_qty numeric, sold_revenue numeric, customers_count integer,
+  daily_velocity numeric, days_of_supply numeric, status text,
+  product_family_code text, product_family_label text,
+  product_type_code   text, product_type_label   text
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  WITH start_date AS (SELECT (current_date - p_lookback_days)::date AS d),
+  excludes AS (SELECT qbo_customer_id FROM ops.inventory_velocity_excludes),
+  sold AS (
+    SELECT v.item_ref_id AS qbo_item_id,
+      sum(v.quantity)::numeric AS qty,
+      sum(v.revenue)::numeric AS revenue,
+      count(DISTINCT v.customer_ref_id)::int AS customers_count
+    FROM ops.v_sales_lines v
+    LEFT JOIN excludes e ON e.qbo_customer_id = v.customer_ref_id
+    WHERE v.txn_date >= (SELECT d FROM start_date)
+      AND e.qbo_customer_id IS NULL
+      AND v.item_ref_id IS NOT NULL
+      AND v.quantity IS NOT NULL AND v.quantity > 0
+    GROUP BY 1
+  ),
+  adj AS (
+    SELECT a.item_ref_id AS qbo_item_id,
+      sum(CASE WHEN a.qty_diff < 0 THEN ABS(a.qty_diff) ELSE 0 END)::numeric AS shrink_qty
+    FROM ops.qbo_inventory_adjustment_lines a
+    WHERE a.item_ref_id IS NOT NULL
+      AND a.txn_date >= (SELECT d FROM start_date)
+    GROUP BY 1
+  )
+  SELECT
+    it.qbo_item_id,
+    COALESCE(it.name, it.fully_qualified_name),
+    it.fully_qualified_name,
+    COALESCE(it.active, true)::boolean,
+    it.category_path,
+    s.category_override,
+    COALESCE(s.category_override, it.category_path, 'Uncategorized'),
+    it.income_account_name,
+    it.expense_account_name,
+    COALESCE(it.qty_on_hand, 0)::numeric,
+    it.unit_price,
+    it.purchase_cost,
+    COALESCE(s.is_managed, false),
+    COALESCE(s.is_planner, false),
+    COALESCE(s.target_days_supply, 30),
+    COALESCE(s.lead_time_days, 7),
+    s.reorder_point,
+    s.min_order_qty,
+    s.notes,
+    COALESCE(sold.qty, 0),
+    COALESCE(sold.revenue, 0),
+    COALESCE(sold.customers_count, 0),
+    ((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1))::numeric,
+    CASE WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) > 0
+         THEN COALESCE(it.qty_on_hand, 0) / ((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1))
+         ELSE NULL END,
+    CASE
+      WHEN COALESCE(it.active, true) = false THEN 'inactive'
+      WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) = 0 AND COALESCE(it.qty_on_hand, 0) > 0 THEN 'idle'
+      WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) = 0 AND COALESCE(it.qty_on_hand, 0) = 0 THEN 'idle'
+      WHEN COALESCE(it.qty_on_hand, 0) <= 0 THEN 'critical'
+      WHEN COALESCE(it.qty_on_hand, 0) <
+           COALESCE(s.lead_time_days, 7) * (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1) THEN 'reorder'
+      ELSE 'ok'
+    END,
+    ipf.family_code,
+    pf.label,
+    ipt.type_code,
+    pt.label
+  FROM ops.qbo_items it
+  LEFT JOIN ops.inventory_settings s ON s.qbo_item_id = it.qbo_item_id
+  LEFT JOIN sold ON sold.qbo_item_id = it.qbo_item_id
+  LEFT JOIN adj  ON adj.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.item_product_families ipf ON ipf.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.product_families pf       ON pf.family_code  = ipf.family_code AND pf.is_active
+  LEFT JOIN ops.item_product_types    ipt ON ipt.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.product_types         pt  ON pt.type_code    = ipt.type_code  AND pt.is_active
+  WHERE
+    (NOT p_managed_only OR COALESCE(s.is_managed, false))
+    AND (
+      p_search IS NULL OR p_search = '' OR
+      it.name ILIKE '%' || p_search || '%' OR
+      it.fully_qualified_name ILIKE '%' || p_search || '%' OR
+      COALESCE(s.category_override, it.category_path) ILIKE '%' || p_search || '%'
+    )
+  ORDER BY
+    COALESCE(it.active, true) DESC,
+    COALESCE(s.category_override, it.category_path) NULLS LAST,
+    it.name;
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_items_master(integer, text, boolean) TO authenticated;

--- a/supabase/migrations/20260512g_sales_rpcs_family_type.sql
+++ b/supabase/migrations/20260512g_sales_rpcs_family_type.sql
@@ -1,0 +1,317 @@
+-- v0.9.34 — Wire product_family / product_type into the Margin RPCs as
+-- (a) two new filter array params on each function and (b) two new dim
+-- options ('product_family', 'product_type') for pivot / sparkline /
+-- dim-values / drill.
+--
+-- The new params get NULL defaults so existing callers keep working;
+-- when supplied, they filter against v_sales_lines.product_family /
+-- product_type (already exposed by v0.9.33).
+
+-- ── fn_sales_pivot ────────────────────────────────────────────────────────
+DROP FUNCTION IF EXISTS ops.fn_sales_pivot(text, date, date, text[], text[], text[], text[], text[], text[], int);
+
+CREATE OR REPLACE FUNCTION ops.fn_sales_pivot(
+  p_dim              text   DEFAULT 'item',
+  p_start            date   DEFAULT '2025-01-01',
+  p_end              date   DEFAULT current_date,
+  p_entities         text[] DEFAULT NULL,
+  p_categories       text[] DEFAULT NULL,
+  p_customers        text[] DEFAULT NULL,
+  p_items            text[] DEFAULT NULL,
+  p_channels         text[] DEFAULT NULL,
+  p_segments         text[] DEFAULT NULL,
+  p_product_families text[] DEFAULT NULL,
+  p_product_types    text[] DEFAULT NULL,
+  p_limit            int    DEFAULT 250
+) RETURNS TABLE(
+  dim_label text, line_count bigint, qty numeric, revenue numeric,
+  est_cost numeric, est_margin numeric, margin_pct numeric, avg_price numeric,
+  effective_segment text
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  WITH base AS (
+    SELECT * FROM ops.v_sales_lines
+    WHERE txn_date >= p_start AND txn_date <= p_end
+      AND (p_entities         IS NULL OR cardinality(p_entities)         = 0 OR entity         = ANY(p_entities))
+      AND (p_categories       IS NULL OR cardinality(p_categories)       = 0 OR category       = ANY(p_categories))
+      AND (p_customers        IS NULL OR cardinality(p_customers)        = 0 OR customer_name  = ANY(p_customers))
+      AND (p_items            IS NULL OR cardinality(p_items)            = 0 OR item_name      = ANY(p_items))
+      AND (p_channels         IS NULL OR cardinality(p_channels)         = 0 OR channels && p_channels)
+      AND (p_segments         IS NULL OR cardinality(p_segments)         = 0 OR segment        = ANY(p_segments))
+      AND (p_product_families IS NULL OR cardinality(p_product_families) = 0 OR product_family = ANY(p_product_families))
+      AND (p_product_types    IS NULL OR cardinality(p_product_types)    = 0 OR product_type   = ANY(p_product_types))
+  ),
+  expanded AS (
+    SELECT b.*, ch.code AS dim_channel FROM base b
+    LEFT JOIN LATERAL (
+      SELECT u AS code FROM unnest(b.channels) AS u
+      WHERE p_dim = 'channel' AND cardinality(b.channels) > 0
+      UNION ALL
+      SELECT '(unassigned)'::text WHERE p_dim = 'channel' AND cardinality(b.channels) = 0
+    ) ch ON TRUE
+  )
+  SELECT
+    COALESCE(CASE p_dim
+      WHEN 'item'           THEN item_name
+      WHEN 'customer'       THEN customer_name
+      WHEN 'category'       THEN category
+      WHEN 'segment'        THEN segment
+      WHEN 'entity'         THEN entity
+      WHEN 'month'          THEN to_char(txn_month, 'YYYY-MM')
+      WHEN 'channel'        THEN dim_channel
+      WHEN 'account'        THEN account_name
+      WHEN 'product_family' THEN product_family
+      WHEN 'product_type'   THEN product_type
+      ELSE item_name
+    END, '(unspecified)')::text AS dim_label,
+    count(*)::bigint           AS line_count,
+    sum(quantity)::numeric     AS qty,
+    sum(revenue)::numeric      AS revenue,
+    sum(est_cost)::numeric     AS est_cost,
+    sum(est_margin)::numeric   AS est_margin,
+    CASE WHEN sum(revenue) > 0 AND sum(est_cost) IS NOT NULL THEN (sum(revenue) - sum(est_cost)) / sum(revenue) ELSE NULL END::numeric AS margin_pct,
+    CASE WHEN sum(quantity) > 0 THEN sum(revenue) / sum(quantity) ELSE NULL END::numeric AS avg_price,
+    (mode() WITHIN GROUP (ORDER BY segment))::text AS effective_segment
+  FROM expanded GROUP BY 1
+  ORDER BY 4 DESC NULLS LAST
+  LIMIT GREATEST(COALESCE(p_limit, 250), 1);
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_sales_pivot(text, date, date, text[], text[], text[], text[], text[], text[], text[], text[], int) TO anon, authenticated;
+
+-- ── fn_sales_totals ──────────────────────────────────────────────────────
+DROP FUNCTION IF EXISTS ops.fn_sales_totals(date, date, text[], text[], text[], text[], text[], text[]);
+
+CREATE OR REPLACE FUNCTION ops.fn_sales_totals(
+  p_start            date   DEFAULT '2025-01-01',
+  p_end              date   DEFAULT current_date,
+  p_entities         text[] DEFAULT NULL,
+  p_categories       text[] DEFAULT NULL,
+  p_customers        text[] DEFAULT NULL,
+  p_items            text[] DEFAULT NULL,
+  p_channels         text[] DEFAULT NULL,
+  p_segments         text[] DEFAULT NULL,
+  p_product_families text[] DEFAULT NULL,
+  p_product_types    text[] DEFAULT NULL
+) RETURNS TABLE(
+  line_count bigint, invoice_count bigint, customer_count bigint, item_count bigint,
+  qty numeric, revenue numeric, est_cost numeric, est_margin numeric,
+  margin_pct numeric, cost_coverage_pct numeric
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  WITH base AS (
+    SELECT * FROM ops.v_sales_lines
+    WHERE txn_date >= p_start AND txn_date <= p_end
+      AND (p_entities         IS NULL OR cardinality(p_entities)         = 0 OR entity         = ANY(p_entities))
+      AND (p_categories       IS NULL OR cardinality(p_categories)       = 0 OR category       = ANY(p_categories))
+      AND (p_customers        IS NULL OR cardinality(p_customers)        = 0 OR customer_name  = ANY(p_customers))
+      AND (p_items            IS NULL OR cardinality(p_items)            = 0 OR item_name      = ANY(p_items))
+      AND (p_channels         IS NULL OR cardinality(p_channels)         = 0 OR channels && p_channels)
+      AND (p_segments         IS NULL OR cardinality(p_segments)         = 0 OR segment        = ANY(p_segments))
+      AND (p_product_families IS NULL OR cardinality(p_product_families) = 0 OR product_family = ANY(p_product_families))
+      AND (p_product_types    IS NULL OR cardinality(p_product_types)    = 0 OR product_type   = ANY(p_product_types))
+  )
+  SELECT count(*)::bigint, count(DISTINCT invoice_id)::bigint,
+    count(DISTINCT customer_name)::bigint, count(DISTINCT item_name)::bigint,
+    sum(quantity)::numeric, sum(revenue)::numeric, sum(est_cost)::numeric, sum(est_margin)::numeric,
+    CASE WHEN sum(revenue) > 0 AND sum(est_cost) IS NOT NULL THEN (sum(revenue) - sum(est_cost)) / sum(revenue) ELSE NULL END,
+    CASE WHEN sum(revenue) > 0 THEN sum(revenue) FILTER (WHERE effective_unit_cost IS NOT NULL) / sum(revenue) ELSE NULL END
+  FROM base;
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_sales_totals(date, date, text[], text[], text[], text[], text[], text[], text[], text[]) TO anon, authenticated;
+
+-- ── fn_sales_dim_values ──────────────────────────────────────────────────
+-- Add product_family + product_type as recognized dims; their distinct
+-- values come from the product_families / product_types taxonomy tables
+-- (in sort_order) PLUS any non-null values appearing in v_sales_lines.
+DROP FUNCTION IF EXISTS ops.fn_sales_dim_values(text, date, date, int);
+
+CREATE OR REPLACE FUNCTION ops.fn_sales_dim_values(
+  p_dim   text,
+  p_start date DEFAULT '2025-01-01',
+  p_end   date DEFAULT current_date,
+  p_limit int  DEFAULT 2000
+) RETURNS TABLE(label text, revenue numeric)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  WITH ch AS (
+    SELECT label::text AS label, NULL::numeric AS revenue, sort_order::numeric AS sort
+    FROM ops.channels WHERE p_dim = 'channel' AND is_active
+  ),
+  seg AS (
+    SELECT label::text AS label, NULL::numeric AS revenue, sort_order::numeric AS sort
+    FROM ops.segments WHERE p_dim = 'segment' AND is_active
+  ),
+  fam AS (
+    SELECT label::text AS label, NULL::numeric AS revenue, sort_order::numeric AS sort
+    FROM ops.product_families WHERE p_dim = 'product_family' AND is_active
+  ),
+  ptype AS (
+    SELECT label::text AS label, NULL::numeric AS revenue, sort_order::numeric AS sort
+    FROM ops.product_types   WHERE p_dim = 'product_type' AND is_active
+  ),
+  other AS (
+    SELECT
+      COALESCE(CASE p_dim
+        WHEN 'item'           THEN item_name
+        WHEN 'customer'       THEN customer_name
+        WHEN 'category'       THEN category
+        WHEN 'entity'         THEN entity
+        WHEN 'segment'        THEN segment
+        WHEN 'product_family' THEN product_family
+        WHEN 'product_type'   THEN product_type
+        WHEN 'account'        THEN account_name
+        WHEN 'month'          THEN to_char(txn_month, 'YYYY-MM')
+        ELSE NULL END, '(unspecified)')::text AS label,
+      sum(revenue)::numeric AS revenue,
+      NULL::numeric AS sort
+    FROM ops.v_sales_lines
+    WHERE p_dim NOT IN ('channel')
+      AND txn_date >= p_start AND txn_date <= p_end
+    GROUP BY 1
+  )
+  SELECT label, max(revenue) AS revenue
+  FROM (
+    SELECT * FROM ch
+    UNION ALL SELECT * FROM seg
+    UNION ALL SELECT * FROM fam
+    UNION ALL SELECT * FROM ptype
+    UNION ALL SELECT * FROM other
+  ) all_rows
+  GROUP BY label
+  ORDER BY min(sort) NULLS LAST, revenue DESC NULLS LAST
+  LIMIT GREATEST(COALESCE(p_limit, 2000), 1);
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_sales_dim_values(text, date, date, int) TO anon, authenticated;
+
+-- ── fn_sparkline ─────────────────────────────────────────────────────────
+DROP FUNCTION IF EXISTS ops.fn_sparkline(text, text[], date, text[], text[], text[], text[], text[], text[], text[]);
+
+CREATE OR REPLACE FUNCTION ops.fn_sparkline(
+  p_dim              text,
+  p_labels           text[],
+  p_end              date   DEFAULT current_date,
+  p_entities         text[] DEFAULT NULL,
+  p_categories       text[] DEFAULT NULL,
+  p_customers        text[] DEFAULT NULL,
+  p_items            text[] DEFAULT NULL,
+  p_channels         text[] DEFAULT NULL,
+  p_segments         text[] DEFAULT NULL,
+  p_sales_reps       text[] DEFAULT NULL,
+  p_product_families text[] DEFAULT NULL,
+  p_product_types    text[] DEFAULT NULL
+) RETURNS TABLE(dim_label text, ym text, revenue numeric)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  WITH range_start AS (SELECT (date_trunc('month', p_end) - interval '11 month')::date AS s),
+  base AS (
+    SELECT v.*, ch.code AS dim_channel
+    FROM ops.v_sales_lines v, range_start rs
+    LEFT JOIN LATERAL (
+      SELECT u AS code FROM unnest(v.channels) AS u
+      WHERE p_dim = 'channel' AND cardinality(v.channels) > 0
+      UNION ALL SELECT '(unassigned)'::text WHERE p_dim = 'channel' AND cardinality(v.channels) = 0
+    ) ch ON TRUE
+    WHERE v.txn_date >= rs.s AND v.txn_date <= p_end
+      AND (p_entities         IS NULL OR cardinality(p_entities)         = 0 OR v.entity         = ANY(p_entities))
+      AND (p_categories       IS NULL OR cardinality(p_categories)       = 0 OR v.category       = ANY(p_categories))
+      AND (p_customers        IS NULL OR cardinality(p_customers)        = 0 OR v.customer_name  = ANY(p_customers))
+      AND (p_items            IS NULL OR cardinality(p_items)            = 0 OR v.item_name      = ANY(p_items))
+      AND (p_channels         IS NULL OR cardinality(p_channels)         = 0 OR v.channels && p_channels)
+      AND (p_segments         IS NULL OR cardinality(p_segments)         = 0 OR v.segment        = ANY(p_segments))
+      AND (p_product_families IS NULL OR cardinality(p_product_families) = 0 OR v.product_family = ANY(p_product_families))
+      AND (p_product_types    IS NULL OR cardinality(p_product_types)    = 0 OR v.product_type   = ANY(p_product_types))
+  )
+  SELECT
+    COALESCE(CASE p_dim
+      WHEN 'item'           THEN item_name
+      WHEN 'customer'       THEN customer_name
+      WHEN 'category'       THEN category
+      WHEN 'segment'        THEN segment
+      WHEN 'entity'         THEN entity
+      WHEN 'month'          THEN to_char(txn_month, 'YYYY-MM')
+      WHEN 'channel'        THEN dim_channel
+      WHEN 'product_family' THEN product_family
+      WHEN 'product_type'   THEN product_type
+      ELSE item_name
+    END, '(unspecified)') AS dim_label,
+    to_char(txn_month, 'YYYY-MM') AS ym,
+    sum(revenue)::numeric AS revenue
+  FROM base
+  WHERE COALESCE(CASE p_dim
+      WHEN 'item'           THEN item_name
+      WHEN 'customer'       THEN customer_name
+      WHEN 'category'       THEN category
+      WHEN 'segment'        THEN segment
+      WHEN 'entity'         THEN entity
+      WHEN 'month'          THEN to_char(txn_month, 'YYYY-MM')
+      WHEN 'channel'        THEN dim_channel
+      WHEN 'product_family' THEN product_family
+      WHEN 'product_type'   THEN product_type
+      ELSE item_name
+    END, '(unspecified)') = ANY(p_labels)
+  GROUP BY 1, 2 ORDER BY 1, 2;
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_sparkline(text, text[], date, text[], text[], text[], text[], text[], text[], text[], text[], text[]) TO anon, authenticated;
+
+-- ── fn_pivot_drill ───────────────────────────────────────────────────────
+DROP FUNCTION IF EXISTS ops.fn_pivot_drill(text, text, date, date, text[], text[], text[], text[], text[], text[], text[], int);
+
+CREATE OR REPLACE FUNCTION ops.fn_pivot_drill(
+  p_dim              text,
+  p_dim_label        text,
+  p_start            date   DEFAULT '2025-01-01',
+  p_end              date   DEFAULT current_date,
+  p_entities         text[] DEFAULT NULL,
+  p_categories       text[] DEFAULT NULL,
+  p_customers        text[] DEFAULT NULL,
+  p_items            text[] DEFAULT NULL,
+  p_channels         text[] DEFAULT NULL,
+  p_segments         text[] DEFAULT NULL,
+  p_sales_reps       text[] DEFAULT NULL,
+  p_product_families text[] DEFAULT NULL,
+  p_product_types    text[] DEFAULT NULL,
+  p_limit            int    DEFAULT 200
+) RETURNS TABLE(
+  txn_date date, doc_number text, qbo_invoice_id text, customer_name text,
+  item_name text, category text, segment text, description text,
+  quantity numeric, unit_price numeric, revenue numeric, est_cost numeric, est_margin numeric
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  SELECT v.txn_date, v.doc_number, v.qbo_invoice_id, v.customer_name,
+    v.item_name, v.category, v.segment, v.description,
+    v.quantity, v.unit_price, v.revenue, v.est_cost, v.est_margin
+  FROM ops.v_sales_lines v
+  WHERE v.txn_date >= p_start AND v.txn_date <= p_end
+    AND (p_entities         IS NULL OR cardinality(p_entities)         = 0 OR v.entity         = ANY(p_entities))
+    AND (p_categories       IS NULL OR cardinality(p_categories)       = 0 OR v.category       = ANY(p_categories))
+    AND (p_customers        IS NULL OR cardinality(p_customers)        = 0 OR v.customer_name  = ANY(p_customers))
+    AND (p_items            IS NULL OR cardinality(p_items)            = 0 OR v.item_name      = ANY(p_items))
+    AND (p_channels         IS NULL OR cardinality(p_channels)         = 0 OR v.channels && p_channels)
+    AND (p_segments         IS NULL OR cardinality(p_segments)         = 0 OR v.segment        = ANY(p_segments))
+    AND (p_sales_reps       IS NULL OR cardinality(p_sales_reps)       = 0 OR v.sales_reps && p_sales_reps)
+    AND (p_product_families IS NULL OR cardinality(p_product_families) = 0 OR v.product_family = ANY(p_product_families))
+    AND (p_product_types    IS NULL OR cardinality(p_product_types)    = 0 OR v.product_type   = ANY(p_product_types))
+    AND (
+      p_dim IS NULL OR p_dim_label IS NULL OR p_dim_label = '(unspecified)'
+      OR (p_dim = 'item'           AND v.item_name      = p_dim_label)
+      OR (p_dim = 'customer'       AND v.customer_name  = p_dim_label)
+      OR (p_dim = 'category'       AND v.category       = p_dim_label)
+      OR (p_dim = 'segment'        AND v.segment        = p_dim_label)
+      OR (p_dim = 'entity'         AND v.entity         = p_dim_label)
+      OR (p_dim = 'month'          AND to_char(v.txn_month, 'YYYY-MM') = p_dim_label)
+      OR (p_dim = 'product_family' AND v.product_family = p_dim_label)
+      OR (p_dim = 'product_type'   AND v.product_type   = p_dim_label)
+      OR (p_dim = 'channel'   AND (
+            p_dim_label = '(unassigned)' AND cardinality(v.channels) = 0
+            OR p_dim_label = ANY(v.channels)))
+      OR (p_dim = 'sales_rep' AND (
+            p_dim_label = '(unassigned)' AND cardinality(v.sales_reps) = 0
+            OR p_dim_label = ANY(v.sales_reps)))
+    )
+  ORDER BY v.revenue DESC NULLS LAST, v.txn_date DESC
+  LIMIT GREATEST(COALESCE(p_limit, 200), 1);
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_pivot_drill(text, text, date, date, text[], text[], text[], text[], text[], text[], text[], text[], text[], int) TO anon, authenticated;

--- a/supabase/migrations/20260512h_items_master_segment.sql
+++ b/supabase/migrations/20260512h_items_master_segment.sql
@@ -1,0 +1,209 @@
+-- v0.9.34a — Surface segment on the Items master grid + add setter RPCs.
+-- Segment was auto-populated for 567/574 items in 20260512d but had no
+-- editor. fn_items_master now returns segment_code + segment_label, and
+-- two new RPCs let the dashboard write/bulk-write segment via the
+-- existing ops.item_segments table (which keys by item_name).
+
+-- 1. Segment list for dropdown ---------------------------------------------
+CREATE OR REPLACE FUNCTION ops.fn_list_segments_for_items()
+RETURNS TABLE(segment_code text, label text, sort_order int)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $$
+  SELECT segment_code, label, sort_order
+    FROM ops.segments
+   WHERE is_active
+   ORDER BY sort_order, label;
+$$;
+GRANT EXECUTE ON FUNCTION ops.fn_list_segments_for_items() TO anon, authenticated;
+
+-- 2. Per-item segment setter -----------------------------------------------
+-- ops.item_segments is keyed by item_name (legacy), so we look the name
+-- up from qbo_item_id. Passing NULL/'' clears the override (item falls
+-- back to category_segments).
+CREATE OR REPLACE FUNCTION ops.fn_set_item_segment(
+  p_qbo_item_id text,
+  p_segment_code text,
+  p_set_by      text DEFAULT 'dashboard'
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ops, public
+AS $$
+DECLARE
+  v_name text;
+BEGIN
+  IF p_qbo_item_id IS NULL THEN RAISE EXCEPTION 'qbo_item_id required'; END IF;
+  SELECT name INTO v_name FROM ops.qbo_items WHERE qbo_item_id = p_qbo_item_id;
+  IF v_name IS NULL THEN RAISE EXCEPTION 'item not found'; END IF;
+
+  IF p_segment_code IS NULL OR p_segment_code = '' THEN
+    DELETE FROM ops.item_segments WHERE item_name = v_name;
+    RETURN;
+  END IF;
+
+  INSERT INTO ops.item_segments AS t (item_name, segment_code, set_by, set_at)
+  VALUES (v_name, p_segment_code, p_set_by, now())
+  ON CONFLICT (item_name) DO UPDATE
+    SET segment_code = EXCLUDED.segment_code,
+        set_by       = EXCLUDED.set_by,
+        set_at       = now();
+END;
+$$;
+GRANT EXECUTE ON FUNCTION ops.fn_set_item_segment(text, text, text) TO authenticated;
+
+-- 3. Bulk segment setter ---------------------------------------------------
+CREATE OR REPLACE FUNCTION ops.fn_bulk_set_item_segment(
+  p_qbo_item_ids text[],
+  p_segment_code text,
+  p_set_by       text DEFAULT 'dashboard-bulk'
+) RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ops, public
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  IF p_qbo_item_ids IS NULL OR cardinality(p_qbo_item_ids) = 0 THEN RETURN 0; END IF;
+
+  IF p_segment_code IS NULL OR p_segment_code = '' THEN
+    DELETE FROM ops.item_segments
+     WHERE item_name IN (
+       SELECT name FROM ops.qbo_items WHERE qbo_item_id = ANY(p_qbo_item_ids)
+     );
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count;
+  END IF;
+
+  INSERT INTO ops.item_segments AS t (item_name, segment_code, set_by, set_at)
+  SELECT it.name, p_segment_code, p_set_by, now()
+    FROM ops.qbo_items it
+   WHERE it.qbo_item_id = ANY(p_qbo_item_ids) AND it.name IS NOT NULL
+  ON CONFLICT (item_name) DO UPDATE
+    SET segment_code = EXCLUDED.segment_code,
+        set_by       = EXCLUDED.set_by,
+        set_at       = now();
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION ops.fn_bulk_set_item_segment(text[], text, text) TO authenticated;
+
+-- 4. fn_items_master — append segment_code + segment_label ----------------
+-- Effective segment = item override (item_segments) if set, else
+-- category fallback (category_segments).
+DROP FUNCTION IF EXISTS ops.fn_items_master(integer, text, boolean);
+
+CREATE FUNCTION ops.fn_items_master(
+  p_lookback_days integer DEFAULT 90,
+  p_search        text    DEFAULT NULL,
+  p_managed_only  boolean DEFAULT false
+)
+RETURNS TABLE(
+  qbo_item_id text, item_name text, fully_qualified_name text, active boolean,
+  category_path text, category_override text, category_resolved text,
+  income_account_name text, expense_account_name text,
+  on_hand numeric, unit_price numeric, purchase_cost numeric,
+  is_managed boolean, is_planner boolean,
+  target_days_supply integer, lead_time_days integer,
+  reorder_point numeric, min_order_qty numeric, notes text,
+  sold_qty numeric, sold_revenue numeric, customers_count integer,
+  daily_velocity numeric, days_of_supply numeric, status text,
+  product_family_code text, product_family_label text,
+  product_type_code   text, product_type_label   text,
+  segment_code text, segment_label text, segment_source text
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  WITH start_date AS (SELECT (current_date - p_lookback_days)::date AS d),
+  excludes AS (SELECT qbo_customer_id FROM ops.inventory_velocity_excludes),
+  sold AS (
+    SELECT v.item_ref_id AS qbo_item_id,
+      sum(v.quantity)::numeric AS qty,
+      sum(v.revenue)::numeric AS revenue,
+      count(DISTINCT v.customer_ref_id)::int AS customers_count
+    FROM ops.v_sales_lines v
+    LEFT JOIN excludes e ON e.qbo_customer_id = v.customer_ref_id
+    WHERE v.txn_date >= (SELECT d FROM start_date)
+      AND e.qbo_customer_id IS NULL
+      AND v.item_ref_id IS NOT NULL
+      AND v.quantity IS NOT NULL AND v.quantity > 0
+    GROUP BY 1
+  ),
+  adj AS (
+    SELECT a.item_ref_id AS qbo_item_id,
+      sum(CASE WHEN a.qty_diff < 0 THEN ABS(a.qty_diff) ELSE 0 END)::numeric AS shrink_qty
+    FROM ops.qbo_inventory_adjustment_lines a
+    WHERE a.item_ref_id IS NOT NULL
+      AND a.txn_date >= (SELECT d FROM start_date)
+    GROUP BY 1
+  )
+  SELECT
+    it.qbo_item_id,
+    COALESCE(it.name, it.fully_qualified_name),
+    it.fully_qualified_name,
+    COALESCE(it.active, true)::boolean,
+    it.category_path,
+    s.category_override,
+    COALESCE(s.category_override, it.category_path, 'Uncategorized'),
+    it.income_account_name,
+    it.expense_account_name,
+    COALESCE(it.qty_on_hand, 0)::numeric,
+    it.unit_price,
+    it.purchase_cost,
+    COALESCE(s.is_managed, false),
+    COALESCE(s.is_planner, false),
+    COALESCE(s.target_days_supply, 30),
+    COALESCE(s.lead_time_days, 7),
+    s.reorder_point,
+    s.min_order_qty,
+    s.notes,
+    COALESCE(sold.qty, 0),
+    COALESCE(sold.revenue, 0),
+    COALESCE(sold.customers_count, 0),
+    ((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1))::numeric,
+    CASE WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) > 0
+         THEN COALESCE(it.qty_on_hand, 0) / ((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1))
+         ELSE NULL END,
+    CASE
+      WHEN COALESCE(it.active, true) = false THEN 'inactive'
+      WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) = 0 AND COALESCE(it.qty_on_hand, 0) > 0 THEN 'idle'
+      WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) = 0 AND COALESCE(it.qty_on_hand, 0) = 0 THEN 'idle'
+      WHEN COALESCE(it.qty_on_hand, 0) <= 0 THEN 'critical'
+      WHEN COALESCE(it.qty_on_hand, 0) <
+           COALESCE(s.lead_time_days, 7) * (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1) THEN 'reorder'
+      ELSE 'ok'
+    END,
+    ipf.family_code,
+    pf.label,
+    ipt.type_code,
+    pt.label,
+    COALESCE(seg_item.segment_code, seg_cat.segment_code)        AS segment_code,
+    COALESCE(s_item_seg.label,       s_cat_seg.label)            AS segment_label,
+    CASE
+      WHEN seg_item.segment_code IS NOT NULL THEN 'item'
+      WHEN seg_cat.segment_code  IS NOT NULL THEN 'category'
+      ELSE NULL
+    END                                                          AS segment_source
+  FROM ops.qbo_items it
+  LEFT JOIN ops.inventory_settings s ON s.qbo_item_id = it.qbo_item_id
+  LEFT JOIN sold ON sold.qbo_item_id = it.qbo_item_id
+  LEFT JOIN adj  ON adj.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.item_product_families ipf ON ipf.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.product_families pf       ON pf.family_code  = ipf.family_code AND pf.is_active
+  LEFT JOIN ops.item_product_types    ipt ON ipt.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.product_types         pt  ON pt.type_code    = ipt.type_code  AND pt.is_active
+  LEFT JOIN ops.item_segments     seg_item ON seg_item.item_name = it.name
+  LEFT JOIN ops.segments        s_item_seg ON s_item_seg.segment_code = seg_item.segment_code AND s_item_seg.is_active
+  LEFT JOIN ops.category_segments  seg_cat ON seg_cat.category = COALESCE(s.category_override, it.category_path)
+  LEFT JOIN ops.segments         s_cat_seg ON s_cat_seg.segment_code  = seg_cat.segment_code  AND s_cat_seg.is_active
+  WHERE
+    (NOT p_managed_only OR COALESCE(s.is_managed, false))
+    AND (
+      p_search IS NULL OR p_search = '' OR
+      it.name ILIKE '%' || p_search || '%' OR
+      it.fully_qualified_name ILIKE '%' || p_search || '%' OR
+      COALESCE(s.category_override, it.category_path) ILIKE '%' || p_search || '%'
+    )
+  ORDER BY
+    COALESCE(it.active, true) DESC,
+    COALESCE(s.category_override, it.category_path) NULLS LAST,
+    it.name;
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_items_master(integer, text, boolean) TO authenticated;

--- a/supabase/migrations/20260512i_account_settings_and_taxonomy_crud.sql
+++ b/supabase/migrations/20260512i_account_settings_and_taxonomy_crud.sql
@@ -1,0 +1,186 @@
+-- v0.9.34b — Account active/inactive table + supporting RPCs, and filter
+-- inactive accounts out of fn_items_master.
+--
+-- The Margin Control app should let the user hide whole P&L accounts
+-- (e.g. legacy SKUs that still have line history). When an account is
+-- marked inactive, every item whose income_account_name = that account
+-- disappears from the Items master grid. v_sales_lines is untouched
+-- so historical revenue and margin reports are unaffected; if you want
+-- to exclude an account from a report, use the account filter on the
+-- Margin page.
+
+-- 1. account_settings table -----------------------------------------------
+CREATE TABLE IF NOT EXISTS ops.account_settings (
+  account_name text PRIMARY KEY,
+  is_active    boolean NOT NULL DEFAULT true,
+  notes        text,
+  set_by       text,
+  set_at       timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE ops.account_settings ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS account_settings_read  ON ops.account_settings;
+DROP POLICY IF EXISTS account_settings_write ON ops.account_settings;
+CREATE POLICY account_settings_read  ON ops.account_settings FOR SELECT TO anon, authenticated USING (true);
+CREATE POLICY account_settings_write ON ops.account_settings FOR ALL    TO authenticated USING (true) WITH CHECK (true);
+GRANT SELECT ON ops.account_settings TO anon;
+GRANT INSERT, UPDATE, DELETE ON ops.account_settings TO authenticated;
+
+-- 2. List helper: every distinct income account + item count + is_active --
+-- Default: any account not in account_settings is treated as active.
+CREATE OR REPLACE FUNCTION ops.fn_list_accounts_for_settings()
+RETURNS TABLE(
+  account_name text,
+  item_count   integer,
+  active_item_count integer,
+  is_active    boolean,
+  notes        text,
+  set_at       timestamptz
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $$
+  WITH accts AS (
+    SELECT income_account_name AS account_name,
+           count(*)::int                                 AS item_count,
+           count(*) FILTER (WHERE COALESCE(active, true))::int AS active_item_count
+    FROM ops.qbo_items
+    WHERE income_account_name IS NOT NULL AND income_account_name <> ''
+    GROUP BY 1
+  )
+  SELECT a.account_name, a.item_count, a.active_item_count,
+         COALESCE(s.is_active, true) AS is_active,
+         s.notes, s.set_at
+  FROM accts a
+  LEFT JOIN ops.account_settings s ON s.account_name = a.account_name
+  ORDER BY a.item_count DESC, a.account_name;
+$$;
+GRANT EXECUTE ON FUNCTION ops.fn_list_accounts_for_settings() TO anon, authenticated;
+
+-- 3. Setter ---------------------------------------------------------------
+CREATE OR REPLACE FUNCTION ops.fn_set_account_active(
+  p_account_name text,
+  p_is_active    boolean,
+  p_set_by       text DEFAULT 'dashboard'
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ops, public
+AS $$
+BEGIN
+  IF p_account_name IS NULL OR p_account_name = '' THEN
+    RAISE EXCEPTION 'account_name required';
+  END IF;
+  INSERT INTO ops.account_settings AS t (account_name, is_active, set_by, set_at)
+  VALUES (p_account_name, COALESCE(p_is_active, true), p_set_by, now())
+  ON CONFLICT (account_name) DO UPDATE
+    SET is_active = EXCLUDED.is_active,
+        set_by    = EXCLUDED.set_by,
+        set_at    = now();
+END;
+$$;
+GRANT EXECUTE ON FUNCTION ops.fn_set_account_active(text, boolean, text) TO authenticated;
+
+-- 4. fn_items_master — filter out items whose income_account is inactive --
+-- Adds a JOIN on account_settings (LEFT JOIN, default-active) and a WHERE
+-- clause. Everything else is identical to 20260512h.
+DROP FUNCTION IF EXISTS ops.fn_items_master(integer, text, boolean);
+
+CREATE FUNCTION ops.fn_items_master(
+  p_lookback_days integer DEFAULT 90,
+  p_search        text    DEFAULT NULL,
+  p_managed_only  boolean DEFAULT false
+)
+RETURNS TABLE(
+  qbo_item_id text, item_name text, fully_qualified_name text, active boolean,
+  category_path text, category_override text, category_resolved text,
+  income_account_name text, expense_account_name text,
+  on_hand numeric, unit_price numeric, purchase_cost numeric,
+  is_managed boolean, is_planner boolean,
+  target_days_supply integer, lead_time_days integer,
+  reorder_point numeric, min_order_qty numeric, notes text,
+  sold_qty numeric, sold_revenue numeric, customers_count integer,
+  daily_velocity numeric, days_of_supply numeric, status text,
+  product_family_code text, product_family_label text,
+  product_type_code   text, product_type_label   text,
+  segment_code text, segment_label text, segment_source text
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  WITH start_date AS (SELECT (current_date - p_lookback_days)::date AS d),
+  excludes AS (SELECT qbo_customer_id FROM ops.inventory_velocity_excludes),
+  sold AS (
+    SELECT v.item_ref_id AS qbo_item_id,
+      sum(v.quantity)::numeric AS qty, sum(v.revenue)::numeric AS revenue,
+      count(DISTINCT v.customer_ref_id)::int AS customers_count
+    FROM ops.v_sales_lines v
+    LEFT JOIN excludes e ON e.qbo_customer_id = v.customer_ref_id
+    WHERE v.txn_date >= (SELECT d FROM start_date) AND e.qbo_customer_id IS NULL
+      AND v.item_ref_id IS NOT NULL AND v.quantity IS NOT NULL AND v.quantity > 0
+    GROUP BY 1
+  ),
+  adj AS (
+    SELECT a.item_ref_id AS qbo_item_id,
+      sum(CASE WHEN a.qty_diff < 0 THEN ABS(a.qty_diff) ELSE 0 END)::numeric AS shrink_qty
+    FROM ops.qbo_inventory_adjustment_lines a
+    WHERE a.item_ref_id IS NOT NULL AND a.txn_date >= (SELECT d FROM start_date)
+    GROUP BY 1
+  )
+  SELECT
+    it.qbo_item_id, COALESCE(it.name, it.fully_qualified_name), it.fully_qualified_name,
+    COALESCE(it.active, true)::boolean,
+    it.category_path, s.category_override,
+    COALESCE(s.category_override, it.category_path, 'Uncategorized'),
+    it.income_account_name, it.expense_account_name,
+    COALESCE(it.qty_on_hand, 0)::numeric, it.unit_price, it.purchase_cost,
+    COALESCE(s.is_managed, false), COALESCE(s.is_planner, false),
+    COALESCE(s.target_days_supply, 30), COALESCE(s.lead_time_days, 7),
+    s.reorder_point, s.min_order_qty, s.notes,
+    COALESCE(sold.qty, 0), COALESCE(sold.revenue, 0), COALESCE(sold.customers_count, 0),
+    ((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1))::numeric,
+    CASE WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) > 0
+         THEN COALESCE(it.qty_on_hand, 0) / ((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1))
+         ELSE NULL END,
+    CASE
+      WHEN COALESCE(it.active, true) = false THEN 'inactive'
+      WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) = 0 AND COALESCE(it.qty_on_hand, 0) > 0 THEN 'idle'
+      WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) = 0 AND COALESCE(it.qty_on_hand, 0) = 0 THEN 'idle'
+      WHEN COALESCE(it.qty_on_hand, 0) <= 0 THEN 'critical'
+      WHEN COALESCE(it.qty_on_hand, 0) <
+           COALESCE(s.lead_time_days, 7) * (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1) THEN 'reorder'
+      ELSE 'ok'
+    END,
+    ipf.family_code, pf.label,
+    ipt.type_code, pt.label,
+    COALESCE(seg_item.segment_code, seg_cat.segment_code),
+    COALESCE(s_item_seg.label, s_cat_seg.label),
+    CASE
+      WHEN seg_item.segment_code IS NOT NULL THEN 'item'
+      WHEN seg_cat.segment_code  IS NOT NULL THEN 'category'
+      ELSE NULL
+    END
+  FROM ops.qbo_items it
+  LEFT JOIN ops.inventory_settings s ON s.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.account_settings acct ON acct.account_name = it.income_account_name
+  LEFT JOIN sold ON sold.qbo_item_id = it.qbo_item_id
+  LEFT JOIN adj  ON adj.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.item_product_families ipf ON ipf.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.product_families pf       ON pf.family_code  = ipf.family_code AND pf.is_active
+  LEFT JOIN ops.item_product_types    ipt ON ipt.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.product_types         pt  ON pt.type_code    = ipt.type_code  AND pt.is_active
+  LEFT JOIN ops.item_segments     seg_item ON seg_item.item_name = it.name
+  LEFT JOIN ops.segments        s_item_seg ON s_item_seg.segment_code = seg_item.segment_code AND s_item_seg.is_active
+  LEFT JOIN ops.category_segments  seg_cat ON seg_cat.category = COALESCE(s.category_override, it.category_path)
+  LEFT JOIN ops.segments         s_cat_seg ON s_cat_seg.segment_code = seg_cat.segment_code AND s_cat_seg.is_active
+  WHERE
+    (NOT p_managed_only OR COALESCE(s.is_managed, false))
+    AND COALESCE(acct.is_active, true)
+    AND (
+      p_search IS NULL OR p_search = '' OR
+      it.name ILIKE '%' || p_search || '%' OR
+      it.fully_qualified_name ILIKE '%' || p_search || '%' OR
+      COALESCE(s.category_override, it.category_path) ILIKE '%' || p_search || '%'
+    )
+  ORDER BY
+    COALESCE(it.active, true) DESC,
+    COALESCE(s.category_override, it.category_path) NULLS LAST,
+    it.name;
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_items_master(integer, text, boolean) TO authenticated;


### PR DESCRIPTION
## Summary
Adds two new item-attribute dimensions so margin reports can slice independently by form factor and product nature:
- **product_family** — BIB, Can, Bottle, Postmix, Melt Equipment, Beverage Equipment, Service, Gas, Rental, Parts, Reman, Scrap, Other
- **product_type** — Carbonated Soft Drink, Juice, Tea, Lemonade, Energy, Tonic/Mixer, Water, Coffee, Hardware, Consumable, Labor/Service, N/A

Plus two new segments: `foodservice_equipment` (Melt + kitchen equipment) and `rental`.

## Auto-match coverage
Migration auto-populates from `income_account_name` + `category_path` + name-prefix patterns. `set_by = 'auto-match v0.9.33'` so a future re-run can re-classify auto-tagged items without clobbering manual edits.

| | Coverage | Notes |
|---|---|---|
| Segment assignments | 567 / 574 | Diff is items with names shared across multiple qbo_item_ids |
| Family assignments | 574 / 574 | 100% |
| Type assignments | 574 / 574 | 100% |

Spot check on the user's example: `3G6121 HANGAR 25 COLA` → **Fountain / Bag in Box / Carbonated Soft Drink** ✓

Top buckets after auto-match:
- 137 Fountain / BIB / CSD
- 134 Foodservice Equipment / Melt Equipment / Hardware
- 93 Other / Other / N/A (items with NULL or generic income accounts — need manual review)
- 56 Equipment Sales / Beverage Equipment / Hardware
- 30 Service / Service / Labor
- 21 Packaged / Can / CSD

## v_sales_lines
Preserves existing column order (including the legacy `sales_reps` column as an empty array for back-compat with whatever still reads it) and appends `product_family` + `product_type` at the end. No dependent RPCs need to change.

## Next steps (not in this PR)
- Surface family/type dropdowns in the Items master grid + bulk-assign action.
- Add `p_product_families` / `p_product_types` filters + group-by dims to `fn_sales_pivot` / `fn_sales_stacked` so the Margin page can use them.
- Manually classify the 93 "Other" items, or refine the auto-match rules.

## Test plan
- [x] Apply migration to live Supabase
- [x] Verify 3G/5G/1G BIB items → Fountain / Bag in Box / CSD (and Juice/Tea/Lemonade/Energy where appropriate)
- [x] Verify Melt Equipment → Foodservice Equipment / Melt Equipment / Hardware
- [x] Verify v_sales_lines exposes product_family + product_type columns
- [ ] Confirm existing margin reports still work (no column-order break in v_sales_lines)

https://claude.ai/code/session_01Y9VBgzstoVBXndAFqPR3Fs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9VBgzstoVBXndAFqPR3Fs)_