### PR TITLE
feat(items): Pull-from-QBO button + wire Stock/BOM toggles end-to-end

### DIFF
--- a/app/src/lib/inventory.ts
+++ b/app/src/lib/inventory.ts
@@ -236,6 +236,38 @@ export async function setItemActive(qbo_item_id: string, active: boolean): Promi
   return callPushQboItem({ action: 'setActive', qbo_item_id, active });
 }
 
+// Pull item master from QBO on demand (instead of waiting for the
+// nightly 1:30am PT cron). Returns the sync result so the UI can show
+// "synced 1,211 items, 738 inactive" or similar.
+export interface QboItemsSyncResult {
+  ok: boolean;
+  synced?: number;
+  active_in_qbo?: number;
+  inactive_in_qbo?: number;
+  with_purchase_cost?: number;
+  upserted?: number;
+  reconciled_inactive?: number;
+  duration_ms?: number;
+  error?: string;
+}
+export async function pullQboItemsNow(): Promise<QboItemsSyncResult> {
+  const token = await _sbToken();
+  const res = await fetch(SB_URL + '/functions/v1/sync-qbo-items', {
+    method: 'POST',
+    headers: {
+      apikey: SB_KEY,
+      Authorization: 'Bearer ' + token,
+      'Content-Type': 'application/json',
+    },
+    body: '{}',
+  });
+  const j = (await res.json()) as QboItemsSyncResult;
+  if (!res.ok || j.ok === false) {
+    throw new Error(j.error || ('QBO items sync failed: HTTP ' + res.status));
+  }
+  return j;
+}
+
 // Logs every QBO writeback attempt to ops.qbo_writeback_log so we have
 // our own audit trail (not just edge-function HTTP logs). Best-effort:
 // logging failures never throw — we don't want to mask the real result.

--- a/app/src/pages/settings/ItemsSettingsEditor.tsx
+++ b/app/src/pages/settings/ItemsSettingsEditor.tsx
@@ -18,6 +18,7 @@ import { sbrpc } from '../../lib/rpc';
 import { useToast } from '../../lib/toast';
 import {
   fetchCategoryList, setItemActiveAudited, logQboWritebackCancelled, logQboWriteback,
+  pullQboItemsNow,
   fetchItemPlAudit, applyPlCategorySuggestions,
   bulkSyncCategoriesToQbo,
   fetchItemHygieneSummary,
@@ -207,6 +208,28 @@ export function ItemsSettingsEditor() {
     qbo_item_id: string; item_name: string; current: boolean; next: boolean;
   } | null>(null);
   const [activeBusy, setActiveBusy] = useState(false);
+  const [qboSyncing, setQboSyncing] = useState(false);
+
+  async function pullFromQbo() {
+    if (qboSyncing) return;
+    setQboSyncing(true);
+    try {
+      const r = await pullQboItemsNow();
+      const parts: string[] = [];
+      if (r.synced != null) parts.push(`${r.synced} items`);
+      if (r.active_in_qbo != null && r.inactive_in_qbo != null) {
+        parts.push(`${r.active_in_qbo} active / ${r.inactive_in_qbo} inactive`);
+      }
+      if (r.reconciled_inactive) parts.push(`${r.reconciled_inactive} reconciled`);
+      const secs = r.duration_ms ? (r.duration_ms / 1000).toFixed(1) : '?';
+      toast.success(`Synced from QBO (${secs}s): ${parts.join(', ')}`);
+      load();
+    } catch (e) {
+      toast.error('QBO sync failed: ' + (e as Error).message);
+    } finally {
+      setQboSyncing(false);
+    }
+  }
   const [pushReview, setPushReview] = useState<{
     categoriesToCreate: string[];
     changes: CategoryChange[];
@@ -1310,6 +1333,11 @@ export function ItemsSettingsEditor() {
           {pushing ? 'Syncing…' : `Push to QBO (${withOverrideCount})`}
         </button>
         <button onClick={load} className="tb-btn">Refresh</button>
+        <button onClick={pullFromQbo} disabled={qboSyncing}
+          className={'tb-btn' + (qboSyncing ? '' : ' tb-btn--primary')}
+          title="Pull the latest item master + active/inactive from QuickBooks now (otherwise waits for the 1:30 AM PT nightly sync)">
+          {qboSyncing ? 'Pulling from QBO…' : 'Pull from QBO'}
+        </button>
         <button onClick={resetLayout} className="tb-btn"
           title="Reset column order, widths, and visibility to defaults">
           Reset layout

--- a/supabase/migrations/20260514c_set_inventory_settings_track_bom.sql
+++ b/supabase/migrations/20260514c_set_inventory_settings_track_bom.sql
@@ -1,0 +1,178 @@
+-- v0.9.39 — extend fn_set_inventory_settings to accept p_track_locations
+-- and p_has_bom. The Items master grid already had Stock + BOM toggles
+-- and the client patchSettings call was already passing those params, but
+-- the server function was 9-arg without those columns — so PostgREST
+-- silently couldn't find a match and the toggles never persisted.
+--
+-- Two changes:
+-- 1. Function signature grows from 9 to 11 args; defaults remain NULL
+--    so existing 9-arg callers don't need to change.
+-- 2. fn_items_master returns the two new flags so the grid can render
+--    them (and the read-side filters on StockPage / ProductionPage /
+--    StockOnHandTab keep working).
+--
+-- Uses the same NULL-preserving COALESCE pattern from v0.9.38: partial
+-- patches don't reset un-patched fields.
+
+DROP FUNCTION IF EXISTS ops.fn_set_inventory_settings(
+  text, boolean, integer, integer, numeric, numeric, text, text, boolean
+);
+
+CREATE OR REPLACE FUNCTION ops.fn_set_inventory_settings(
+  p_qbo_item_id        TEXT,
+  p_is_managed         BOOLEAN DEFAULT NULL,
+  p_target_days_supply INTEGER DEFAULT NULL,
+  p_lead_time_days     INTEGER DEFAULT NULL,
+  p_reorder_point      NUMERIC DEFAULT NULL,
+  p_min_order_qty      NUMERIC DEFAULT NULL,
+  p_notes              TEXT    DEFAULT NULL,
+  p_category_override  TEXT    DEFAULT NULL,
+  p_is_planner         BOOLEAN DEFAULT NULL,
+  p_track_locations    BOOLEAN DEFAULT NULL,
+  p_has_bom            BOOLEAN DEFAULT NULL
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = ops, public
+AS $func$
+BEGIN
+  INSERT INTO ops.inventory_settings (
+    qbo_item_id, is_managed, target_days_supply, lead_time_days,
+    reorder_point, min_order_qty, notes, category_override, is_planner,
+    track_locations, has_bom, updated_at
+  )
+  VALUES (
+    p_qbo_item_id,
+    COALESCE(p_is_managed, false),
+    COALESCE(p_target_days_supply, 30),
+    COALESCE(p_lead_time_days, 7),
+    p_reorder_point, p_min_order_qty, p_notes, p_category_override,
+    COALESCE(p_is_planner, false),
+    COALESCE(p_track_locations, false),
+    COALESCE(p_has_bom, false),
+    NOW()
+  )
+  ON CONFLICT (qbo_item_id) DO UPDATE SET
+    is_managed         = COALESCE(p_is_managed,         ops.inventory_settings.is_managed),
+    target_days_supply = COALESCE(p_target_days_supply, ops.inventory_settings.target_days_supply),
+    lead_time_days     = COALESCE(p_lead_time_days,     ops.inventory_settings.lead_time_days),
+    reorder_point      = COALESCE(p_reorder_point,      ops.inventory_settings.reorder_point),
+    min_order_qty      = COALESCE(p_min_order_qty,      ops.inventory_settings.min_order_qty),
+    notes              = COALESCE(p_notes,              ops.inventory_settings.notes),
+    category_override  = COALESCE(p_category_override,  ops.inventory_settings.category_override),
+    is_planner         = COALESCE(p_is_planner,         ops.inventory_settings.is_planner),
+    track_locations    = COALESCE(p_track_locations,    ops.inventory_settings.track_locations),
+    has_bom            = COALESCE(p_has_bom,            ops.inventory_settings.has_bom),
+    updated_at         = NOW();
+END;
+$func$;
+GRANT EXECUTE ON FUNCTION ops.fn_set_inventory_settings(
+  TEXT, BOOLEAN, INTEGER, INTEGER, NUMERIC, NUMERIC, TEXT, TEXT, BOOLEAN, BOOLEAN, BOOLEAN
+) TO authenticated;
+
+DROP FUNCTION IF EXISTS ops.fn_items_master(integer, text, boolean);
+
+CREATE FUNCTION ops.fn_items_master(
+  p_lookback_days integer DEFAULT 90,
+  p_search        text    DEFAULT NULL,
+  p_managed_only  boolean DEFAULT false
+)
+RETURNS TABLE(
+  qbo_item_id text, item_name text, fully_qualified_name text, active boolean,
+  category_path text, category_override text, category_resolved text,
+  income_account_name text, expense_account_name text,
+  on_hand numeric, unit_price numeric, purchase_cost numeric,
+  is_managed boolean, is_planner boolean,
+  target_days_supply integer, lead_time_days integer,
+  reorder_point numeric, min_order_qty numeric, notes text,
+  sold_qty numeric, sold_revenue numeric, customers_count integer,
+  daily_velocity numeric, days_of_supply numeric, status text,
+  product_family_code text, product_family_label text,
+  product_type_code   text, product_type_label   text,
+  segment_code text, segment_label text, segment_source text,
+  track_locations boolean, has_bom boolean
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  WITH start_date AS (SELECT (current_date - p_lookback_days)::date AS d),
+  excludes AS (SELECT qbo_customer_id FROM ops.inventory_velocity_excludes),
+  sold AS (
+    SELECT v.item_ref_id AS qbo_item_id,
+      sum(v.quantity)::numeric AS qty, sum(v.revenue)::numeric AS revenue,
+      count(DISTINCT v.customer_ref_id)::int AS customers_count
+    FROM ops.v_sales_lines v
+    LEFT JOIN excludes e ON e.qbo_customer_id = v.customer_ref_id
+    WHERE v.txn_date >= (SELECT d FROM start_date) AND e.qbo_customer_id IS NULL
+      AND v.item_ref_id IS NOT NULL AND v.quantity IS NOT NULL AND v.quantity > 0
+    GROUP BY 1
+  ),
+  adj AS (
+    SELECT a.item_ref_id AS qbo_item_id,
+      sum(CASE WHEN a.qty_diff < 0 THEN abs(a.qty_diff) ELSE 0 END)::numeric AS shrink_qty
+    FROM ops.qbo_inventory_adjustment_lines a
+    WHERE a.item_ref_id IS NOT NULL AND a.txn_date >= (SELECT d FROM start_date)
+    GROUP BY 1
+  )
+  SELECT
+    it.qbo_item_id, COALESCE(it.name, it.fully_qualified_name), it.fully_qualified_name,
+    COALESCE(it.active, true)::boolean,
+    it.category_path, s.category_override,
+    COALESCE(s.category_override, it.category_path, 'Uncategorized'),
+    it.income_account_name, it.expense_account_name,
+    COALESCE(it.qty_on_hand, 0)::numeric, it.unit_price, it.purchase_cost,
+    COALESCE(s.is_managed, false), COALESCE(s.is_planner, false),
+    COALESCE(s.target_days_supply, 30), COALESCE(s.lead_time_days, 7),
+    s.reorder_point, s.min_order_qty, s.notes,
+    COALESCE(sold.qty, 0), COALESCE(sold.revenue, 0), COALESCE(sold.customers_count, 0),
+    ((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1))::numeric,
+    CASE WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) > 0
+         THEN COALESCE(it.qty_on_hand, 0) / ((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1))
+         ELSE NULL END,
+    CASE
+      WHEN COALESCE(it.active, true) = false THEN 'inactive'
+      WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) = 0 AND COALESCE(it.qty_on_hand, 0) > 0 THEN 'idle'
+      WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) = 0 AND COALESCE(it.qty_on_hand, 0) = 0 THEN 'idle'
+      WHEN COALESCE(it.qty_on_hand, 0) <= 0 THEN 'critical'
+      WHEN COALESCE(it.qty_on_hand, 0) <
+           COALESCE(s.lead_time_days, 7) * (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1) THEN 'reorder'
+      ELSE 'ok'
+    END,
+    ipf.family_code, pf.label,
+    ipt.type_code, pt.label,
+    COALESCE(seg_item.segment_code, seg_cat.segment_code),
+    COALESCE(s_item_seg.label, s_cat_seg.label),
+    CASE
+      WHEN seg_item.segment_code IS NOT NULL THEN 'item'
+      WHEN seg_cat.segment_code  IS NOT NULL THEN 'category'
+      ELSE NULL
+    END,
+    COALESCE(s.track_locations, false),
+    COALESCE(s.has_bom, false)
+  FROM ops.qbo_items it
+  LEFT JOIN ops.inventory_settings s ON s.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.account_settings acct ON acct.account_name = it.income_account_name
+  LEFT JOIN sold ON sold.qbo_item_id = it.qbo_item_id
+  LEFT JOIN adj  ON adj.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.item_product_families ipf ON ipf.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.product_families pf       ON pf.family_code  = ipf.family_code AND pf.is_active
+  LEFT JOIN ops.item_product_types    ipt ON ipt.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.product_types         pt  ON pt.type_code    = ipt.type_code  AND pt.is_active
+  LEFT JOIN ops.item_segments     seg_item ON seg_item.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.segments        s_item_seg ON s_item_seg.segment_code = seg_item.segment_code AND s_item_seg.is_active
+  LEFT JOIN ops.category_segments  seg_cat ON seg_cat.category = COALESCE(s.category_override, it.category_path)
+  LEFT JOIN ops.segments         s_cat_seg ON s_cat_seg.segment_code = seg_cat.segment_code AND s_cat_seg.is_active
+  WHERE
+    (NOT p_managed_only OR COALESCE(s.is_managed, false))
+    AND COALESCE(acct.is_active, true)
+    AND (
+      p_search IS NULL OR p_search = '' OR
+      it.name ILIKE '%' || p_search || '%' OR
+      it.fully_qualified_name ILIKE '%' || p_search || '%' OR
+      COALESCE(s.category_override, it.category_path) ILIKE '%' || p_search || '%'
+    )
+  ORDER BY
+    COALESCE(it.active, true) DESC,
+    COALESCE(s.category_override, it.category_path) NULLS LAST,
+    it.name;
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_items_master(integer, text, boolean) TO authenticated;


### PR DESCRIPTION
## Two changes

### 1. "Pull from QBO" button on Items master
Inventory normally only syncs at the 1:30 AM PT nightly cron. After today's BIB-Income-deactivation issue, it was clear that waiting until the next morning to see QBO changes reflected in BRIX is a problem when something goes wrong.

New **Pull from QBO** button (primary style) between Refresh and Reset layout. Calls the `sync-qbo-items` edge function and shows a summary toast on success ("Synced from QBO (28.4s): 1,211 items, 473 active / 738 inactive"), then refreshes local data.

### 2. Wire Stock + BOM toggles end-to-end
The Items master had `Stock` (track_locations) and `BOM` (has_bom) toggle columns wired to `patchSettings`, and the read-side filters on `StockPage` / `StockOnHandTab` / `ProductionPage` already honor those flags — but **the WRITE side never worked**: `fn_set_inventory_settings` was a 9-arg signature with no `p_track_locations` / `p_has_bom` params. PostgREST couldn't find a match → calls failed silently → toggles never persisted.

Migration extends `fn_set_inventory_settings` to 11 args (defaults NULL so existing 9-arg callers still work) and `fn_items_master` to return the two new flag columns. Same NULL-preserving `COALESCE` pattern from v0.9.38 so partial patches don't reset the other flags.

**Verified live:**
- Set Managed + Stock=true → both persist
- Set BOM only → managed/stock stay true, BOM flips on
- Flip Stock off → managed and BOM preserved

**Read-side propagation (already in place, confirmed working):**
- `track_locations=false` → drops item from Stock page, Stock On Hand tab, and Production component-options dropdown
- `has_bom=false` → drops item from Production finished-goods dropdown

## Status
Both migrations applied to live Supabase. `tsc -b` clean.

https://claude.ai/code/session_01Y9VBgzstoVBXndAFqPR3Fs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9VBgzstoVBXndAFqPR3Fs)_