### PR TITLE
feat(stock): Reconcile vs QBO tab — surface + fix BRIX/QBO drift

### DIFF
--- a/app/src/lib/inventoryControl.ts
+++ b/app/src/lib/inventoryControl.ts
@@ -155,6 +155,49 @@ export async function fetchOnHand(): Promise<OnHandRow[]> {
   return sbq<OnHandRow>('v_inventory_on_hand', 'select=*');
 }
 
+// ── Inventory drift / reconcile ──────────────────────────────────────────
+// One row per active item with QBO's qty_on_hand vs the BRIX
+// warehouse-only sum from v_inventory_on_hand. Drift > 0 = BRIX short.
+
+export interface InventoryDriftRow {
+  qbo_item_id: string;
+  item_name: string;
+  item_type: string | null;
+  active: boolean;
+  qbo_qty: number;
+  brix_qty: number;
+  brix_in_transit: number;
+  brix_adjustment_offset: number;
+  drift: number;
+  track_locations: boolean;
+  is_managed: boolean;
+  category_resolved: string;
+}
+
+export async function fetchInventoryDrift(): Promise<InventoryDriftRow[]> {
+  return sbq<InventoryDriftRow>('v_inventory_drift', 'select=*&order=drift.desc');
+}
+
+export interface ReconcileResult {
+  qbo_item_id: string;
+  drift_resolved: number;
+  movement_id: string | null;
+  message: string;
+}
+
+export async function reconcileInventoryToQbo(args: {
+  qbo_item_id: string;
+  target_location_id?: string | null;
+  reason?: string | null;
+}): Promise<ReconcileResult> {
+  const rows = await sbrpc<ReconcileResult[]>('fn_reconcile_inventory_to_qbo', {
+    p_qbo_item_id:        args.qbo_item_id,
+    p_target_location_id: args.target_location_id ?? null,
+    p_reason:             args.reason ?? null,
+  });
+  return Array.isArray(rows) ? rows[0] : (rows as unknown as ReconcileResult);
+}
+
 // ── Location CRUD ────────────────────────────────────────────────────────
 
 export type NewLocation = Pick<InventoryLocation,

--- a/app/src/pages/stock/StockPage.tsx
+++ b/app/src/pages/stock/StockPage.tsx
@@ -18,8 +18,9 @@ import { StockOnHandTab } from './StockOnHandTab';
 import { StockTransfersTab } from './StockTransfersTab';
 import { StockMovementsTab } from './StockMovementsTab';
 import { StockAdjustmentsTab } from './StockAdjustmentsTab';
+import { StockReconcileTab } from './StockReconcileTab';
 
-type TabId = 'on_hand' | 'locations' | 'transfers' | 'adjustments' | 'movements';
+type TabId = 'on_hand' | 'locations' | 'transfers' | 'adjustments' | 'movements' | 'reconcile';
 
 const TABS: { id: TabId; label: string }[] = [
   { id: 'on_hand',     label: 'On-Hand'     },
@@ -27,6 +28,7 @@ const TABS: { id: TabId; label: string }[] = [
   { id: 'transfers',   label: 'Transfers'   },
   { id: 'adjustments', label: 'Adjustments' },
   { id: 'movements',   label: 'Movements'   },
+  { id: 'reconcile',   label: 'Reconcile vs QBO' },
 ];
 
 export interface ItemLookup {
@@ -142,6 +144,7 @@ export function StockPage() {
           itemLookup={itemLookup}
         />
       )}
+      {tab === 'reconcile' && <StockReconcileTab onRefresh={reloadAll} />}
     </div>
   );
 }

--- a/app/src/pages/stock/StockReconcileTab.tsx
+++ b/app/src/pages/stock/StockReconcileTab.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useMemo, useState } from 'react';
+import { DataGridPro, type GridColDef } from '@mui/x-data-grid-pro';
+import { Search, X, CheckCircle2 } from 'lucide-react';
+import { fmtNum } from '../../lib/formatters';
+import { btnPrimary, btnSecondary } from '../../lib/styles';
+import { KPICard } from '../../components/KPICard';
+import {
+  InventoryDriftRow,
+  fetchInventoryDrift,
+  reconcileInventoryToQbo,
+} from '../../lib/inventoryControl';
+import { useToast } from '../../lib/toast';
+import { GRID_SX } from './stockStyles';
+
+// "Reconcile" tab — surfaces drift between QBO's Item.QtyOnHand
+// (the authoritative total) and BRIX's per-location ledger sum
+// (warehouses only). One-click reconcile posts a balancing
+// inventory_movements row of type 'adjustment' between the target
+// warehouse and the virtual Adjustment Counter.
+
+interface Props {
+  onRefresh: () => void;
+}
+
+function errMsg(e: unknown): string { return e instanceof Error ? e.message : String(e); }
+
+export function StockReconcileTab({ onRefresh }: Props) {
+  const toast = useToast();
+  const [rows, setRows] = useState<InventoryDriftRow[] | null>(null);
+  const [search, setSearch] = useState('');
+  const [trackedOnly, setTrackedOnly] = useState(true);
+  const [busy, setBusy] = useState<Record<string, boolean>>({});
+  const [bulkBusy, setBulkBusy] = useState(false);
+
+  function load() {
+    setRows(null);
+    fetchInventoryDrift().then(setRows).catch((e) => {
+      toast.error(errMsg(e));
+      setRows([]);
+    });
+  }
+  useEffect(load, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const filtered = useMemo(() => {
+    if (!rows) return [];
+    const q = search.trim().toLowerCase();
+    return rows.filter((r) => {
+      if (Number(r.drift) === 0) return false;
+      if (trackedOnly && !r.track_locations) return false;
+      if (!q) return true;
+      return r.item_name.toLowerCase().includes(q)
+          || r.category_resolved.toLowerCase().includes(q);
+    });
+  }, [rows, search, trackedOnly]);
+
+  const gridRows = useMemo(
+    () => filtered.map((r) => ({ ...r, id: r.qbo_item_id })),
+    [filtered],
+  );
+
+  async function reconcileOne(qbo_item_id: string) {
+    setBusy((cur) => ({ ...cur, [qbo_item_id]: true }));
+    try {
+      const res = await reconcileInventoryToQbo({ qbo_item_id });
+      toast.success(res.message + ' · drift ' + fmtNum(Math.abs(res.drift_resolved)));
+      // refresh just this row inline
+      const refreshed = await fetchInventoryDrift();
+      setRows(refreshed);
+      onRefresh();
+    } catch (e) { toast.error(errMsg(e)); }
+    finally {
+      setBusy((cur) => { const n = { ...cur }; delete n[qbo_item_id]; return n; });
+    }
+  }
+
+  async function reconcileAll() {
+    if (filtered.length === 0) return;
+    if (!confirm('Reconcile ' + filtered.length + ' item(s) to QBO? This posts a balancing adjustment per item — net inventory across all locations stays the same, but each warehouse total will now match QBO.')) return;
+    setBulkBusy(true);
+    let okCount = 0;
+    const errors: string[] = [];
+    for (const r of filtered) {
+      try {
+        await reconcileInventoryToQbo({ qbo_item_id: r.qbo_item_id });
+        okCount++;
+      } catch (e) { errors.push(r.item_name + ': ' + errMsg(e)); }
+    }
+    if (errors.length === 0) {
+      toast.success('Reconciled ' + okCount + ' item' + (okCount === 1 ? '' : 's'));
+    } else {
+      toast.error('Reconciled ' + okCount + ' · ' + errors.length + ' error' + (errors.length === 1 ? '' : 's') + ': ' + errors.slice(0, 3).join(' · '));
+    }
+    const refreshed = await fetchInventoryDrift();
+    setRows(refreshed);
+    onRefresh();
+    setBulkBusy(false);
+  }
+
+  const columns: GridColDef[] = useMemo(() => [
+    { field: 'item_name', headerName: 'Item', flex: 1, minWidth: 240,
+      renderCell: (p) => <span style={{ fontWeight: 600 }}>{String(p.value)}</span> },
+    { field: 'category_resolved', headerName: 'Category', width: 200,
+      renderCell: (p) => <span style={{ color: 'var(--mt)', fontSize: 11 }}>{String(p.value ?? '')}</span> },
+    { field: 'qbo_qty', headerName: 'QBO Qty', type: 'number', width: 100, cellClassName: 'mn',
+      valueFormatter: (v) => fmtNum(Number(v ?? 0)) },
+    { field: 'brix_qty', headerName: 'BRIX Qty', type: 'number', width: 100, cellClassName: 'mn',
+      valueFormatter: (v) => fmtNum(Number(v ?? 0)) },
+    {
+      field: 'drift', headerName: 'Drift', type: 'number', width: 110, cellClassName: 'mn',
+      renderCell: (p) => {
+        const v = Number(p.value ?? 0);
+        if (v === 0) return <span style={{ color: 'var(--mt)' }}>0</span>;
+        const sign = v > 0 ? '+' : '−';
+        return (
+          <span style={{ color: v > 0 ? 'var(--am)' : 'var(--rd)', fontWeight: 700 }}>
+            {sign}{fmtNum(Math.abs(v))}
+          </span>
+        );
+      },
+    },
+    {
+      field: 'reconcile', headerName: '', width: 140, sortable: false, filterable: false,
+      renderCell: (p) => (
+        <button
+          onClick={() => reconcileOne(String(p.row.qbo_item_id))}
+          disabled={!!busy[String(p.row.qbo_item_id)]}
+          style={{ ...btnSecondary(), padding: '4px 10px', fontSize: 10 }}
+          title="Post a balancing adjustment so BRIX matches QBO"
+        >
+          {busy[String(p.row.qbo_item_id)] ? '…' : 'Reconcile'}
+        </button>
+      ),
+    },
+  ], [busy]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (rows === null) {
+    return <div className="ld">Loading drift…</div>;
+  }
+
+  const totalDriftAbs = (rows ?? [])
+    .filter((r) => !trackedOnly || r.track_locations)
+    .reduce((s, r) => s + Math.abs(Number(r.drift ?? 0)), 0);
+  const itemsWithDrift = (rows ?? [])
+    .filter((r) => Number(r.drift ?? 0) !== 0 && (!trackedOnly || r.track_locations));
+  const longCount  = itemsWithDrift.filter((r) => Number(r.drift) < 0).length;
+  const shortCount = itemsWithDrift.filter((r) => Number(r.drift) > 0).length;
+  const cleanCount = (rows ?? []).filter((r) => Number(r.drift ?? 0) === 0 && (!trackedOnly || r.track_locations)).length;
+
+  return (
+    <div>
+      <div className="gr g4" style={{ marginBottom: 14 }}>
+        <KPICard title="ITEMS WITH DRIFT" value={itemsWithDrift.length} accent={itemsWithDrift.length > 0 ? 'var(--am)' : undefined} sub="QBO ≠ BRIX warehouse sum" />
+        <KPICard title="BRIX SHORT" value={shortCount} accent="var(--am)" sub="QBO has more — counted as missing" />
+        <KPICard title="BRIX LONG" value={longCount} accent="var(--rd)" sub="BRIX has more — likely uncaught sales" />
+        <KPICard title="IN AGREEMENT" value={cleanCount} accent="var(--gn)" sub={fmtNum(totalDriftAbs) + ' units total drift'} />
+      </div>
+
+      <div className="cd" style={{
+        padding: '8px 12px', marginBottom: 12,
+        background: 'rgba(91,181,240,0.04)', border: '1px solid var(--bd)',
+        fontSize: 11, color: 'var(--mt)',
+      }}>
+        <strong style={{ color: 'var(--tx)' }}>What is this?</strong> QBO's <code>Item.QtyOnHand</code> is the authoritative total.
+        BRIX's <code>inventory_movements</code> ledger sums to a different number when QBO has booked
+        sales/adjustments that never made it back into the ledger. Clicking <strong>Reconcile</strong> posts a balancing
+        movement between the warehouse and the virtual <em>Adjustment Counter</em>, so the warehouse sum matches QBO again.
+        Net inventory across <em>all</em> locations stays the same.
+      </div>
+
+      <div className="cd" style={{
+        padding: '10px 12px', marginBottom: 14, display: 'flex',
+        gap: 8, alignItems: 'center', flexWrap: 'wrap', fontSize: 11,
+      }}>
+        <div style={{
+          display: 'inline-flex', alignItems: 'center', gap: 6,
+          padding: '4px 10px', height: 30, borderRadius: 4,
+          background: 'var(--bg)', border: '1px solid var(--bd)', minWidth: 240,
+        }}>
+          <Search size={13} strokeWidth={2.2} color="var(--mt)" aria-hidden="true" />
+          <input type="text" value={search} placeholder="Search items…"
+            onChange={(e) => setSearch(e.target.value)}
+            style={{ background: 'transparent', border: 'none', outline: 'none',
+              color: 'var(--tx)', fontFamily: 'var(--ff-mono)', fontSize: 12, flex: 1, padding: 0 }} />
+          {search && (
+            <button onClick={() => setSearch('')} aria-label="Clear"
+              style={{ background: 'transparent', border: 'none', cursor: 'pointer', padding: 2, display: 'inline-flex' }}>
+              <X size={12} strokeWidth={2.4} color="var(--mt)" />
+            </button>
+          )}
+        </div>
+        <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer', color: 'var(--mt)' }}>
+          <input type="checkbox" checked={trackedOnly}
+            onChange={(e) => setTrackedOnly(e.target.checked)}
+            style={{ accentColor: 'var(--ac)' }} />
+          Tracked items only
+        </label>
+        <span style={{ color: 'var(--mt)', marginLeft: 6 }}>
+          {gridRows.length} item{gridRows.length === 1 ? '' : 's'} need reconciliation
+        </span>
+        <span style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}>
+          <button onClick={load} style={btnSecondary()}>Refresh</button>
+          <button onClick={reconcileAll} disabled={gridRows.length === 0 || bulkBusy} style={btnPrimary()}>
+            {bulkBusy ? 'Reconciling…' : 'RECONCILE ALL'}
+          </button>
+        </span>
+      </div>
+
+      <div className="cd" style={{ padding: 0, overflow: 'hidden' }}>
+        {gridRows.length === 0 ? (
+          <div className="ld" style={{ padding: 24, display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--gn)' }}>
+            <CheckCircle2 size={14} /> All items in agreement with QBO.
+          </div>
+        ) : (
+          <DataGridPro
+            rows={gridRows}
+            columns={columns}
+            sx={GRID_SX}
+            density="compact"
+            disableRowSelectionOnClick
+            initialState={{ sorting: { sortModel: [{ field: 'drift', sort: 'desc' }] } }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20260515e_inventory_drift_reconcile.sql
+++ b/supabase/migrations/20260515e_inventory_drift_reconcile.sql
@@ -1,0 +1,159 @@
+-- v0.9.45 — inventory drift visibility + one-click reconcile to QBO
+--
+-- Problem: Stock screen says one number, Inventory screen says another.
+-- The two views read from different sources:
+--   Stock     ← ops.inventory_movements (BRIX per-location ledger)
+--   Inventory ← ops.qbo_items.qty_on_hand (QBO snapshot)
+-- When location tracking was first enabled, each item was seeded with a
+-- +qty movement to its home warehouse and a balancing −qty at the virtual
+-- "Adjustment Counter" location. Since then QBO has booked sales,
+-- adjustments, and bills against qty_on_hand — but those never made it
+-- into the BRIX ledger, so the two drift apart. Example caught by user:
+-- 24P126121 HANGAR 25 COLA CASE — Stock 311 / Inventory 261 / drift 50.
+--
+-- This migration adds:
+--   1. ops.v_inventory_drift — per-item view of QBO total vs BRIX total,
+--      ignoring the virtual "Adjustment Counter" / "In Transit" rows so
+--      only real warehouses count toward the BRIX side.
+--   2. ops.fn_reconcile_inventory_to_qbo(p_qbo_item_id, p_target_location_id)
+--      — posts an offsetting movement_type='adjustment' row between the
+--      target real location and the Adjustment Counter virtual location so
+--      that SUM(real-location BRIX) == QBO qty_on_hand. Idempotent: a
+--      second call with no drift does nothing.
+--
+-- Follow-up phases (separate PRs):
+--   • Auto-emit inventory_movements rows from QBO sales so the ledger
+--     keeps pace with QBO instead of drifting.
+--   • Merge Stock + Inventory under one page with tabs.
+--   • Mobile cycle-count app that posts adjustments + emails report.
+
+CREATE OR REPLACE VIEW ops.v_inventory_drift AS
+WITH brix AS (
+  SELECT
+    v.qbo_item_id,
+    sum(CASE WHEN l.kind = 'warehouse' THEN v.on_hand ELSE 0 END)::numeric AS brix_warehouse_total,
+    sum(CASE WHEN l.kind = 'in_transit' THEN v.on_hand ELSE 0 END)::numeric AS brix_in_transit,
+    sum(CASE WHEN l.kind = 'adjustment' THEN v.on_hand ELSE 0 END)::numeric AS brix_adjustment_offset,
+    sum(v.on_hand)::numeric AS brix_all_locations
+  FROM ops.v_inventory_on_hand v
+  JOIN ops.inventory_locations l ON l.id = v.location_id
+  GROUP BY v.qbo_item_id
+)
+SELECT
+  it.qbo_item_id,
+  COALESCE(it.name, it.fully_qualified_name)         AS item_name,
+  it.type                                            AS item_type,
+  COALESCE(it.active, true)                          AS active,
+  COALESCE(it.qty_on_hand, 0)::numeric               AS qbo_qty,
+  COALESCE(b.brix_warehouse_total, 0)::numeric       AS brix_qty,
+  COALESCE(b.brix_in_transit, 0)::numeric            AS brix_in_transit,
+  COALESCE(b.brix_adjustment_offset, 0)::numeric     AS brix_adjustment_offset,
+  (COALESCE(it.qty_on_hand, 0) - COALESCE(b.brix_warehouse_total, 0))::numeric AS drift,
+  COALESCE(s.track_locations, false)                 AS track_locations,
+  COALESCE(s.is_managed, false)                      AS is_managed,
+  COALESCE(s.category_override, it.category_path, 'Uncategorized') AS category_resolved
+FROM ops.qbo_items it
+LEFT JOIN brix b ON b.qbo_item_id = it.qbo_item_id
+LEFT JOIN ops.inventory_settings s ON s.qbo_item_id = it.qbo_item_id
+WHERE COALESCE(it.active, true)
+  AND COALESCE(it.type, '') NOT IN ('Category', 'Group');
+
+GRANT SELECT ON ops.v_inventory_drift TO authenticated;
+
+
+-- ── fn_reconcile_inventory_to_qbo ─────────────────────────────────────────
+-- Aligns BRIX ledger to QBO's qty_on_hand for one item. Posts an
+-- inventory_movements row of type 'adjustment' that nets out the drift
+-- against the virtual Adjustment Counter location.
+--
+-- Sign rules:
+--   drift > 0  (QBO has more than BRIX shows) → +drift to target location,
+--               −drift from Adjustment Counter
+--   drift < 0  (BRIX shows more than QBO has) → +abs(drift) to Adjustment
+--               Counter, −abs(drift) from target location
+-- This is balanced (movement_type='adjustment' takes one from / one to),
+-- so net inventory is unchanged when summed across both legs, but the
+-- warehouse-only sum now matches QBO.
+CREATE OR REPLACE FUNCTION ops.fn_reconcile_inventory_to_qbo(
+  p_qbo_item_id        TEXT,
+  p_target_location_id UUID DEFAULT NULL,
+  p_reason             TEXT DEFAULT NULL
+)
+RETURNS TABLE(
+  qbo_item_id    text,
+  drift_resolved numeric,
+  movement_id    uuid,
+  message        text
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ops, pg_temp AS $$
+DECLARE
+  v_drift   NUMERIC;
+  v_target  UUID := p_target_location_id;
+  v_adj     UUID;
+  v_actor   UUID := auth.uid();
+  v_mv_id   UUID;
+BEGIN
+  IF p_qbo_item_id IS NULL OR p_qbo_item_id = '' THEN
+    RAISE EXCEPTION 'qbo_item_id is required';
+  END IF;
+
+  SELECT drift INTO v_drift FROM ops.v_inventory_drift WHERE v_inventory_drift.qbo_item_id = p_qbo_item_id;
+  IF v_drift IS NULL THEN
+    RAISE EXCEPTION 'item not found in v_inventory_drift';
+  END IF;
+  IF v_drift = 0 THEN
+    RETURN QUERY SELECT p_qbo_item_id, 0::numeric, NULL::uuid, 'no drift to reconcile';
+    RETURN;
+  END IF;
+
+  SELECT id INTO v_adj FROM ops.inventory_locations WHERE kind = 'adjustment' AND is_active LIMIT 1;
+  IF v_adj IS NULL THEN
+    RAISE EXCEPTION 'no active adjustment location configured';
+  END IF;
+
+  IF v_target IS NULL THEN
+    SELECT id INTO v_target FROM ops.inventory_locations
+      WHERE kind = 'warehouse' AND is_active
+      ORDER BY (code = 'BRIX-WAREHOUSE') DESC, name ASC LIMIT 1;
+    IF v_target IS NULL THEN
+      RAISE EXCEPTION 'no active warehouse to receive reconcile adjustment';
+    END IF;
+  END IF;
+
+  -- Always book the adjustment as a balanced movement. movement_type
+  -- 'adjustment' requires qty > 0 with from/to locations; we pick the
+  -- direction based on drift sign.
+  IF v_drift > 0 THEN
+    -- BRIX is short → add to warehouse, take from adjustment counter.
+    INSERT INTO ops.inventory_movements (
+      movement_type, qbo_item_id, qty,
+      from_location_id, to_location_id, unit_cost,
+      source_doc_type, source_doc_id,
+      occurred_at, created_by, notes
+    ) VALUES (
+      'adjustment', p_qbo_item_id, v_drift,
+      v_adj, v_target, NULL,
+      'reconcile_qbo', NULL,
+      now(), v_actor,
+      COALESCE(p_reason, 'Reconcile to QBO · BRIX was short ' || v_drift)
+    ) RETURNING id INTO v_mv_id;
+  ELSE
+    -- BRIX is long → remove from warehouse, add to adjustment counter.
+    INSERT INTO ops.inventory_movements (
+      movement_type, qbo_item_id, qty,
+      from_location_id, to_location_id, unit_cost,
+      source_doc_type, source_doc_id,
+      occurred_at, created_by, notes
+    ) VALUES (
+      'adjustment', p_qbo_item_id, abs(v_drift),
+      v_target, v_adj, NULL,
+      'reconcile_qbo', NULL,
+      now(), v_actor,
+      COALESCE(p_reason, 'Reconcile to QBO · BRIX was over by ' || abs(v_drift))
+    ) RETURNING id INTO v_mv_id;
+  END IF;
+
+  RETURN QUERY SELECT p_qbo_item_id, v_drift, v_mv_id, 'reconciled';
+END;
+$$;
+GRANT EXECUTE ON FUNCTION ops.fn_reconcile_inventory_to_qbo(TEXT, UUID, TEXT) TO authenticated;


### PR DESCRIPTION
## Summary

Stock and Inventory were disagreeing — Stock showed 311 for 24P126121 HANGAR 25 COLA CASE, Inventory showed 261. That's not a bug in either screen; it's a drift between two parallel data sources that nothing reconciles:

```
QBO Item.QtyOnHand           ←  Sales, Inventory Adjustments, Bills (everything that hits QBO)
ops.inventory_movements       ←  Transfers, PO receipts, WO consume/yield (BRIX-side only)
```

When location tracking was first turned on, BRIX seeded each item with a `+qty` movement to its home warehouse + an offsetting `−qty` at the virtual *Adjustment Counter*. Since then QBO has kept tallying, BRIX has not. The drift grows.

This PR makes the drift visible and one-click fixable. **Migration already applied live.**

## What's in this PR

- **`ops.v_inventory_drift`** — per-item view of `qbo_qty − brix_qty` (warehouses only; the virtual Adjustment Counter / In Transit rows are excluded so they don't artificially balance the math).
- **`ops.fn_reconcile_inventory_to_qbo(qbo_item_id, target_location_id, reason)`** — posts a single balanced `inventory_movements` row of `movement_type='adjustment'` between the target warehouse and the Adjustment Counter. Net inventory across *all* locations stays the same; the warehouse total now matches QBO. Idempotent: zero-drift items are no-ops.
- **New `Stock → Reconcile vs QBO` tab** — KPIs (items with drift, short, long, in agreement), per-row Reconcile button, bulk Reconcile All. Includes a short explainer block at the top.

## Sample drift on Hangar 25 line (before reconcile)

| Item | QBO | BRIX | Drift |
|---|---:|---:|---:|
| 3G1091 HANGAR 25 DIET COLA | 267 | 86 | +181 |
| 3G6121 HANGAR 25 COLA | 381 | 208 | +173 |
| 24P126121 HANGAR 25 COLA CASE | 261 | 311 | −50 |
| 24P121091 HANGAR 25 DIET COLA CASE | 510 | 552 | −42 |

## What's next (separate PRs)

- Sales → ledger emission so the drift stops accumulating.
- Merge the Stock + Inventory pages into one surface.
- Mobile cycle-count flow (signatures + emailed report).

## Test plan

- [ ] Open `Stock → Reconcile vs QBO`. Confirm 24P126121 HANGAR 25 COLA CASE shows drift −50.
- [ ] Click Reconcile on that row. Confirm drift returns to 0 and the on-hand at Brix Warehouse drops by 50.
- [ ] Open `Stock → Movements`. Confirm the adjustment row was created (source_doc_type='reconcile_qbo').
- [ ] Bulk **Reconcile All** on the remaining drift items.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9VBgzstoVBXndAFqPR3Fs)_