### PR TITLE
feat(production): work-order writeback to QBO InventoryAdjustment

### DIFF
--- a/app/src/lib/production.ts
+++ b/app/src/lib/production.ts
@@ -1,4 +1,5 @@
 import { sbq, sbrpc, sbUpdate } from './rpc';
+import { SB_KEY, SB_URL, _sbToken } from './supabase';
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -61,6 +62,9 @@ export interface WorkOrder {
   voided_by: string | null;
   void_reason: string | null;
   notes: string | null;
+  qbo_inventory_adjustment_id: string | null;
+  qbo_pushed_at: string | null;
+  qbo_push_error: string | null;
   created_by: string | null;
   created_at: string;
   updated_at: string;
@@ -167,4 +171,51 @@ export async function closeWorkOrder(woId: string, qtyProducedActual: number, cl
 
 export async function voidWorkOrder(woId: string, reason: string): Promise<void> {
   await sbrpc('fn_void_work_order', { p_wo_id: woId, p_reason: reason });
+}
+
+// ── QBO writeback for closed work orders ────────────────────────────────
+// Posts an InventoryAdjustment to QBO so QBO's Item.QtyOnHand reflects
+// the build. Idempotent — refuses to push a WO that already has
+// qbo_inventory_adjustment_id set. dry_run=true returns the payload
+// preview + resolved adjust account without actually posting.
+export interface PushWoToQboResult {
+  ok: boolean;
+  no_change?: boolean;
+  dry_run?: boolean;
+  work_order_id: string;
+  qbo_inventory_adjustment_id?: string;
+  qbo_pushed_at?: string;
+  adjust_account?: { id: string; name: string };
+  line_count?: number;
+  skipped?: { qbo_item_id: string; reason: string }[];
+  payload?: unknown;
+  error?: string;
+  duration_ms?: number;
+  message?: string;
+}
+
+export async function pushWorkOrderToQbo(
+  woId: string,
+  opts: { dry_run?: boolean; adjust_account_id?: string | null } = {},
+): Promise<PushWoToQboResult> {
+  const token = await _sbToken();
+  const res = await fetch(SB_URL + '/functions/v1/push-qbo-item', {
+    method: 'POST',
+    headers: {
+      apikey: SB_KEY,
+      Authorization: 'Bearer ' + token,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      action: 'postInventoryAdjustment',
+      work_order_id: woId,
+      dry_run: opts.dry_run ?? false,
+      adjust_account_id: opts.adjust_account_id ?? null,
+    }),
+  });
+  const j = (await res.json()) as PushWoToQboResult;
+  if (!res.ok || j.ok === false) {
+    throw new Error(j.error || ('push-qbo-item failed: HTTP ' + res.status));
+  }
+  return j;
 }

--- a/app/src/pages/production/WorkOrdersTab.tsx
+++ b/app/src/pages/production/WorkOrdersTab.tsx
@@ -5,6 +5,7 @@ import {
   ProductBom, WorkOrder, WorkOrderCosts, WorkOrderStatus,
   closeWorkOrder, consumeWorkOrder, createWorkOrder,
   fetchBomLines, fetchWorkOrderCosts, voidWorkOrder,
+  pushWorkOrderToQbo,
   ProductBomLine,
 } from '../../lib/production';
 import { InventoryLocation } from '../../lib/inventoryControl';
@@ -334,6 +335,33 @@ function WorkOrderDetailModal({
     finally { setBusy(false); }
   }
 
+  async function doPushToQbo() {
+    if (!confirm(
+      'Push this work order to QuickBooks as an InventoryAdjustment?\n\n' +
+      'This will create a single adjustment record in QBO with:\n' +
+      '  • Negative quantity for each component consumed\n' +
+      '  • Positive quantity for the finished good produced\n\n' +
+      'Only Inventory-tracked items are pushed; Service / NonInventory components are skipped.\n\n' +
+      'The push is idempotent — once successful, this button hides.'
+    )) return;
+    setBusy(true);
+    try {
+      const result = await pushWorkOrderToQbo(woId);
+      if (result.no_change) {
+        toast.info('Already synced to QBO.');
+      } else {
+        toast.success(
+          `Pushed to QBO as InventoryAdjustment #${result.qbo_inventory_adjustment_id}` +
+          (result.skipped && result.skipped.length > 0
+            ? ` (${result.skipped.length} non-inventory items skipped)`
+            : ''),
+        );
+      }
+      onChanged();
+    } catch (e) { toast.error('QBO push failed: ' + errMsg(e)); }
+    finally { setBusy(false); }
+  }
+
   async function doVoid() {
     const reason = prompt('Void reason?');
     if (!reason) return;
@@ -530,6 +558,21 @@ function WorkOrderDetailModal({
           </div>
         )}
 
+        {wo.status === 'closed' && wo.qbo_inventory_adjustment_id && (
+          <div style={{
+            marginTop: 14, padding: '8px 12px', fontSize: 11,
+            background: 'rgba(91,181,240,0.08)', borderLeft: '3px solid var(--ac)',
+            borderRadius: 4, color: 'var(--tx2)',
+          }}>
+            ✓ Synced to QBO as InventoryAdjustment <code style={{ color: 'var(--ac)' }}>#{wo.qbo_inventory_adjustment_id}</code>
+            {wo.qbo_pushed_at && (
+              <span style={{ marginLeft: 8, color: 'var(--mt)' }}>
+                · {new Date(wo.qbo_pushed_at).toLocaleString()}
+              </span>
+            )}
+          </div>
+        )}
+
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18, flexWrap: 'wrap' }}>
           <button onClick={printSummary} style={btnSecondary()}>
             <FileText size={12} style={{ marginRight: 4, verticalAlign: -1 }} /> Print
@@ -542,6 +585,12 @@ function WorkOrderDetailModal({
           )}
           {wo.status === 'consumed' && (
             <button onClick={doClose} disabled={busy} style={btnPrimary()}>Close + lock costs →</button>
+          )}
+          {wo.status === 'closed' && !wo.qbo_inventory_adjustment_id && (
+            <button onClick={doPushToQbo} disabled={busy} style={btnPrimary()}
+              title="Post an InventoryAdjustment to QBO with the consume + yield deltas from this work order">
+              Push to QBO →
+            </button>
           )}
         </div>
       </div>

--- a/supabase/migrations/20260514d_work_orders_qbo_pushed.sql
+++ b/supabase/migrations/20260514d_work_orders_qbo_pushed.sql
@@ -1,0 +1,26 @@
+-- v0.9.40 — track QBO writeback state on work orders.
+--
+-- Phase 3 from 20260514b: closing a work order in BRIX needs to push
+-- the consume + yield movements to QBO as an InventoryAdjustment so
+-- QBO's Item.QtyOnHand reflects the build. Without this, BRIX and
+-- QBO drift apart every time a WO closes.
+--
+-- These columns let us:
+-- (a) Prevent double-push — the UI hides the "Push to QBO" button
+--     once qbo_inventory_adjustment_id is set.
+-- (b) Surface when the WO was synced + which adjustment record it
+--     became in QBO (for audit / drill-through).
+-- (c) Capture push errors without losing the WO state.
+--
+-- The edge function push-qbo-item v4 adds a `postInventoryAdjustment`
+-- action that reads ops.inventory_movements for the WO, builds a QBO
+-- InventoryAdjustment payload, POSTs it, and writes the resulting id
+-- back to ops.work_orders via service-role.
+
+ALTER TABLE ops.work_orders
+  ADD COLUMN IF NOT EXISTS qbo_inventory_adjustment_id text,
+  ADD COLUMN IF NOT EXISTS qbo_pushed_at               timestamptz,
+  ADD COLUMN IF NOT EXISTS qbo_push_error              text;
+
+CREATE INDEX IF NOT EXISTS idx_wo_qbo_pushed_at ON ops.work_orders(qbo_pushed_at)
+  WHERE qbo_inventory_adjustment_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Closes Phase 3 of the production module: when a work order is closed in BRIX, its consume + yield movements now push to QBO as an `InventoryAdjustment` so QBO's `Item.QtyOnHand` reflects the build. Without this, BRIX and QBO drift apart every time a WO closes.

## What's in this PR

- **Migration `20260514d_work_orders_qbo_pushed.sql`** (already applied live) — adds `qbo_inventory_adjustment_id`, `qbo_pushed_at`, `qbo_push_error` columns to `ops.work_orders` + a partial index on pushed WOs.
- **Edge function `push-qbo-item` v4** (already deployed) — adds `postInventoryAdjustment` action that:
  - Validates `status='closed'` and not already pushed (idempotent).
  - Reads `ops.inventory_movements` for the WO, signs deltas (consume = negative, yield = positive), aggregates per `qbo_item_id`.
  - Fetches each item's QBO metadata, skips non-Inventory types (returns `skipped[]`).
  - Resolves the adjust account (preferred id or `Inventory Shrinkage` / `Inventory Adjustment` / `Cost of Goods Sold` fallback).
  - POSTs to `/v3/company/{realm}/inventoryadjustment` and persists the returned id back to the WO row.
  - Supports `dry_run=true` for preview (returns payload + resolved account without posting).
- **Client lib** (`app/src/lib/production.ts`) — extended `WorkOrder` type with the new columns; new `PushWoToQboResult` interface + `pushWorkOrderToQbo()` calling the edge function.
- **UI** (`app/src/pages/production/WorkOrdersTab.tsx`) — "Push to QBO" button on closed WOs that haven't been pushed yet, and a "✓ Synced to QBO as InventoryAdjustment #X" indicator once pushed.

## Test plan

- [ ] Close a work order in BRIX (existing flow), then click **Push to QBO** in the detail modal.
- [ ] Verify the resulting `InventoryAdjustment` in QBO matches the WO's consume/yield lines.
- [ ] Re-click Push — should refuse (idempotent: `qbo_inventory_adjustment_id` already set).
- [ ] Try a WO that includes a non-Inventory component — should report `skipped[]` and still adjust the inventory items.
- [ ] Confirm `tsc -b` passes (it does locally).

PO module follows as a separate PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9VBgzstoVBXndAFqPR3Fs)_