### PR TITLE
chore: add public/_redirects for Cloudflare Pages backup mirror

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,24 @@
+# Cloudflare Pages / Netlify-compatible redirects.
+#
+# Both Cloudflare Pages and Netlify read _redirects in this same format
+# so the same file works on both deploy targets. Keep this in sync with
+# the [[redirects]] blocks in netlify.toml whenever you add a new rule.
+#
+# Order matters — the first matching rule wins. Function redirects MUST
+# come before the SPA fallback or the SPA catch-all swallows them.
+
+# ── Brixpense API → underlying Netlify Functions ──────────────────────────
+/api/expense-request-decide     /.netlify/functions/expense-request-decide     200
+/api/expense-request-notify     /.netlify/functions/expense-request-notify     200
+/api/expense-request-link-bill  /.netlify/functions/expense-request-link-bill  200
+/api/expense-ocr                /.netlify/functions/expense-ocr                200
+
+# ── Expense app SPA fallback (any unmatched /expense/* → expense SPA) ────
+/expense/*                      /expense/index.html                            200
+
+# ── Margin app SPA fallback (any unmatched /sales-next/* → margin SPA) ───
+/sales-next/*                   /sales-next/index.html                         200
+
+# ── Legacy /ops/ → /sales/ ───────────────────────────────────────────────
+/ops                            /sales/                                        301!
+/ops/*                          /sales/:splat                                  301!


### PR DESCRIPTION
## Summary

First step of multi-CDN failover. Adds `public/_redirects` so a parallel Cloudflare Pages deploy has the same routing rules as Netlify.

## Why

Today Netlify's edge went 100% 403 (`host_not_allowed`) across every site on the platform — including their own dashboard. Recovery time: ~40 min and counting at the time of this PR. The only architectural fix is multi-CDN: same git repo, two deploy targets.

Cloudflare Pages reads `_redirects` in the **identical Netlify format**, so one file works on both targets.

## Setup steps (operator)

After merging:

1. Log into Cloudflare → **Workers & Pages → Create application → Pages → Connect to Git**
2. Pick `apbg-billing`, branch `main`
3. Build command: `node architecture/lint-manifest.mjs && mkdir -p public/docs && cp -r docs/. public/docs/ && npm install --prefix app && npm run build --prefix app && npm install --prefix app-expense && npm run build --prefix app-expense`
4. Output dir: `public`
5. Env vars: copy `VITE_MUI_X_LICENSE` and any other `VITE_*` from Netlify
6. Deploy. You'll get `apbg-billing.pages.dev`.

## What this PR does NOT do

- Doesn't change anything that's running on Netlify today
- Doesn't set up DNS failover (manual or automatic) — that's the next step
- Doesn't port Netlify Functions to Cloudflare Pages Functions (Functions stay Netlify-only for now; the SPA fallback + static assets get the second home)

## Test plan

- [ ] Netlify build still passes (no change in behavior — `_redirects` rules match `netlify.toml` exactly)
- [ ] Cloudflare Pages first build succeeds with the build command above
- [ ] `apbg-billing.pages.dev/expense/` serves the expense SPA
- [ ] `apbg-billing.pages.dev/margin/` (or wherever the margin SPA lives) serves
- [ ] When Netlify is up: both URLs serve identical content

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9VBgzstoVBXndAFqPR3Fs)_