### PR TITLE
fix(inventory): default 'Managed only' to TRUE

### DIFF
--- a/app/src/pages/InventoryPage.tsx
+++ b/app/src/pages/InventoryPage.tsx
@@ -136,7 +136,7 @@ function SearchInput({ value, onChange, placeholder = 'Search items…' }: {
 export function InventoryPage() {
   const [tab, setTab] = useState<TabId>('reorder');
   const [lookback, setLookback] = useState(90);
-  const [managedOnly, setManagedOnly] = useState(false);
+  const [managedOnly, setManagedOnly] = useState(true);
   const [rows, setRows] = useState<InventoryHealthRow[] | null>(null);
 
   function load() {


### PR DESCRIPTION
## Summary

Inventory page (Reorder · Velocity · Excludes) defaults the "Managed only" filter to TRUE. The user can still uncheck it to see all items.

## Why

The toggle 404 (fixed in #76) meant most items had `is_managed=false` because no one could turn them on. Inventory pages were showing the entire QBO item catalog, including non-inventory NonInventory + Service items the user never asked to manage.

Now: only items where the user has explicitly clicked Managed in the Items master appear.

## Test plan

- [ ] Open Inventory page → "Managed only" is checked.
- [ ] Item count drops from full catalog to the small subset the user has toggled.
- [ ] Uncheck Managed only → full list reappears.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9VBgzstoVBXndAFqPR3Fs)_