### PR TITLE
brixpense: allow superadmin to self-approve their own purchase request

### DIFF
--- a/app-expense/src/pages/ApprovalPage.tsx
+++ b/app-expense/src/pages/ApprovalPage.tsx
@@ -52,6 +52,13 @@ export default function ApprovalPage() {
   const myName = (session?.user?.user_metadata as { full_name?: string } | undefined)?.full_name
     || session?.user?.email
     || '';
+  // Server-controlled role (vs. user-editable user_metadata). Mirrors the
+  // backend escape hatch in expense-request-decide.mjs so a superadmin who
+  // routed a PR to themselves can actually reach the Approve button —
+  // without this, the page-load gate below short-circuits to 'forbidden'
+  // and the relaxed backend gate is unreachable through the UI.
+  const myRole = (session?.user?.app_metadata as { role?: string } | undefined)?.role || null;
+  const isSuperadmin = myRole === 'superadmin';
 
   useEffect(() => {
     if (myName && !signerName) setSignerName(myName);
@@ -85,7 +92,7 @@ export default function ApprovalPage() {
         setState('forbidden');
         return;
       }
-      if (req.submitted_by === session.user.id) {
+      if (req.submitted_by === session.user.id && !isSuperadmin) {
         setState('forbidden');
         return;
       }

--- a/netlify/functions/expense-request-decide.mjs
+++ b/netlify/functions/expense-request-decide.mjs
@@ -85,6 +85,15 @@ export default async function handler(req) {
   const { data: { user }, error: authErr } = await supabase.auth.getUser();
   if (authErr || !user) return err('Invalid or expired session', 401);
   const callerEmail = String(user.email || '').toLowerCase();
+  // Server-controlled role lives in app_metadata (vs. user-editable
+  // user_metadata). Superadmins can submit-to-self and approve-from-self
+  // for their own admin/back-office workflows; the regular separation-of-
+  // duties block still applies to everyone else. RLS already permits the
+  // update (the submitter == manager_email row matches both update_self
+  // and update_manager policies), so this is the only place that gates
+  // the case.
+  const callerRole = user.app_metadata?.role || null;
+  const isSuperadmin = callerRole === 'superadmin';
 
   const { data: request, error: fetchErr } = await supabase
     .schema('ops')
@@ -95,7 +104,9 @@ export default async function handler(req) {
   if (fetchErr || !request) return err(`Expense request not found (id=${requestId}, err=${fetchErr?.message || 'no row'})`, 404);
 
   if (request.status !== 'pending') return err(`Cannot decide on a request with status "${request.status}"`, 409);
-  if (request.submitted_by === user.id) return err('You cannot approve your own request.', 403);
+  if (request.submitted_by === user.id && !isSuperadmin) {
+    return err('You cannot approve your own request.', 403);
+  }
   const routedTo = String(request.manager_email || '').toLowerCase();
   if (!routedTo || routedTo !== callerEmail) {
     return err(`This request is routed to ${request.manager_email || 'no one'}, not to you (${user.email}).`, 403);
@@ -112,6 +123,8 @@ export default async function handler(req) {
     decline_reason: decline_reason ? decline_reason.trim() : null,
     free_text_note: notes || null,
     decided_at: now,
+    self_approval: request.submitted_by === user.id,
+    caller_role: callerRole,
   });
 
   const { error: approvalErr } = await supabase.schema('ops').from('expense_approvals').insert({


### PR DESCRIPTION
## Why

> "The app is still hanging up on the approval. I need it to be able to submit to myself and approve from myself as a super admin."

`expense-request-decide.mjs:98` unconditionally rejects self-approval:
```js
if (request.submitted_by === user.id) return err('You cannot approve your own request.', 403);
```

Even a superadmin who submits a PR to themselves (legitimate back-office workflow) gets 403'd after typing signature + initials, which is why the form felt like it was "hanging up" on the final step.

## What

Allow `app_metadata.role === 'superadmin'` to bypass the self-approval check. Server-controlled role (vs. user-editable `user_metadata`), so this can't be self-elevated.

```diff
+ const callerRole = user.app_metadata?.role || null;
+ const isSuperadmin = callerRole === 'superadmin';
- if (request.submitted_by === user.id) return err('You cannot approve your own request.', 403);
+ if (request.submitted_by === user.id && !isSuperadmin) {
+   return err('You cannot approve your own request.', 403);
+ }
```

RLS allows the underlying UPDATE already — `expense_requests_update_self` and `expense_requests_update_manager` policies both match the submitter==manager_email row, so no DB migration. This was purely an application-level gate.

Audit log entry now records `self_approval` (boolean) and `caller_role` so the approvals log distinguishes superadmin self-approves from normal ones — useful for SOX-style reviewers later.

## Test plan

- [ ] As `skypace@brixbev.com` (superadmin per `auth.users.app_metadata.role`): submit a PR with `manager_email = skypace@brixbev.com`, navigate to `/expense/review/:id`, sign + Approve → expect `200` + `new_status: 'awaiting_invoice'`, NOT `403 "You cannot approve your own request."`
- [ ] As a non-superadmin employee: same flow → still 403 (separation of duties intact)
- [ ] Approving someone else's PR (normal flow) → still works
- [ ] Audit row in `ops.expense_approvals` for the superadmin self-approval has `notes` JSON containing `"self_approval":true,"caller_role":"superadmin"`

---
_Generated by [Claude Code](https://claude.ai/code/session_012iWSo6eNQAbMQTUdu16gwA)_