### PR TITLE
fix(customers): tree-group rows span full row, not selectable

### DIFF
--- a/app/src/pages/settings/CustomersSettingsEditor.tsx
+++ b/app/src/pages/settings/CustomersSettingsEditor.tsx
@@ -399,6 +399,14 @@ export function CustomersSettingsEditor() {
 
   const groupingColDef = useMemo(() => ({
     headerName: 'Channel / Customer', width: 320, hideDescendantCount: false,
+    // Group rows are channel/parent headers — they have no qbo_customer_id and
+    // shouldn't render the per-row dropdowns. Spanning the whole grid keeps
+    // them visually distinct and stops e.g. the "Primary Channel" select from
+    // showing "— unassigned —" on every section header.
+    colSpan: (_value: unknown, row: Record<string, unknown>) => {
+      const isGroup = row?.qbo_customer_id == null;
+      return isGroup ? columns.length + 1 : 1;
+    },
     renderCell: (params: {
       rowNode: { type: string; groupingKey?: string | number | null; depth?: number };
       row: { display_name?: string; is_sub_customer?: boolean; ar_total?: number };
@@ -431,7 +439,7 @@ export function CustomersSettingsEditor() {
       );
     },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  }) as any, []);
+  }) as any, [columns.length]);
 
   if (!rows) return <div className="ld">Loading customers…</div>;
 
@@ -521,6 +529,7 @@ export function CustomersSettingsEditor() {
             treeData getTreeDataPath={getTreeDataPath}
             groupingColDef={groupingColDef}
             density="compact" pagination disableRowSelectionOnClick
+            isRowSelectable={(p) => (p.row as { qbo_customer_id?: string }).qbo_customer_id != null}
             pageSizeOptions={[20, 40, 60, 100, 250, { value: -1, label: 'All' }]}
             defaultGroupingExpansionDepth={1}
             initialState={{


### PR DESCRIPTION
## Summary

Channel section headers in the Customers settings grid (the "— Wholesale —", "— Direct Sales —", "— Unassigned —" rows) were silently rendering every column's `renderCell` — including the `<select>— unassigned —</select>` dropdown for Primary Channel. That made each header row look like an extra customer with no channel assigned, which is what the user saw as "headers counting as unassigned channels."

Two fixes, both following the same pattern already used in `ItemsSettingsEditor`:

1. **`groupingColDef.colSpan`** — group rows now span the full grid width, so no per-column dropdowns render on them.
2. **`isRowSelectable`** — group rows can't be selected (defensive; checkbox selection isn't enabled today but this stops a future accidental selection).

## Test plan

- [ ] Open Settings → Customers. Confirm section headers (channels) show only the header label, no dropdowns inline.
- [ ] Confirm "UNASSIGNED CHANNEL" KPI count matches actual customers with no `primary_channel` (no longer inflated by header rows).
- [ ] Try clicking a section header — confirm nothing edits, no save fires.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9VBgzstoVBXndAFqPR3Fs)_