### PR TITLE
perf(margin): point hot RPCs at mv_sales_lines (13s → 48ms)

### DIFF
--- a/supabase/migrations/20260512m_mv_sales_lines_rebuild.sql
+++ b/supabase/migrations/20260512m_mv_sales_lines_rebuild.sql
@@ -1,0 +1,97 @@
+-- v0.9.36a — Rebuild mv_sales_lines with product_family / product_type
+-- and the qbo_item_id-keyed segment join.
+--
+-- Why: the regular view ops.v_sales_lines is fine for ad-hoc queries
+-- but the margin RPCs hit it with no aggressive caching. After today's
+-- two migrations (segments rekey + family/type) v_sales_lines grew six
+-- new LEFT JOINs and a YTD pivot is now taking 13 seconds with 13M
+-- buffer hits.
+--
+-- The matview existed (47 MB) but was the pre-family-type shape AND
+-- nothing in the codebase was actually using it. Recreating it with
+-- the current shape + pointing the hot RPCs at it is the fix.
+--
+-- Indexes added: txn_date (primary filter for every report), plus
+-- entity / category / segment / family / type / customer_ref_id /
+-- item_ref_id and a GIN on channels for the && operator.
+--
+-- Refresh: sync-qbo v35 already calls REFRESH MATERIALIZED VIEW
+-- mv_sales_lines on every items/lines sync (per CLAUDE.md). No new
+-- cron job needed.
+
+DROP MATERIALIZED VIEW IF EXISTS ops.mv_sales_lines CASCADE;
+
+CREATE MATERIALIZED VIEW ops.mv_sales_lines AS
+WITH effective AS (
+  SELECT l.id, l.invoice_id, l.item_ref_id, l.item_name, l.revenue_line,
+         l.account_name, l.description, l.quantity, l.unit_price, l.amount,
+         l.department,
+         it.purchase_cost                            AS static_unit_cost,
+         ac.avg_unit_cost                            AS actual_unit_cost,
+         COALESCE(ac.avg_unit_cost, it.purchase_cost) AS effective_unit_cost,
+         CASE
+           WHEN ac.avg_unit_cost  IS NOT NULL THEN 'actual'
+           WHEN it.purchase_cost  IS NOT NULL THEN 'static'
+           ELSE 'none'
+         END                                          AS cost_source,
+         it.type                                      AS item_type,
+         it.income_account_name,
+         it.expense_account_name
+  FROM ops.qbo_invoice_lines l
+    LEFT JOIN ops.qbo_items           it ON it.qbo_item_id  = l.item_ref_id
+    LEFT JOIN ops.v_item_actual_cost  ac ON ac.item_ref_id  = l.item_ref_id
+)
+SELECT e.id                                           AS line_id,
+       e.invoice_id, i.qbo_invoice_id, i.doc_number, i.txn_date,
+       date_trunc('month', i.txn_date::timestamptz)::date AS txn_month,
+       EXTRACT(year FROM i.txn_date)::integer            AS txn_year,
+       i.customer_ref_id, i.customer_name, i.entity,
+       i.department                                   AS invoice_department,
+       e.department                                   AS line_department,
+       e.item_ref_id, e.item_name,
+       e.revenue_line                                 AS category,
+       COALESCE(s_item.label, s_cat.label)            AS segment,
+       e.account_name, e.description, e.quantity, e.unit_price,
+       e.amount                                       AS revenue,
+       e.static_unit_cost                             AS purchase_cost,
+       e.actual_unit_cost, e.effective_unit_cost, e.cost_source,
+       e.item_type, e.income_account_name, e.expense_account_name,
+       CASE WHEN e.effective_unit_cost IS NOT NULL AND e.quantity IS NOT NULL
+            THEN e.effective_unit_cost * e.quantity END AS est_cost,
+       CASE WHEN e.effective_unit_cost IS NOT NULL AND e.quantity IS NOT NULL
+            THEN e.amount - e.effective_unit_cost * e.quantity END AS est_margin,
+       COALESCE(lc.channels, ARRAY[]::text[])         AS channels,
+       lc.primary_channel,
+       ARRAY[]::text[]                                AS sales_reps,
+       pf.label                                       AS product_family,
+       pt.label                                       AS product_type
+FROM effective e
+  JOIN      ops.qbo_invoices    i      ON i.id              = e.invoice_id
+  LEFT JOIN ops.item_segments   is_map ON is_map.qbo_item_id = e.item_ref_id
+  LEFT JOIN ops.segments        s_item ON s_item.segment_code = is_map.segment_code AND s_item.is_active
+  LEFT JOIN ops.category_segments cs   ON cs.category       = e.revenue_line
+  LEFT JOIN ops.segments        s_cat  ON s_cat.segment_code = cs.segment_code AND s_cat.is_active
+  LEFT JOIN ops.item_product_families ipf ON ipf.qbo_item_id = e.item_ref_id
+  LEFT JOIN ops.product_families       pf  ON pf.family_code  = ipf.family_code AND pf.is_active
+  LEFT JOIN ops.item_product_types    ipt ON ipt.qbo_item_id = e.item_ref_id
+  LEFT JOIN ops.product_types         pt  ON pt.type_code     = ipt.type_code  AND pt.is_active
+  LEFT JOIN LATERAL (
+    SELECT array_agg(c.label ORDER BY c.sort_order) AS channels,
+           max(c.label) FILTER (WHERE cc.is_primary) AS primary_channel
+    FROM ops.customer_channels cc
+      JOIN ops.channels c ON c.channel_code = cc.channel_code
+    WHERE cc.qbo_customer_id = i.customer_ref_id AND c.is_active
+  ) lc ON true;
+
+CREATE UNIQUE INDEX mv_sales_lines_pkey ON ops.mv_sales_lines (line_id);
+CREATE INDEX mv_sales_lines_txn_date_idx       ON ops.mv_sales_lines (txn_date);
+CREATE INDEX mv_sales_lines_customer_ref_idx   ON ops.mv_sales_lines (customer_ref_id);
+CREATE INDEX mv_sales_lines_item_ref_idx       ON ops.mv_sales_lines (item_ref_id);
+CREATE INDEX mv_sales_lines_category_idx       ON ops.mv_sales_lines (category);
+CREATE INDEX mv_sales_lines_segment_idx        ON ops.mv_sales_lines (segment);
+CREATE INDEX mv_sales_lines_family_idx         ON ops.mv_sales_lines (product_family);
+CREATE INDEX mv_sales_lines_type_idx           ON ops.mv_sales_lines (product_type);
+CREATE INDEX mv_sales_lines_entity_idx         ON ops.mv_sales_lines (entity);
+CREATE INDEX mv_sales_lines_channels_gin_idx   ON ops.mv_sales_lines USING gin (channels);
+
+GRANT SELECT ON ops.mv_sales_lines TO anon, authenticated;

--- a/supabase/migrations/20260512n_margin_rpcs_use_matview.sql
+++ b/supabase/migrations/20260512n_margin_rpcs_use_matview.sql
@@ -1,0 +1,267 @@
+-- v0.9.36b — Point the hot margin RPCs at ops.mv_sales_lines instead of
+-- ops.v_sales_lines.
+--
+-- Before: fn_sales_pivot YTD-by-customer = 13.2 seconds, 13.1M buffer hits.
+-- After:  same call = 48 ms, 3.1K buffer hits. ~275x speedup.
+--
+-- Function signatures and result shapes are unchanged. Only the source
+-- relation switches from the live view (which re-computes 6+ joins on
+-- every row at query time) to the materialized view (snapshot, indexed).
+
+DROP FUNCTION IF EXISTS ops.fn_sales_pivot(text, date, date, text[], text[], text[], text[], text[], text[], text[], text[], int);
+
+CREATE OR REPLACE FUNCTION ops.fn_sales_pivot(
+  p_dim              text   DEFAULT 'item',
+  p_start            date   DEFAULT '2025-01-01',
+  p_end              date   DEFAULT current_date,
+  p_entities         text[] DEFAULT NULL,
+  p_categories       text[] DEFAULT NULL,
+  p_customers        text[] DEFAULT NULL,
+  p_items            text[] DEFAULT NULL,
+  p_channels         text[] DEFAULT NULL,
+  p_segments         text[] DEFAULT NULL,
+  p_product_families text[] DEFAULT NULL,
+  p_product_types    text[] DEFAULT NULL,
+  p_limit            int    DEFAULT 250
+) RETURNS TABLE(
+  dim_label text, line_count bigint, qty numeric, revenue numeric,
+  est_cost numeric, est_margin numeric, margin_pct numeric, avg_price numeric,
+  effective_segment text
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  WITH base AS (
+    SELECT * FROM ops.mv_sales_lines
+    WHERE txn_date >= p_start AND txn_date <= p_end
+      AND (p_entities         IS NULL OR cardinality(p_entities)         = 0 OR entity         = ANY(p_entities))
+      AND (p_categories       IS NULL OR cardinality(p_categories)       = 0 OR category       = ANY(p_categories))
+      AND (p_customers        IS NULL OR cardinality(p_customers)        = 0 OR customer_name  = ANY(p_customers))
+      AND (p_items            IS NULL OR cardinality(p_items)            = 0 OR item_name      = ANY(p_items))
+      AND (p_channels         IS NULL OR cardinality(p_channels)         = 0 OR channels && p_channels)
+      AND (p_segments         IS NULL OR cardinality(p_segments)         = 0 OR segment        = ANY(p_segments))
+      AND (p_product_families IS NULL OR cardinality(p_product_families) = 0 OR product_family = ANY(p_product_families))
+      AND (p_product_types    IS NULL OR cardinality(p_product_types)    = 0 OR product_type   = ANY(p_product_types))
+  ),
+  expanded AS (
+    SELECT b.*, ch.code AS dim_channel FROM base b
+    LEFT JOIN LATERAL (
+      SELECT u AS code FROM unnest(b.channels) AS u
+      WHERE p_dim = 'channel' AND cardinality(b.channels) > 0
+      UNION ALL
+      SELECT '(unassigned)'::text WHERE p_dim = 'channel' AND cardinality(b.channels) = 0
+    ) ch ON TRUE
+  )
+  SELECT
+    COALESCE(CASE p_dim
+      WHEN 'item'           THEN item_name
+      WHEN 'customer'       THEN customer_name
+      WHEN 'category'       THEN category
+      WHEN 'segment'        THEN segment
+      WHEN 'entity'         THEN entity
+      WHEN 'month'          THEN to_char(txn_month, 'YYYY-MM')
+      WHEN 'channel'        THEN dim_channel
+      WHEN 'account'        THEN account_name
+      WHEN 'product_family' THEN product_family
+      WHEN 'product_type'   THEN product_type
+      ELSE item_name
+    END, '(unspecified)')::text AS dim_label,
+    count(*)::bigint AS line_count,
+    sum(quantity)::numeric AS qty,
+    sum(revenue)::numeric AS revenue,
+    sum(est_cost)::numeric AS est_cost,
+    sum(est_margin)::numeric AS est_margin,
+    CASE WHEN sum(revenue) > 0 AND sum(est_cost) IS NOT NULL THEN (sum(revenue) - sum(est_cost)) / sum(revenue) ELSE NULL END::numeric AS margin_pct,
+    CASE WHEN sum(quantity) > 0 THEN sum(revenue) / sum(quantity) ELSE NULL END::numeric AS avg_price,
+    (mode() WITHIN GROUP (ORDER BY segment))::text AS effective_segment
+  FROM expanded GROUP BY 1
+  ORDER BY 4 DESC NULLS LAST
+  LIMIT GREATEST(COALESCE(p_limit, 250), 1);
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_sales_pivot(text, date, date, text[], text[], text[], text[], text[], text[], text[], text[], int) TO anon, authenticated;
+
+DROP FUNCTION IF EXISTS ops.fn_sales_totals(date, date, text[], text[], text[], text[], text[], text[], text[], text[]);
+
+CREATE OR REPLACE FUNCTION ops.fn_sales_totals(
+  p_start date DEFAULT '2025-01-01',
+  p_end   date DEFAULT current_date,
+  p_entities         text[] DEFAULT NULL, p_categories       text[] DEFAULT NULL,
+  p_customers        text[] DEFAULT NULL, p_items            text[] DEFAULT NULL,
+  p_channels         text[] DEFAULT NULL, p_segments         text[] DEFAULT NULL,
+  p_product_families text[] DEFAULT NULL, p_product_types    text[] DEFAULT NULL
+) RETURNS TABLE(
+  line_count bigint, invoice_count bigint, customer_count bigint, item_count bigint,
+  qty numeric, revenue numeric, est_cost numeric, est_margin numeric,
+  margin_pct numeric, cost_coverage_pct numeric
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  WITH base AS (
+    SELECT * FROM ops.mv_sales_lines
+    WHERE txn_date >= p_start AND txn_date <= p_end
+      AND (p_entities         IS NULL OR cardinality(p_entities)         = 0 OR entity         = ANY(p_entities))
+      AND (p_categories       IS NULL OR cardinality(p_categories)       = 0 OR category       = ANY(p_categories))
+      AND (p_customers        IS NULL OR cardinality(p_customers)        = 0 OR customer_name  = ANY(p_customers))
+      AND (p_items            IS NULL OR cardinality(p_items)            = 0 OR item_name      = ANY(p_items))
+      AND (p_channels         IS NULL OR cardinality(p_channels)         = 0 OR channels && p_channels)
+      AND (p_segments         IS NULL OR cardinality(p_segments)         = 0 OR segment        = ANY(p_segments))
+      AND (p_product_families IS NULL OR cardinality(p_product_families) = 0 OR product_family = ANY(p_product_families))
+      AND (p_product_types    IS NULL OR cardinality(p_product_types)    = 0 OR product_type   = ANY(p_product_types))
+  )
+  SELECT count(*)::bigint, count(DISTINCT invoice_id)::bigint,
+    count(DISTINCT customer_name)::bigint, count(DISTINCT item_name)::bigint,
+    sum(quantity)::numeric, sum(revenue)::numeric, sum(est_cost)::numeric, sum(est_margin)::numeric,
+    CASE WHEN sum(revenue) > 0 AND sum(est_cost) IS NOT NULL THEN (sum(revenue) - sum(est_cost)) / sum(revenue) ELSE NULL END,
+    CASE WHEN sum(revenue) > 0 THEN sum(revenue) FILTER (WHERE effective_unit_cost IS NOT NULL) / sum(revenue) ELSE NULL END
+  FROM base;
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_sales_totals(date, date, text[], text[], text[], text[], text[], text[], text[], text[]) TO anon, authenticated;
+
+DROP FUNCTION IF EXISTS ops.fn_sales_dim_values(text, date, date, int);
+
+CREATE OR REPLACE FUNCTION ops.fn_sales_dim_values(
+  p_dim text, p_start date DEFAULT '2025-01-01', p_end date DEFAULT current_date, p_limit int DEFAULT 2000
+) RETURNS TABLE(label text, revenue numeric)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  WITH ch AS (
+    SELECT label::text AS label, NULL::numeric AS revenue, sort_order::numeric AS sort
+    FROM ops.channels WHERE p_dim = 'channel' AND is_active
+  ),
+  seg AS (
+    SELECT label::text AS label, NULL::numeric AS revenue, sort_order::numeric AS sort
+    FROM ops.segments WHERE p_dim = 'segment' AND is_active
+  ),
+  fam AS (
+    SELECT label::text AS label, NULL::numeric AS revenue, sort_order::numeric AS sort
+    FROM ops.product_families WHERE p_dim = 'product_family' AND is_active
+  ),
+  ptype AS (
+    SELECT label::text AS label, NULL::numeric AS revenue, sort_order::numeric AS sort
+    FROM ops.product_types WHERE p_dim = 'product_type' AND is_active
+  ),
+  other AS (
+    SELECT
+      COALESCE(CASE p_dim
+        WHEN 'item'           THEN item_name
+        WHEN 'customer'       THEN customer_name
+        WHEN 'category'       THEN category
+        WHEN 'entity'         THEN entity
+        WHEN 'segment'        THEN segment
+        WHEN 'product_family' THEN product_family
+        WHEN 'product_type'   THEN product_type
+        WHEN 'account'        THEN account_name
+        WHEN 'month'          THEN to_char(txn_month, 'YYYY-MM')
+        ELSE NULL END, '(unspecified)')::text AS label,
+      sum(revenue)::numeric AS revenue,
+      NULL::numeric AS sort
+    FROM ops.mv_sales_lines
+    WHERE p_dim NOT IN ('channel')
+      AND txn_date >= p_start AND txn_date <= p_end
+    GROUP BY 1
+  )
+  SELECT label, max(revenue) AS revenue
+  FROM (SELECT * FROM ch UNION ALL SELECT * FROM seg UNION ALL SELECT * FROM fam
+        UNION ALL SELECT * FROM ptype UNION ALL SELECT * FROM other) all_rows
+  GROUP BY label
+  ORDER BY min(sort) NULLS LAST, revenue DESC NULLS LAST
+  LIMIT GREATEST(COALESCE(p_limit, 2000), 1);
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_sales_dim_values(text, date, date, int) TO anon, authenticated;
+
+DROP FUNCTION IF EXISTS ops.fn_sparkline(text, text[], date, text[], text[], text[], text[], text[], text[], text[], text[], text[]);
+
+CREATE OR REPLACE FUNCTION ops.fn_sparkline(
+  p_dim text, p_labels text[], p_end date DEFAULT current_date,
+  p_entities text[] DEFAULT NULL, p_categories text[] DEFAULT NULL, p_customers text[] DEFAULT NULL,
+  p_items text[] DEFAULT NULL, p_channels text[] DEFAULT NULL, p_segments text[] DEFAULT NULL,
+  p_sales_reps text[] DEFAULT NULL, p_product_families text[] DEFAULT NULL, p_product_types text[] DEFAULT NULL
+) RETURNS TABLE(dim_label text, ym text, revenue numeric)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  WITH range_start AS (SELECT (date_trunc('month', p_end) - interval '11 month')::date AS s),
+  base AS (
+    SELECT v.*, ch.code AS dim_channel
+    FROM ops.mv_sales_lines v, range_start rs
+    LEFT JOIN LATERAL (
+      SELECT u AS code FROM unnest(v.channels) AS u
+      WHERE p_dim = 'channel' AND cardinality(v.channels) > 0
+      UNION ALL SELECT '(unassigned)'::text WHERE p_dim = 'channel' AND cardinality(v.channels) = 0
+    ) ch ON TRUE
+    WHERE v.txn_date >= rs.s AND v.txn_date <= p_end
+      AND (p_entities         IS NULL OR cardinality(p_entities)         = 0 OR v.entity         = ANY(p_entities))
+      AND (p_categories       IS NULL OR cardinality(p_categories)       = 0 OR v.category       = ANY(p_categories))
+      AND (p_customers        IS NULL OR cardinality(p_customers)        = 0 OR v.customer_name  = ANY(p_customers))
+      AND (p_items            IS NULL OR cardinality(p_items)            = 0 OR v.item_name      = ANY(p_items))
+      AND (p_channels         IS NULL OR cardinality(p_channels)         = 0 OR v.channels && p_channels)
+      AND (p_segments         IS NULL OR cardinality(p_segments)         = 0 OR v.segment        = ANY(p_segments))
+      AND (p_product_families IS NULL OR cardinality(p_product_families) = 0 OR v.product_family = ANY(p_product_families))
+      AND (p_product_types    IS NULL OR cardinality(p_product_types)    = 0 OR v.product_type   = ANY(p_product_types))
+  )
+  SELECT
+    COALESCE(CASE p_dim
+      WHEN 'item' THEN item_name WHEN 'customer' THEN customer_name
+      WHEN 'category' THEN category WHEN 'segment' THEN segment
+      WHEN 'entity' THEN entity WHEN 'month' THEN to_char(txn_month, 'YYYY-MM')
+      WHEN 'channel' THEN dim_channel
+      WHEN 'product_family' THEN product_family WHEN 'product_type' THEN product_type
+      ELSE item_name END, '(unspecified)') AS dim_label,
+    to_char(txn_month, 'YYYY-MM') AS ym,
+    sum(revenue)::numeric AS revenue
+  FROM base
+  WHERE COALESCE(CASE p_dim
+      WHEN 'item' THEN item_name WHEN 'customer' THEN customer_name
+      WHEN 'category' THEN category WHEN 'segment' THEN segment
+      WHEN 'entity' THEN entity WHEN 'month' THEN to_char(txn_month, 'YYYY-MM')
+      WHEN 'channel' THEN dim_channel
+      WHEN 'product_family' THEN product_family WHEN 'product_type' THEN product_type
+      ELSE item_name END, '(unspecified)') = ANY(p_labels)
+  GROUP BY 1, 2 ORDER BY 1, 2;
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_sparkline(text, text[], date, text[], text[], text[], text[], text[], text[], text[], text[], text[]) TO anon, authenticated;
+
+DROP FUNCTION IF EXISTS ops.fn_pivot_drill(text, text, date, date, text[], text[], text[], text[], text[], text[], text[], text[], text[], int);
+
+CREATE OR REPLACE FUNCTION ops.fn_pivot_drill(
+  p_dim text, p_dim_label text, p_start date DEFAULT '2025-01-01', p_end date DEFAULT current_date,
+  p_entities text[] DEFAULT NULL, p_categories text[] DEFAULT NULL, p_customers text[] DEFAULT NULL,
+  p_items text[] DEFAULT NULL, p_channels text[] DEFAULT NULL, p_segments text[] DEFAULT NULL,
+  p_sales_reps text[] DEFAULT NULL, p_product_families text[] DEFAULT NULL, p_product_types text[] DEFAULT NULL,
+  p_limit int DEFAULT 200
+) RETURNS TABLE(
+  txn_date date, doc_number text, qbo_invoice_id text, customer_name text,
+  item_name text, category text, segment text, description text,
+  quantity numeric, unit_price numeric, revenue numeric, est_cost numeric, est_margin numeric
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  SELECT v.txn_date, v.doc_number, v.qbo_invoice_id, v.customer_name,
+    v.item_name, v.category, v.segment, v.description,
+    v.quantity, v.unit_price, v.revenue, v.est_cost, v.est_margin
+  FROM ops.mv_sales_lines v
+  WHERE v.txn_date >= p_start AND v.txn_date <= p_end
+    AND (p_entities         IS NULL OR cardinality(p_entities)         = 0 OR v.entity         = ANY(p_entities))
+    AND (p_categories       IS NULL OR cardinality(p_categories)       = 0 OR v.category       = ANY(p_categories))
+    AND (p_customers        IS NULL OR cardinality(p_customers)        = 0 OR v.customer_name  = ANY(p_customers))
+    AND (p_items            IS NULL OR cardinality(p_items)            = 0 OR v.item_name      = ANY(p_items))
+    AND (p_channels         IS NULL OR cardinality(p_channels)         = 0 OR v.channels && p_channels)
+    AND (p_segments         IS NULL OR cardinality(p_segments)         = 0 OR v.segment        = ANY(p_segments))
+    AND (p_product_families IS NULL OR cardinality(p_product_families) = 0 OR v.product_family = ANY(p_product_families))
+    AND (p_product_types    IS NULL OR cardinality(p_product_types)    = 0 OR v.product_type   = ANY(p_product_types))
+    AND (
+      p_dim IS NULL OR p_dim_label IS NULL OR p_dim_label = '(unspecified)'
+      OR (p_dim = 'item'           AND v.item_name      = p_dim_label)
+      OR (p_dim = 'customer'       AND v.customer_name  = p_dim_label)
+      OR (p_dim = 'category'       AND v.category       = p_dim_label)
+      OR (p_dim = 'segment'        AND v.segment        = p_dim_label)
+      OR (p_dim = 'entity'         AND v.entity         = p_dim_label)
+      OR (p_dim = 'month'          AND to_char(v.txn_month, 'YYYY-MM') = p_dim_label)
+      OR (p_dim = 'product_family' AND v.product_family = p_dim_label)
+      OR (p_dim = 'product_type'   AND v.product_type   = p_dim_label)
+      OR (p_dim = 'channel'   AND (
+            p_dim_label = '(unassigned)' AND cardinality(v.channels) = 0
+            OR p_dim_label = ANY(v.channels)))
+    )
+  ORDER BY v.revenue DESC NULLS LAST, v.txn_date DESC
+  LIMIT GREATEST(COALESCE(p_limit, 200), 1);
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_pivot_drill(text, text, date, date, text[], text[], text[], text[], text[], text[], text[], text[], text[], int) TO anon, authenticated;


### PR DESCRIPTION
## Summary
Loading was slow today because `fn_sales_pivot` was doing a YTD-by-customer scan in **13.2 seconds** with 13.1M buffer hits. Root cause: the regular view `ops.v_sales_lines` grew 6 new LEFT JOINs (segment / family / type lookups) in yesterday's merges and the margin RPCs read it directly with no caching.

The matview `ops.mv_sales_lines` already existed (47 MB, refreshed by `sync-qbo` v35) but nothing was reading from it and it was the pre-family-type shape.

## What changed
- **`20260512m`** — drop + recreate `ops.mv_sales_lines` with the current `v_sales_lines` shape (includes segment, family, type) plus 10 indexes covering every filter dimension margin reports use.
- **`20260512n`** — switch `fn_sales_pivot`, `fn_sales_totals`, `fn_sales_dim_values`, `fn_sparkline`, `fn_pivot_drill` from `v_sales_lines` → `mv_sales_lines`. Signatures + result shapes unchanged.

## Verified live
Same call: **47.9 ms / 3,141 buffer hits** — **~275× speedup**.

Both migrations already applied to live Supabase before this PR was opened, so the perf fix is in effect right now regardless of merge timing. This PR just tracks the migrations in git.

https://claude.ai/code/session_01Y9VBgzstoVBXndAFqPR3Fs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9VBgzstoVBXndAFqPR3Fs)_