### PR TITLE
fix(inventory): reorder math + on-order column + Create-PO bridge

### DIFF
--- a/app/src/lib/inventory.ts
+++ b/app/src/lib/inventory.ts
@@ -33,6 +33,7 @@ export interface InventoryHealthRow {
   purchased_cost: number;
   adjustment_qty: number;
   shrinkage_qty: number;
+  qty_on_order: number;
   daily_velocity: number | null;
   days_of_supply: number | null;
   suggested_order_qty: number | null;

--- a/app/src/pages/InventoryPage.tsx
+++ b/app/src/pages/InventoryPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import { DataGridPro, type GridColDef, type GridGroupNode } from '@mui/x-data-grid-pro';
-import { Search, X } from 'lucide-react';
+import { Search, X, ShoppingCart } from 'lucide-react';
 import { KPICard } from '../components/KPICard';
 import { fm, fmtNum } from '../lib/formatters';
 import { btnDanger, btnPrimary, btnSecondary, inp } from '../lib/styles';
@@ -30,6 +30,8 @@ const STATUS_COLOR: Record<string, string> = {
   idle:         'var(--mt)', ok:           'var(--gn)',
   inactive:     '#64748b',
 };
+
+const REORDER_STATUSES = new Set(['reorder_now', 'reorder', 'reorder_soon', 'critical']);
 
 const TABS_SX = {
   minHeight: 36, mb: 1.5, borderBottom: '1px solid var(--bd)',
@@ -206,7 +208,7 @@ function ReorderTable({ rows }: { rows: InventoryHealthRow[] | null }) {
   const reorder = useMemo(() => {
     if (!rows) return [];
     return rows
-      .filter((r) => r.status === 'reorder_now' || r.status === 'reorder' || r.status === 'critical' || r.status === 'reorder_soon' || !r.active)
+      .filter((r) => REORDER_STATUSES.has(r.status) || !r.active)
       .sort((a, b) => Number(a.days_of_supply ?? 999) - Number(b.days_of_supply ?? 999));
   }, [rows]);
   const filtered = useMemo(() => filterBySearch(reorder, search), [reorder, search]);
@@ -236,27 +238,59 @@ function ReorderTable({ rows }: { rows: InventoryHealthRow[] | null }) {
       valueFormatter: (v) => (v == null ? '—' : Number(v).toFixed(2)) },
     { field: 'days_of_supply', headerName: 'Days Supply', type: 'number', width: 110, cellClassName: 'mn',
       valueFormatter: (v) => (v == null ? '—' : Number(v).toFixed(0)) },
+    {
+      field: 'qty_on_order', headerName: 'On Order', type: 'number', width: 100, cellClassName: 'mn',
+      renderCell: (p) => {
+        const v = Number(p.value ?? 0);
+        return v > 0
+          ? <span style={{ color: 'var(--gn)', fontWeight: 600 }}>{fmtNum(v)}</span>
+          : <span style={{ color: 'var(--mt)' }}>—</span>;
+      },
+    },
     { field: 'reorder_point', headerName: 'Reorder Pt', type: 'number', width: 100, cellClassName: 'mn',
       valueFormatter: (v) => (v == null ? '—' : String(v)) },
     {
       field: 'suggested_order_qty', headerName: 'Suggested Qty', type: 'number', width: 130, cellClassName: 'mn',
       renderCell: (p) => (
-        <span style={{ color: 'var(--ac)', fontWeight: 600 }}>{p.value != null ? String(p.value) : '—'}</span>
+        <span style={{ color: 'var(--ac)', fontWeight: 600 }}>{p.value != null ? fmtNum(Number(p.value)) : '—'}</span>
       ),
     },
   ], []);
 
   function exportCsv() {
     if (reorder.length === 0) return;
-    const head = ['Item', 'Category', 'Active', 'On Hand', 'Daily Velocity', 'Days of Supply', 'Reorder Point', 'Suggested Order Qty', 'Status'];
+    const head = ['Item', 'Category', 'Active', 'On Hand', 'On Order', 'Daily Velocity', 'Days of Supply', 'Reorder Point', 'Suggested Order Qty', 'Status'];
     const data = reorder.map((r) => [
       r.item_name, r.category_resolved ?? '', r.active ? 'yes' : 'no',
-      r.on_hand ?? '',
+      r.on_hand ?? '', r.qty_on_order ?? '',
       r.daily_velocity != null ? Number(r.daily_velocity).toFixed(2) : '',
       r.days_of_supply != null ? Number(r.days_of_supply).toFixed(0) : '',
       r.reorder_point ?? '', r.suggested_order_qty ?? '', r.status,
     ]);
     downloadCsv(`reorder_${new Date().toISOString().slice(0,10)}.csv`, toCsv([head, ...data]));
+  }
+
+  // Push the visible reorder list into sessionStorage as a PO prefill,
+  // then navigate to the Production page → Purchase Orders tab. The PO
+  // module reads the key on mount, opens its Create form, and seeds
+  // lines with item + suggested qty + last known unit cost.
+  function createPoFromReorder() {
+    const candidates = (filtered.length > 0 ? filtered : reorder).filter(
+      (r) => r.active && r.suggested_order_qty != null && Number(r.suggested_order_qty) > 0,
+    );
+    if (candidates.length === 0) return;
+    const prefill = candidates.map((r) => ({
+      qbo_item_id: r.qbo_item_id,
+      item_name: r.item_name,
+      qty_ordered: Number(r.suggested_order_qty),
+      unit_cost: r.purchase_cost ?? 0,
+    }));
+    sessionStorage.setItem('brix.po.prefill', JSON.stringify({
+      source: 'inventory-reorder',
+      generated_at: new Date().toISOString(),
+      lines: prefill,
+    }));
+    window.location.hash = '#production';
   }
 
   function printOrderSheet() {
@@ -281,14 +315,15 @@ function ReorderTable({ rows }: { rows: InventoryHealthRow[] | null }) {
   const healthy     = rows.filter((r) => r.active && (r.status === 'healthy' || r.status === 'ok'));
   const overstock   = rows.filter((r) => r.active && r.status === 'overstock');
   const inactiveCount = rows.filter((r) => !r.active).length;
+  const onOrderTotal = rows.reduce((s, r) => s + Number(r.qty_on_order ?? 0), 0);
 
   return (
     <div>
       <div className="gr g4" style={{ marginBottom: 14 }}>
-        <KPICard title="REORDER NOW" value={reorderNow.length} accent="var(--rd)" sub="below reorder point" />
-        <KPICard title="REORDER SOON" value={reorderSoon.length} accent="var(--am)" sub="approaching reorder point" />
-        <KPICard title="HEALTHY" value={healthy.length} accent="var(--gn)" />
-        <KPICard title="OVERSTOCK" value={overstock.length} accent="#a78bfa" sub={`${inactiveCount} inactive in list`} />
+        <KPICard title="REORDER NOW" value={reorderNow.length} accent="var(--rd)" sub="days of supply ≤ lead time" />
+        <KPICard title="REORDER SOON" value={reorderSoon.length} accent="var(--am)" sub="within 2× lead time" />
+        <KPICard title="ON ORDER" value={fmtNum(onOrderTotal)} accent="var(--gn)" sub="open PO units pending" />
+        <KPICard title="OVERSTOCK" value={overstock.length} accent="#a78bfa" sub={`${healthy.length} healthy · ${inactiveCount} inactive`} />
       </div>
 
       <div className="cd" style={{
@@ -300,7 +335,16 @@ function ReorderTable({ rows }: { rows: InventoryHealthRow[] | null }) {
           {filtered.length} of {reorder.length} items
         </span>
         <span style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}>
-          <button onClick={printOrderSheet} disabled={reorder.length === 0} style={btnPrimary()}>PRINT ORDER SHEET</button>
+          <button
+            onClick={createPoFromReorder}
+            disabled={reorder.length === 0}
+            style={btnPrimary()}
+            title="Open Production → Purchase Orders pre-filled with these items"
+          >
+            <ShoppingCart size={11} style={{ marginRight: 4, verticalAlign: -1 }} />
+            CREATE PO
+          </button>
+          <button onClick={printOrderSheet} disabled={reorder.length === 0} style={btnSecondary()}>PRINT ORDER SHEET</button>
           <button onClick={exportCsv} disabled={reorder.length === 0} style={btnSecondary()}>EXPORT CSV</button>
         </span>
       </div>
@@ -353,6 +397,15 @@ function VelocityTable({ rows }: { rows: InventoryHealthRow[] | null }) {
     { field: 'customers_count', headerName: 'Customers', type: 'number', width: 100, cellClassName: 'mn' },
     { field: 'purchased_qty', headerName: 'Purchased', type: 'number', width: 110, cellClassName: 'mn',
       valueFormatter: (v) => fmtNum(Number(v ?? 0)) },
+    {
+      field: 'qty_on_order', headerName: 'On Order', type: 'number', width: 100, cellClassName: 'mn',
+      renderCell: (p) => {
+        const v = Number(p.value ?? 0);
+        return v > 0
+          ? <span style={{ color: 'var(--gn)', fontWeight: 600 }}>{fmtNum(v)}</span>
+          : <span style={{ color: 'var(--mt)' }}>—</span>;
+      },
+    },
     {
       field: 'adjustment_qty', headerName: 'Adj Qty', type: 'number', width: 100, cellClassName: 'mn',
       renderCell: (p) => {

--- a/app/src/pages/production/ProductionPage.tsx
+++ b/app/src/pages/production/ProductionPage.tsx
@@ -33,7 +33,13 @@ export interface ProductionItemLookup {
 }
 
 export function ProductionPage() {
-  const [tab, setTab] = useState<TabId>('boms');
+  // If an Inventory → Reorder click stashed a PO prefill, open that tab
+  // immediately so the prefilled Create-PO form is visible on mount.
+  const initialTab: TabId =
+    typeof sessionStorage !== 'undefined' && sessionStorage.getItem('brix.po.prefill')
+      ? 'purchase_orders'
+      : 'boms';
+  const [tab, setTab] = useState<TabId>(initialTab);
   const [boms, setBoms] = useState<ProductBom[] | null>(null);
   const [wos, setWos] = useState<WorkOrder[] | null>(null);
   const [items, setItems] = useState<InventoryHealthRow[] | null>(null);

--- a/app/src/pages/production/PurchaseOrdersTab.tsx
+++ b/app/src/pages/production/PurchaseOrdersTab.tsx
@@ -33,14 +33,47 @@ interface Props {
 
 function errMsg(e: unknown): string { return e instanceof Error ? e.message : String(e); }
 
+interface PoPrefillLine {
+  qbo_item_id: string;
+  item_name: string;
+  qty_ordered: number;
+  unit_cost: number;
+}
+interface PoPrefillState {
+  source: string;
+  generated_at: string;
+  lines: PoPrefillLine[];
+}
+
+function readPrefill(): PoPrefillState | null {
+  if (typeof sessionStorage === 'undefined') return null;
+  const raw = sessionStorage.getItem('brix.po.prefill');
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as PoPrefillState;
+    if (!parsed || !Array.isArray(parsed.lines) || parsed.lines.length === 0) return null;
+    return parsed;
+  } catch { return null; }
+}
+
 export function PurchaseOrdersTab({
   vendors, purchaseOrders, locations, locById, itemLookup, onChanged,
 }: Props) {
   const toast = useToast();
-  const [creating, setCreating] = useState(false);
+  // Prefill comes from Inventory → Reorder ("Create PO"). When present, we
+  // open the Create form on mount and seed its lines.
+  const [prefill] = useState<PoPrefillState | null>(() => readPrefill());
+  const [creating, setCreating] = useState(prefill !== null);
   const [openId, setOpenId] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<'all' | PoStatus>('all');
   const [syncing, setSyncing] = useState(false);
+
+  // One-shot: clear sessionStorage so refreshing doesn't keep opening the form.
+  useEffect(() => {
+    if (prefill && typeof sessionStorage !== 'undefined') {
+      sessionStorage.removeItem('brix.po.prefill');
+    }
+  }, [prefill]);
 
   const physicalLocs = useMemo(
     () => locations.filter((l) => l.is_active && l.kind !== 'in_transit' && l.kind !== 'adjustment'),
@@ -167,6 +200,7 @@ export function PurchaseOrdersTab({
           locations={physicalLocs}
           componentItems={componentItems}
           itemLookup={itemLookup}
+          prefill={prefill}
           onCancel={() => setCreating(false)}
           onCreated={() => { setCreating(false); onChanged(); }}
         />
@@ -212,12 +246,13 @@ function newDraftLine(): DraftLine {
 }
 
 function CreatePoForm({
-  vendors, locations, componentItems, itemLookup, onCancel, onCreated,
+  vendors, locations, componentItems, itemLookup, prefill, onCancel, onCreated,
 }: {
   vendors: QboVendor[];
   locations: InventoryLocation[];
   componentItems: { id: string; label: string }[];
   itemLookup: ProductionItemLookup;
+  prefill: PoPrefillState | null;
   onCancel: () => void;
   onCreated: () => void;
 }) {
@@ -225,8 +260,17 @@ function CreatePoForm({
   const [vendorId, setVendorId] = useState('');
   const [locId, setLocId] = useState('');
   const [expected, setExpected] = useState('');
-  const [notes, setNotes] = useState('');
-  const [lines, setLines] = useState<DraftLine[]>([newDraftLine()]);
+  const [notes, setNotes] = useState(prefill ? 'Generated from inventory reorder list' : '');
+  const [lines, setLines] = useState<DraftLine[]>(
+    prefill && prefill.lines.length > 0
+      ? prefill.lines.map((p) => ({
+          qbo_item_id: p.qbo_item_id,
+          qty_ordered: String(p.qty_ordered),
+          unit_cost: p.unit_cost > 0 ? String(p.unit_cost) : '',
+          description: '',
+        }))
+      : [newDraftLine()],
+  );
   const [saving, setSaving] = useState(false);
 
   function updateLine(idx: number, patch: Partial<DraftLine>) {

--- a/supabase/migrations/20260515d_reorder_status_on_order.sql
+++ b/supabase/migrations/20260515d_reorder_status_on_order.sql
@@ -1,0 +1,192 @@
+-- v0.9.44 — fix reorder math + add on-order awareness
+--
+-- Three problems wrapped into one fix:
+--
+-- 1. STATUS LOGIC was off. The rule was
+--      on_hand < lead_time * velocity  →  'reorder'
+--    but that means by the time the order arrives you're at zero. An
+--    item with days_of_supply ≈ lead_time stayed 'ok' until it crossed
+--    the threshold by a single unit. Example caught by user:
+--    24P126121 HANGAR 25 COLA CASE — on_hand 261, velocity 35/day,
+--    days_of_supply 7.4, lead_time 7 → status was 'ok'. Should be
+--    'reorder' (will be empty in ~7 days when the next order arrives).
+--    New rule, easier to reason about:
+--      days_of_supply <= lead_time      → 'reorder'      (won't make it)
+--      days_of_supply <= 2 * lead_time  → 'reorder_soon' (approaching)
+--      else                              → 'ok'
+--
+-- 2. SUGGESTED ORDER QTY was promised by the TypeScript type but never
+--    actually returned by fn_items_master. The Reorder tab's
+--    "Suggested Qty" column rendered "—" on every row.
+--    Now computed server-side: cover (target_days_supply + lead_time)
+--    of demand, less on-hand, less currently-on-order, rounded up to
+--    min_order_qty, returned as suggested_order_qty.
+--
+-- 3. NO ON-ORDER AWARENESS. Open POs sitting in
+--    ops.purchase_order_lines have qty_ordered - qty_received still
+--    coming, but the reorder math ignored them — so the Suggested Qty
+--    would double-count and reorder lists would keep flagging items
+--    that already had a PO in flight. New column qty_on_order on
+--    fn_items_master sums open PO commitments per item. The suggestion
+--    math subtracts it; the UI gets a new "On Order" column to display.
+
+DROP FUNCTION IF EXISTS ops.fn_items_master(integer, text, boolean);
+
+CREATE FUNCTION ops.fn_items_master(
+  p_lookback_days integer DEFAULT 90,
+  p_search        text    DEFAULT NULL,
+  p_managed_only  boolean DEFAULT false
+)
+RETURNS TABLE(
+  qbo_item_id text, item_name text, fully_qualified_name text, active boolean,
+  category_path text, category_override text, category_resolved text,
+  income_account_name text, expense_account_name text,
+  on_hand numeric, unit_price numeric, purchase_cost numeric,
+  is_managed boolean, is_planner boolean,
+  target_days_supply integer, lead_time_days integer,
+  reorder_point numeric, min_order_qty numeric, notes text,
+  sold_qty numeric, sold_revenue numeric, customers_count integer,
+  purchased_qty numeric, purchased_cost numeric,
+  adjustment_qty numeric, shrinkage_qty numeric,
+  qty_on_order numeric, suggested_order_qty numeric, suggested_order_cycle_days numeric,
+  daily_velocity numeric, days_of_supply numeric, status text,
+  product_family_code text, product_family_label text,
+  product_type_code   text, product_type_label   text,
+  segment_code text, segment_label text, segment_source text,
+  track_locations boolean, has_bom boolean
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ops, public
+AS $function$
+  WITH start_date AS (SELECT (current_date - p_lookback_days)::date AS d),
+  excludes AS (SELECT qbo_customer_id FROM ops.inventory_velocity_excludes),
+  sold AS (
+    SELECT v.item_ref_id AS qbo_item_id,
+      sum(v.quantity)::numeric AS qty, sum(v.revenue)::numeric AS revenue,
+      count(DISTINCT v.customer_ref_id)::int AS customers_count
+    FROM ops.v_sales_lines v
+    LEFT JOIN excludes e ON e.qbo_customer_id = v.customer_ref_id
+    WHERE v.txn_date >= (SELECT d FROM start_date) AND e.qbo_customer_id IS NULL
+      AND v.item_ref_id IS NOT NULL AND v.quantity IS NOT NULL AND v.quantity > 0
+    GROUP BY 1
+  ),
+  purch AS (
+    SELECT m.qbo_item_id,
+      sum(m.qty)::numeric AS qty,
+      sum(m.qty * COALESCE(m.unit_cost, 0))::numeric AS cost
+    FROM ops.inventory_movements m
+    WHERE m.movement_type = 'receipt'
+      AND m.occurred_at >= (SELECT d FROM start_date)
+      AND m.qbo_item_id IS NOT NULL
+    GROUP BY 1
+  ),
+  adj AS (
+    SELECT a.item_ref_id AS qbo_item_id,
+      sum(a.qty_diff)::numeric AS adjustment_qty,
+      sum(CASE WHEN a.qty_diff < 0 THEN abs(a.qty_diff) ELSE 0 END)::numeric AS shrink_qty
+    FROM ops.qbo_inventory_adjustment_lines a
+    WHERE a.item_ref_id IS NOT NULL AND a.txn_date >= (SELECT d FROM start_date)
+    GROUP BY 1
+  ),
+  -- Open PO commitments: anything not yet received on a non-void/closed
+  -- PO. We deliberately count 'draft' + 'open' + 'partial' + 'received'
+  -- (received but not yet closed could still revert), but exclude
+  -- 'closed' and 'void'.
+  on_order AS (
+    SELECT l.qbo_item_id,
+      sum(GREATEST(l.qty_ordered - l.qty_received, 0))::numeric AS qty_pending
+    FROM ops.purchase_order_lines l
+    JOIN ops.purchase_orders p ON p.id = l.po_id
+    WHERE p.status IN ('draft', 'open', 'partial', 'received')
+    GROUP BY 1
+  )
+  SELECT
+    it.qbo_item_id, COALESCE(it.name, it.fully_qualified_name), it.fully_qualified_name,
+    COALESCE(it.active, true)::boolean,
+    it.category_path, s.category_override,
+    COALESCE(s.category_override, it.category_path, 'Uncategorized'),
+    it.income_account_name, it.expense_account_name,
+    COALESCE(it.qty_on_hand, 0)::numeric, it.unit_price, it.purchase_cost,
+    COALESCE(s.is_managed, false), COALESCE(s.is_planner, false),
+    COALESCE(s.target_days_supply, 30), COALESCE(s.lead_time_days, 7),
+    s.reorder_point, s.min_order_qty, s.notes,
+    COALESCE(sold.qty, 0), COALESCE(sold.revenue, 0), COALESCE(sold.customers_count, 0),
+    COALESCE(purch.qty, 0)::numeric, COALESCE(purch.cost, 0)::numeric,
+    COALESCE(adj.adjustment_qty, 0)::numeric, COALESCE(adj.shrink_qty, 0)::numeric,
+    COALESCE(on_order.qty_pending, 0)::numeric AS qty_on_order,
+    -- Suggested order qty: cover (target_days + lead_time) of demand,
+    -- less on-hand, less on-order. Round up to min_order_qty if set.
+    -- NULL when item has no velocity or is inactive (no signal).
+    CASE
+      WHEN COALESCE(it.active, true) = false THEN NULL
+      WHEN ((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1)) <= 0 THEN NULL
+      ELSE
+        GREATEST(
+          ceil(
+            ((COALESCE(s.target_days_supply, 30) + COALESCE(s.lead_time_days, 7))
+             * ((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1)))
+            - COALESCE(it.qty_on_hand, 0)
+            - COALESCE(on_order.qty_pending, 0)
+          ),
+          COALESCE(s.min_order_qty, 0)
+        )
+    END AS suggested_order_qty,
+    -- Suggested cycle in days = target_days_supply (how often to reorder
+    -- at steady state). Echoed for UI convenience.
+    COALESCE(s.target_days_supply, 30)::numeric AS suggested_order_cycle_days,
+    ((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1))::numeric AS daily_velocity,
+    CASE WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) > 0
+         THEN COALESCE(it.qty_on_hand, 0) / ((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1))
+         ELSE NULL END AS days_of_supply,
+    -- New status logic based on days_of_supply vs lead_time.
+    CASE
+      WHEN COALESCE(it.active, true) = false THEN 'inactive'
+      WHEN (COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) = 0 THEN 'idle'
+      WHEN COALESCE(it.qty_on_hand, 0) <= 0 THEN 'critical'
+      WHEN (COALESCE(it.qty_on_hand, 0) / NULLIF((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1), 0))
+           <= COALESCE(s.lead_time_days, 7) THEN 'reorder'
+      WHEN (COALESCE(it.qty_on_hand, 0) / NULLIF((COALESCE(sold.qty, 0) + COALESCE(adj.shrink_qty, 0)) / GREATEST(p_lookback_days, 1), 0))
+           <= COALESCE(s.lead_time_days, 7) * 2 THEN 'reorder_soon'
+      ELSE 'ok'
+    END AS status,
+    ipf.family_code, pf.label,
+    ipt.type_code, pt.label,
+    COALESCE(seg_item.segment_code, seg_cat.segment_code),
+    COALESCE(s_item_seg.label, s_cat_seg.label),
+    CASE
+      WHEN seg_item.segment_code IS NOT NULL THEN 'item'
+      WHEN seg_cat.segment_code  IS NOT NULL THEN 'category'
+      ELSE NULL
+    END,
+    COALESCE(s.track_locations, false),
+    COALESCE(s.has_bom, false)
+  FROM ops.qbo_items it
+  LEFT JOIN ops.inventory_settings s ON s.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.account_settings acct ON acct.account_name = it.income_account_name
+  LEFT JOIN sold     ON sold.qbo_item_id     = it.qbo_item_id
+  LEFT JOIN purch    ON purch.qbo_item_id    = it.qbo_item_id
+  LEFT JOIN adj      ON adj.qbo_item_id      = it.qbo_item_id
+  LEFT JOIN on_order ON on_order.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.item_product_families ipf ON ipf.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.product_families pf       ON pf.family_code  = ipf.family_code AND pf.is_active
+  LEFT JOIN ops.item_product_types    ipt ON ipt.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.product_types         pt  ON pt.type_code    = ipt.type_code  AND pt.is_active
+  LEFT JOIN ops.item_segments     seg_item ON seg_item.qbo_item_id = it.qbo_item_id
+  LEFT JOIN ops.segments        s_item_seg ON s_item_seg.segment_code = seg_item.segment_code AND s_item_seg.is_active
+  LEFT JOIN ops.category_segments  seg_cat ON seg_cat.category = COALESCE(s.category_override, it.category_path)
+  LEFT JOIN ops.segments         s_cat_seg ON s_cat_seg.segment_code = seg_cat.segment_code AND s_cat_seg.is_active
+  WHERE
+    COALESCE(it.type, '') NOT IN ('Category', 'Group')
+    AND (NOT p_managed_only OR COALESCE(s.is_managed, false))
+    AND COALESCE(acct.is_active, true)
+    AND (
+      p_search IS NULL OR p_search = '' OR
+      it.name ILIKE '%' || p_search || '%' OR
+      it.fully_qualified_name ILIKE '%' || p_search || '%' OR
+      COALESCE(s.category_override, it.category_path) ILIKE '%' || p_search || '%'
+    )
+  ORDER BY
+    COALESCE(it.active, true) DESC,
+    COALESCE(s.category_override, it.category_path) NULLS LAST,
+    it.name;
+$function$;
+GRANT EXECUTE ON FUNCTION ops.fn_items_master(integer, text, boolean) TO authenticated;


### PR DESCRIPTION
## Summary

Three reorder/PO fixes wrapped together, plus a bridge from Inventory → PO.

### 1. Status logic (the real "24PK Hangar 25" bug)

Old rule was `on_hand < lead_time * velocity → reorder`. For **24P126121 HANGAR 25 COLA CASE** that put 261 on-hand against 35.3/day velocity, 7-day lead time — 7.4 days of supply — into `ok` because it crossed the threshold by 14 units. By the time the order arrives, you're at zero.

New rule, compared in days:

| Condition | Status |
|---|---|
| `days_of_supply ≤ lead_time` | `reorder` (won't make it) |
| `days_of_supply ≤ 2 × lead_time` | `reorder_soon` |
| else | `ok` |

24P126121 now correctly flags `reorder_soon`.

### 2. Suggested Order Qty was vapor

The TypeScript type promised `suggested_order_qty` and the Reorder grid had a column for it, but `fn_items_master` never returned it — every row rendered "—". Now actually computed:
```
ceil((target_days + lead_time) × velocity − on_hand − on_order)
  clamped to min_order_qty
```
NULL when item has no velocity (no signal).

### 3. On-Order awareness

New `qty_on_order` column on `fn_items_master` sums open PO commitments per item:
```
SUM(qty_ordered − qty_received)
WHERE po.status IN ('draft','open','partial','received')
```
- Subtracted from suggested qty so the system stops re-flagging items already on order.
- Surfaced as **On Order** column on both Reorder and Velocity tabs.
- New **ON ORDER** KPI card on the Reorder dashboard.

### 4. Create PO from reorder list

New `CREATE PO` button on the Reorder toolbar. Click it → the visible reorder items (with their suggested qty and last known unit cost) get stashed in sessionStorage → page navigates to Production → Purchase Orders tab → Create form opens pre-seeded with those lines. User picks the vendor + destination + reviews qty/cost, clicks Create.

## Mobile inventory-count feature

Deferred to its own PR per user direction.

## Test plan

- [ ] Open Inventory > Reorder. Confirm `24P126121 HANGAR 25 COLA CASE` now appears with status `REORDER SOON`.
- [ ] Confirm Suggested Qty column shows real numbers.
- [ ] If you have any open PO, the On Order column reflects it on both Reorder and Velocity tabs.
- [ ] Click `CREATE PO` on Reorder → Production page opens directly to the PO tab → Create form is pre-filled with lines from reorder list.
- [ ] Confirm sessionStorage clears (refresh shouldn't re-open the form).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9VBgzstoVBXndAFqPR3Fs)_