### PR TITLE
margin/inventory: per-PO QBO picker — On Order includes QBO-direct POs

### DIFF
--- a/app/src/lib/qboPosPicker.ts
+++ b/app/src/lib/qboPosPicker.ts
@@ -5,7 +5,7 @@
 // (imported from QBO via this picker). Picking a PO here writes a shadow
 // row that fn_items_master joins against.
 
-import { supabase } from './supabase';
+import { _sbToken } from './supabase';
 
 export interface QboPoPickerLine {
   line_num: number;
@@ -46,8 +46,7 @@ export interface QboPoPickerPreview {
 }
 
 async function bearer(): Promise<string> {
-  const { data } = await supabase.auth.getSession();
-  const token = data?.session?.access_token;
+  const token = await _sbToken();
   if (!token) throw new Error('Not signed in');
   return `Bearer ${token}`;
 }

--- a/app/src/lib/qboPosPicker.ts
+++ b/app/src/lib/qboPosPicker.ts
@@ -1,0 +1,91 @@
+// Data layer for the QBO Purchase Order picker (Pull POs from QBO).
+//
+// Receipt-level summary: the inventory page's "On Order" column sums lines
+// from BOTH ops.purchase_orders (BRIX-native) AND ops.qbo_purchase_orders
+// (imported from QBO via this picker). Picking a PO here writes a shadow
+// row that fn_items_master joins against.
+
+import { supabase } from './supabase';
+
+export interface QboPoPickerLine {
+  line_num: number;
+  description: string;
+  amount: number | null;
+  qbo_item_id: string | null;
+  qbo_item_name: string | null;
+  qty: number | null;
+  unit_cost: number | null;
+  account_id: string | null;
+  account_name: string | null;
+}
+
+export interface QboPoPickerItem {
+  qbo_id: string;
+  doc_number: string | null;
+  vendor_id: string | null;
+  vendor_name: string | null;
+  txn_date: string | null;
+  total_amt: number | null;
+  status: string;
+  memo: string | null;
+  line_count: number;
+  lines: QboPoPickerLine[];
+  /** True if this PO has been imported before via this picker. */
+  already_imported: boolean;
+  imported_at: string | null;
+  last_synced_at: string | null;
+  /** True if a BRIX-native PO in ops.purchase_orders already links to this
+   *  QBO id. Re-importing would double-count, so the UI disables these. */
+  brix_native: boolean;
+}
+
+export interface QboPoPickerPreview {
+  count: number;
+  open_pickable: number;
+  items: QboPoPickerItem[];
+}
+
+async function bearer(): Promise<string> {
+  const { data } = await supabase.auth.getSession();
+  const token = data?.session?.access_token;
+  if (!token) throw new Error('Not signed in');
+  return `Bearer ${token}`;
+}
+
+export async function fetchQboPosPreview(): Promise<QboPoPickerPreview> {
+  const res = await fetch('/margin/.netlify/functions/qbo-pos-preview', {
+    method: 'GET',
+    headers: { Authorization: await bearer() },
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`Preview failed (${res.status}): ${detail.slice(0, 300)}`);
+  }
+  return (await res.json()) as QboPoPickerPreview;
+}
+
+export interface ImportResult {
+  requested: number;
+  imported: number;
+  skipped: number;
+  missing: number;
+  details: {
+    imported: Array<{ qbo_id: string; doc_number: string | null; lines: number }>;
+    skipped: Array<{ qbo_id: string; reason: string }>;
+    missing: string[];
+  };
+}
+
+export async function importQboPos(ids: string[]): Promise<ImportResult> {
+  if (ids.length === 0) return { requested: 0, imported: 0, skipped: 0, missing: 0, details: { imported: [], skipped: [], missing: [] } };
+  const res = await fetch('/margin/.netlify/functions/qbo-pos-import', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: await bearer() },
+    body: JSON.stringify({ ids }),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`Import failed (${res.status}): ${detail.slice(0, 300)}`);
+  }
+  return (await res.json()) as ImportResult;
+}

--- a/app/src/pages/production/PurchaseOrdersTab.tsx
+++ b/app/src/pages/production/PurchaseOrdersTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { DataGridPro, type GridColDef } from '@mui/x-data-grid-pro';
-import { Plus, X as XIcon, RefreshCw, Truck, CheckCircle2 } from 'lucide-react';
+import { Plus, X as XIcon, RefreshCw, Truck, CheckCircle2, Download } from 'lucide-react';
+import { QboPosPickerModal } from './QboPosPickerModal';
 import {
   PoStatus, PurchaseOrderLine, PurchaseOrderRow, QboVendor,
   closePurchaseOrder, createPurchaseOrder, fetchPoLines,
@@ -67,6 +68,9 @@ export function PurchaseOrdersTab({
   const [openId, setOpenId] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<'all' | PoStatus>('all');
   const [syncing, setSyncing] = useState(false);
+  // Modal for importing QBO-direct POs into the shadow tables so the
+  // inventory On Order column reflects POs that were never created in BRIX.
+  const [pullingQboPos, setPullingQboPos] = useState(false);
 
   // One-shot: clear sessionStorage so refreshing doesn't keep opening the form.
   useEffect(() => {
@@ -174,6 +178,10 @@ export function PurchaseOrdersTab({
             <RefreshCw size={12} style={{ marginRight: 4, verticalAlign: -1 }} />
             {syncing ? 'Syncing…' : 'Pull Vendors from QBO'}
           </button>
+          <button onClick={() => setPullingQboPos(true)} style={btnSecondary()}>
+            <Download size={12} style={{ marginRight: 4, verticalAlign: -1 }} />
+            Pull POs from QBO
+          </button>
           <button
             onClick={() => setCreating(true)}
             style={btnPrimary()}
@@ -183,6 +191,13 @@ export function PurchaseOrdersTab({
           </button>
         </div>
       </div>
+
+      {pullingQboPos && (
+        <QboPosPickerModal
+          onClose={() => setPullingQboPos(false)}
+          onImported={() => { onChanged(); }}
+        />
+      )}
 
       {activeVendors.length === 0 && (
         <div style={{

--- a/app/src/pages/production/QboPosPickerModal.tsx
+++ b/app/src/pages/production/QboPosPickerModal.tsx
@@ -35,7 +35,7 @@ export function QboPosPickerModal({ onClose, onImported }: Props) {
       setItems(data.items);
       setSelected(new Set());
     } catch (e) {
-      toast.push('Failed to load QBO POs: ' + errMsg(e), { type: 'error' });
+      toast.error('Failed to load QBO POs: ' + errMsg(e));
     } finally {
       setLoading(false);
     }
@@ -89,11 +89,11 @@ export function QboPosPickerModal({ onClose, onImported }: Props) {
     try {
       const result = await importQboPos(Array.from(selected));
       const lines = result.details.imported.reduce((s, r) => s + r.lines, 0);
-      toast.push(`Imported ${result.imported} PO${result.imported === 1 ? '' : 's'} (${lines} line${lines === 1 ? '' : 's'})${result.skipped > 0 ? ` · ${result.skipped} skipped` : ''}`, { type: 'success' });
+      toast.success(`Imported ${result.imported} PO${result.imported === 1 ? '' : 's'} (${lines} line${lines === 1 ? '' : 's'})${result.skipped > 0 ? ` · ${result.skipped} skipped` : ''}`);
       onImported();
       await load(); // refresh "already imported" flags
     } catch (e) {
-      toast.push('Import failed: ' + errMsg(e), { type: 'error' });
+      toast.error('Import failed: ' + errMsg(e));
     } finally {
       setImporting(false);
     }
@@ -143,7 +143,7 @@ export function QboPosPickerModal({ onClose, onImported }: Props) {
             <input type="checkbox" checked={showAll} onChange={(e) => setShowAll(e.target.checked)} />
             Show already-imported
           </label>
-          <button onClick={() => void load()} className={btnSecondary} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <button onClick={() => void load()} style={{ ...btnSecondary(), display: 'flex', alignItems: 'center', gap: 4 }}>
             <RefreshCw size={14} /> Refresh
           </button>
         </div>
@@ -256,12 +256,11 @@ export function QboPosPickerModal({ onClose, onImported }: Props) {
             )}
           </div>
           <div style={{ display: 'flex', gap: 8 }}>
-            <button onClick={onClose} className={btnSecondary}>Cancel</button>
+            <button onClick={onClose} style={btnSecondary()}>Cancel</button>
             <button
               onClick={() => void doImport()}
               disabled={selected.size === 0 || importing}
-              className={btnPrimary}
-              style={{ display: 'flex', alignItems: 'center', gap: 6 }}
+              style={{ ...btnPrimary(), display: 'flex', alignItems: 'center', gap: 6 }}
             >
               {importing ? <Loader2 size={14} style={{ animation: 'spin 1s linear infinite' }} /> : <Download size={14} />}
               Import {selected.size || ''} selected

--- a/app/src/pages/production/QboPosPickerModal.tsx
+++ b/app/src/pages/production/QboPosPickerModal.tsx
@@ -1,0 +1,274 @@
+// "Pull POs from QBO" modal — operator-driven import of QBO-direct
+// PurchaseOrders into the ops.qbo_purchase_orders shadow tables, so the
+// inventory page's On Order column reflects QBO POs that were never created
+// through BRIX.
+
+import { useEffect, useMemo, useState } from 'react';
+import { X as XIcon, Loader2, RefreshCw, Download } from 'lucide-react';
+import { fetchQboPosPreview, importQboPos, type QboPoPickerItem } from '../../lib/qboPosPicker';
+import { useToast } from '../../lib/toast';
+import { btnPrimary, btnSecondary } from '../../lib/styles';
+import { fm } from '../../lib/formatters';
+
+interface Props {
+  onClose: () => void;
+  /** Bubble up so the parent can refresh inventory / PO views after import. */
+  onImported: () => void;
+}
+
+function errMsg(e: unknown): string { return e instanceof Error ? e.message : String(e); }
+
+export function QboPosPickerModal({ onClose, onImported }: Props) {
+  const toast = useToast();
+  const [loading, setLoading] = useState(true);
+  const [importing, setImporting] = useState(false);
+  const [items, setItems] = useState<QboPoPickerItem[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [filter, setFilter] = useState('');
+  const [showAll, setShowAll] = useState(false); // hide already-imported by default
+
+  async function load() {
+    setLoading(true);
+    try {
+      const data = await fetchQboPosPreview();
+      setItems(data.items);
+      setSelected(new Set());
+    } catch (e) {
+      toast.push('Failed to load QBO POs: ' + errMsg(e), { type: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { void load(); }, []);
+
+  const visible = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    return items.filter((i) => {
+      // Always hide BRIX-native rows — re-importing would double-count.
+      if (i.brix_native) return false;
+      if (!showAll && i.already_imported) return false;
+      if (!q) return true;
+      return (
+        (i.doc_number || '').toLowerCase().includes(q) ||
+        (i.vendor_name || '').toLowerCase().includes(q) ||
+        (i.memo || '').toLowerCase().includes(q)
+      );
+    });
+  }, [items, filter, showAll]);
+
+  const pickableIds = useMemo(
+    () => visible.filter((i) => i.status === 'Open' && !i.brix_native).map((i) => i.qbo_id),
+    [visible],
+  );
+
+  const allSelected = pickableIds.length > 0 && pickableIds.every((id) => selected.has(id));
+  function toggleAll() {
+    if (allSelected) setSelected(new Set());
+    else setSelected(new Set(pickableIds));
+  }
+  function toggleOne(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+  function toggleExpand(id: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  async function doImport() {
+    if (selected.size === 0) return;
+    setImporting(true);
+    try {
+      const result = await importQboPos(Array.from(selected));
+      const lines = result.details.imported.reduce((s, r) => s + r.lines, 0);
+      toast.push(`Imported ${result.imported} PO${result.imported === 1 ? '' : 's'} (${lines} line${lines === 1 ? '' : 's'})${result.skipped > 0 ? ` · ${result.skipped} skipped` : ''}`, { type: 'success' });
+      onImported();
+      await load(); // refresh "already imported" flags
+    } catch (e) {
+      toast.push('Import failed: ' + errMsg(e), { type: 'error' });
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  const totalSelected = useMemo(
+    () => Array.from(selected).reduce((s, id) => {
+      const it = items.find((i) => i.qbo_id === id);
+      return s + (it?.total_amt || 0);
+    }, 0),
+    [selected, items],
+  );
+
+  return (
+    <div style={{
+      position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 50,
+      display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20,
+    }}>
+      <div style={{
+        background: 'var(--bg)', color: 'var(--tx)', border: '1px solid var(--bd)',
+        borderRadius: 8, maxWidth: 1100, width: '100%', maxHeight: '90vh',
+        display: 'flex', flexDirection: 'column',
+      }}>
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '14px 18px', borderBottom: '1px solid var(--bd)',
+        }}>
+          <div>
+            <div style={{ fontSize: 15, fontWeight: 700 }}>Pull purchase orders from QBO</div>
+            <div style={{ fontSize: 12, color: 'var(--mt)', marginTop: 2 }}>
+              Pick which open POs to mirror into BRIX. They count toward the inventory <em>On Order</em> column. Re-pull anytime to refresh totals + status.
+            </div>
+          </div>
+          <button onClick={onClose} style={{ background: 'transparent', border: 'none', cursor: 'pointer', color: 'var(--mt)' }}>
+            <XIcon size={20} />
+          </button>
+        </div>
+
+        <div style={{ padding: '12px 18px', display: 'flex', alignItems: 'center', gap: 10, borderBottom: '1px solid var(--bd)' }}>
+          <input
+            placeholder="Search by PO #, vendor, memo…"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            style={{ flex: 1, padding: '6px 10px', background: 'var(--bg-2)', color: 'var(--tx)', border: '1px solid var(--bd)', borderRadius: 6, fontSize: 13 }}
+          />
+          <label style={{ fontSize: 12, color: 'var(--mt)', display: 'flex', alignItems: 'center', gap: 6 }}>
+            <input type="checkbox" checked={showAll} onChange={(e) => setShowAll(e.target.checked)} />
+            Show already-imported
+          </label>
+          <button onClick={() => void load()} className={btnSecondary} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <RefreshCw size={14} /> Refresh
+          </button>
+        </div>
+
+        <div style={{ flex: 1, overflow: 'auto', padding: '4px 18px 18px' }}>
+          {loading ? (
+            <div style={{ padding: 40, textAlign: 'center', color: 'var(--mt)' }}>
+              <Loader2 size={24} style={{ animation: 'spin 1s linear infinite' }} /> Loading QBO POs…
+            </div>
+          ) : visible.length === 0 ? (
+            <div style={{ padding: 40, textAlign: 'center', color: 'var(--mt)' }}>
+              No POs match. {!showAll && items.some((i) => i.already_imported) ? 'Toggle "Show already-imported" to see ones already in BRIX.' : ''}
+            </div>
+          ) : (
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+              <thead>
+                <tr style={{ background: 'var(--bg-2)' }}>
+                  <th style={{ padding: '8px 10px', textAlign: 'left', borderBottom: '1px solid var(--bd)', width: 36 }}>
+                    <input type="checkbox" checked={allSelected} onChange={toggleAll} disabled={pickableIds.length === 0} />
+                  </th>
+                  <th style={{ padding: '8px 10px', textAlign: 'left', borderBottom: '1px solid var(--bd)' }}>PO #</th>
+                  <th style={{ padding: '8px 10px', textAlign: 'left', borderBottom: '1px solid var(--bd)' }}>Vendor</th>
+                  <th style={{ padding: '8px 10px', textAlign: 'left', borderBottom: '1px solid var(--bd)' }}>Date</th>
+                  <th style={{ padding: '8px 10px', textAlign: 'right', borderBottom: '1px solid var(--bd)' }}>Total</th>
+                  <th style={{ padding: '8px 10px', textAlign: 'right', borderBottom: '1px solid var(--bd)' }}>Lines</th>
+                  <th style={{ padding: '8px 10px', textAlign: 'left', borderBottom: '1px solid var(--bd)' }}>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visible.map((it) => {
+                  const isPickable = it.status === 'Open' && !it.brix_native;
+                  const isSelected = selected.has(it.qbo_id);
+                  const isExpanded = expanded.has(it.qbo_id);
+                  return (
+                    <>
+                      <tr key={it.qbo_id} style={{ borderBottom: '1px solid var(--bd)' }}>
+                        <td style={{ padding: '8px 10px' }}>
+                          <input type="checkbox" checked={isSelected} disabled={!isPickable} onChange={() => toggleOne(it.qbo_id)} />
+                        </td>
+                        <td style={{ padding: '8px 10px', fontFamily: 'var(--ff-mono)', fontWeight: 600 }}>
+                          <button onClick={() => toggleExpand(it.qbo_id)} style={{ background: 'transparent', border: 'none', cursor: 'pointer', color: 'var(--ac)', padding: 0, fontFamily: 'inherit', fontWeight: 'inherit' }}>
+                            {it.doc_number || it.qbo_id} {isExpanded ? '▾' : '▸'}
+                          </button>
+                        </td>
+                        <td style={{ padding: '8px 10px' }}>{it.vendor_name || '—'}</td>
+                        <td style={{ padding: '8px 10px' }}>{it.txn_date || '—'}</td>
+                        <td style={{ padding: '8px 10px', textAlign: 'right', fontFamily: 'var(--ff-mono)' }}>{fm(it.total_amt || 0)}</td>
+                        <td style={{ padding: '8px 10px', textAlign: 'right' }}>{it.line_count}</td>
+                        <td style={{ padding: '8px 10px' }}>
+                          <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: 0.4, padding: '1px 6px', borderRadius: 10, border: '1px solid', color: it.status === 'Open' ? 'var(--gn)' : 'var(--mt)' }}>
+                            {it.status.toUpperCase()}
+                          </span>
+                          {it.already_imported && <span style={{ marginLeft: 6, fontSize: 10, color: 'var(--mt)' }}>imported</span>}
+                          {it.brix_native && <span style={{ marginLeft: 6, fontSize: 10, color: 'var(--mt)' }}>brix-native</span>}
+                        </td>
+                      </tr>
+                      {isExpanded && (
+                        <tr style={{ background: 'rgba(255,255,255,0.02)' }}>
+                          <td colSpan={7} style={{ padding: '8px 18px' }}>
+                            {it.lines.length === 0 ? (
+                              <div style={{ color: 'var(--mt)', fontStyle: 'italic' }}>No item lines on this PO.</div>
+                            ) : (
+                              <table style={{ width: '100%', fontSize: 11 }}>
+                                <thead>
+                                  <tr style={{ color: 'var(--mt)' }}>
+                                    <th style={{ textAlign: 'left', padding: '4px 8px' }}>Item / Description</th>
+                                    <th style={{ textAlign: 'right', padding: '4px 8px' }}>Qty</th>
+                                    <th style={{ textAlign: 'right', padding: '4px 8px' }}>Unit cost</th>
+                                    <th style={{ textAlign: 'right', padding: '4px 8px' }}>Amount</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {it.lines.map((l) => (
+                                    <tr key={l.line_num}>
+                                      <td style={{ padding: '4px 8px' }}>
+                                        <strong>{l.qbo_item_name || l.account_name || '—'}</strong>
+                                        {l.description ? <span style={{ color: 'var(--mt)' }}> · {l.description}</span> : null}
+                                        {!l.qbo_item_id && <span style={{ color: 'var(--am)', marginLeft: 6, fontSize: 10 }}>(no item — won't count toward On Order)</span>}
+                                      </td>
+                                      <td style={{ padding: '4px 8px', textAlign: 'right', fontFamily: 'var(--ff-mono)' }}>{l.qty ?? '—'}</td>
+                                      <td style={{ padding: '4px 8px', textAlign: 'right', fontFamily: 'var(--ff-mono)' }}>{l.unit_cost != null ? fm(l.unit_cost) : '—'}</td>
+                                      <td style={{ padding: '4px 8px', textAlign: 'right', fontFamily: 'var(--ff-mono)' }}>{l.amount != null ? fm(l.amount) : '—'}</td>
+                                    </tr>
+                                  ))}
+                                </tbody>
+                              </table>
+                            )}
+                          </td>
+                        </tr>
+                      )}
+                    </>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '12px 18px', borderTop: '1px solid var(--bd)', gap: 12,
+        }}>
+          <div style={{ fontSize: 12, color: 'var(--mt)' }}>
+            {selected.size > 0 ? (
+              <>
+                <strong style={{ color: 'var(--tx)' }}>{selected.size}</strong> selected · {fm(totalSelected)}
+              </>
+            ) : (
+              <>Tip: only Open POs can be imported — closed ones don't contribute to On Order.</>
+            )}
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button onClick={onClose} className={btnSecondary}>Cancel</button>
+            <button
+              onClick={() => void doImport()}
+              disabled={selected.size === 0 || importing}
+              className={btnPrimary}
+              style={{ display: 'flex', alignItems: 'center', gap: 6 }}
+            >
+              {importing ? <Loader2 size={14} style={{ animation: 'spin 1s linear infinite' }} /> : <Download size={14} />}
+              Import {selected.size || ''} selected
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/architecture/schema-snapshot.json
+++ b/architecture/schema-snapshot.json
@@ -59,6 +59,8 @@
     "qbo_invoice_lines",
     "qbo_invoices",
     "qbo_items",
+    "qbo_purchase_order_lines",
+    "qbo_purchase_orders",
     "qbo_pto_cache",
     "qbo_token_cache",
     "reman_jobs",

--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -285,6 +285,18 @@
       ],
       "notes": "BRIX Stock surface (app/src/pages/stock/) writes via ops.fn_create_transfer / fn_ship_transfer / fn_receive_transfer / fn_void_transfer (all SECURITY DEFINER, authenticated only). inventory_movements is append-only via those RPCs; clients never INSERT directly. inventory_locations is directly writable from the UI under permissive RLS (low volume CRUD; virtual TRANSIT and ADJUSTMENT rows are protected by a kind-NOT-IN check in the update policy). Phase 1 only emits transfer_ship and transfer_receive movement types; Phase 4 will add receipt (from bills) and shipment (from invoices). See architecture/PRODUCT-CONTROL.md for the full design. Migration: 20260513a_inventory_stock.sql.",
       "last_verified": "2026-05-13"
+    },
+    {
+      "name": "qbo-pos-import",
+      "kind": "netlify-function",
+      "source_repo": "skypace/apbg-billing",
+      "schedule": "on-demand (operator clicks 'Pull POs from QBO' in the Margin Production tab)",
+      "writes": [
+        "ops.qbo_purchase_orders",
+        "ops.qbo_purchase_order_lines"
+      ],
+      "notes": "Mirrors QBO-direct PurchaseOrders into shadow tables so the inventory On Order column (fn_items_master.on_order CTE) counts POs that were never created through BRIX. Per-PO picker modal in app/src/pages/production/QboPosPickerModal.tsx. Bearer-only auth (any logged-in @brixbev.com employee can preview + import). Upserts headers by qbo_id; lines are replaced wholesale on each import. De-dup with ops.purchase_orders.qbo_purchase_order_id so a BRIX-native PO pushed to QBO isn't counted twice. Migration: 20260516b_qbo_purchase_orders_shadow.sql.",
+      "last_verified": "2026-05-16"
     }
   ],
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -73,6 +73,14 @@
   from = "/api/expense-payment-accounts"
   to = "/.netlify/functions/expense-payment-accounts"
   status = 200
+[[redirects]]
+  from = "/api/qbo-pos-preview"
+  to = "/.netlify/functions/qbo-pos-preview"
+  status = 200
+[[redirects]]
+  from = "/api/qbo-pos-import"
+  to = "/.netlify/functions/qbo-pos-import"
+  status = 200
 
 # ── Expense app: SPA fallback ──
 # Any /expense/* path that doesn't match a static file → serve the expense SPA

--- a/netlify/functions/qbo-pos-import.mjs
+++ b/netlify/functions/qbo-pos-import.mjs
@@ -1,0 +1,145 @@
+// /api/qbo-pos-import — accept a list of QBO PO ids and upsert them + their
+// lines into the shadow tables. Triggered by the operator clicking
+// "Import N selected" on the picker modal. Re-running on the same ids
+// refreshes the snapshot (line items, total, status) from QBO.
+
+import { createClient } from '@supabase/supabase-js';
+import { qboQuery } from './qbo-helpers.mjs';
+
+const SUPABASE_URL = 'https://gfsdpwiqzshhexkofiif.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdmc2Rwd2lxenNoaGV4a29maWlmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU1OTUyMzcsImV4cCI6MjA5MTE3MTIzN30.AygnPJwQ5NfIeKwPtkO6tgVYmkV3MAxL1lMFwN9HPnY';
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Content-Type': 'application/json',
+};
+
+const json = (d, s = 200) => new Response(JSON.stringify(d), { status: s, headers: CORS });
+
+function escapeQbo(v) {
+  return String(v).replace(/'/g, "\\'");
+}
+
+export default async function handler(req) {
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: CORS });
+  if (req.method !== 'POST') return json({ error: 'POST only' }, 405);
+
+  const authHeader = req.headers.get('authorization') || '';
+  if (!authHeader.startsWith('Bearer ')) return json({ error: 'Unauthorized — Bearer token required' }, 401);
+
+  let body;
+  try { body = await req.json(); } catch { return json({ error: 'Invalid JSON body' }, 400); }
+  const ids = Array.isArray(body?.ids) ? body.ids.map(String).filter(Boolean) : [];
+  if (ids.length === 0) return json({ error: 'ids[] required (QBO PurchaseOrder ids)' }, 400);
+  if (ids.length > 500) return json({ error: 'Max 500 ids per import call' }, 400);
+
+  const sb = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    db: { schema: 'ops' },
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { headers: { Authorization: authHeader } },
+  });
+  // Stamp imported_by from the caller's user.id when we can resolve it.
+  let importedBy = null;
+  try {
+    const { data: { user } } = await sb.auth.getUser();
+    importedBy = user?.id || null;
+  } catch {}
+
+  // QBO IN-clause caps at ~1000 chars per id list — chunk to be safe.
+  const chunks = [];
+  for (let i = 0; i < ids.length; i += 50) chunks.push(ids.slice(i, i + 50));
+
+  const fetched = [];
+  for (const ch of chunks) {
+    const inList = ch.map((id) => `'${escapeQbo(id)}'`).join(',');
+    try {
+      const res = await qboQuery(`SELECT * FROM PurchaseOrder WHERE Id IN (${inList}) MAXRESULTS 500`);
+      const rows = res?.QueryResponse?.PurchaseOrder || [];
+      fetched.push(...rows);
+    } catch (e) {
+      console.error('qbo-pos-import: QBO fetch chunk failed', e);
+      return json({ error: `QBO fetch failed: ${e?.message || e}` }, 502);
+    }
+  }
+
+  const now = new Date().toISOString();
+  const imported = [];
+  const skipped = [];
+  for (const po of fetched) {
+    const linkedBills = (po.LinkedTxn || []).filter((t) => t.TxnType === 'Bill');
+    const status = po.POStatus || (linkedBills.length > 0 ? 'PartiallyBilled' : 'Open');
+
+    const headerRow = {
+      qbo_id: po.Id,
+      doc_number: po.DocNumber || null,
+      qbo_vendor_id: po.VendorRef?.value || null,
+      vendor_name: po.VendorRef?.name || null,
+      txn_date: po.TxnDate || null,
+      po_status: status,
+      total_amt: po.TotalAmt ?? null,
+      memo: po.Memo || po.PrivateNote || null,
+      sync_token: po.SyncToken || null,
+      raw: po,
+      imported_by: importedBy,
+      last_synced_at: now,
+    };
+
+    const { error: upsertErr } = await sb
+      .from('qbo_purchase_orders')
+      .upsert(headerRow, { onConflict: 'qbo_id' });
+    if (upsertErr) {
+      console.error('qbo-pos-import: header upsert failed', po.Id, upsertErr);
+      skipped.push({ qbo_id: po.Id, reason: upsertErr.message });
+      continue;
+    }
+
+    // Replace lines wholesale on each import — simplest way to keep them in
+    // sync with QBO. Cheap because PO line counts are small.
+    const { error: delErr } = await sb.from('qbo_purchase_order_lines').delete().eq('qbo_po_id', po.Id);
+    if (delErr) {
+      console.error('qbo-pos-import: line delete failed', po.Id, delErr);
+      skipped.push({ qbo_id: po.Id, reason: `line delete: ${delErr.message}` });
+      continue;
+    }
+
+    const lineRows = (po.Line || [])
+      .filter((l) => l.DetailType === 'ItemBasedExpenseLineDetail' || l.DetailType === 'AccountBasedExpenseLineDetail')
+      .map((l, i) => {
+        const ib = l.ItemBasedExpenseLineDetail;
+        return {
+          qbo_po_id: po.Id,
+          line_num: l.LineNum || i + 1,
+          qbo_item_id: ib?.ItemRef?.value || null,
+          description: l.Description || null,
+          qty: ib?.Qty ?? null,
+          unit_cost: ib?.UnitPrice ?? null,
+          amount: l.Amount ?? null,
+        };
+      });
+
+    if (lineRows.length > 0) {
+      const { error: insErr } = await sb.from('qbo_purchase_order_lines').insert(lineRows);
+      if (insErr) {
+        console.error('qbo-pos-import: line insert failed', po.Id, insErr);
+        skipped.push({ qbo_id: po.Id, reason: `line insert: ${insErr.message}` });
+        continue;
+      }
+    }
+
+    imported.push({ qbo_id: po.Id, doc_number: po.DocNumber || null, lines: lineRows.length });
+  }
+
+  const missing = ids.filter((id) => !fetched.some((p) => p.Id === id));
+
+  return json({
+    requested: ids.length,
+    imported: imported.length,
+    skipped: skipped.length,
+    missing: missing.length,
+    details: { imported, skipped, missing },
+  });
+}
+
+export const config = { path: '/api/qbo-pos-import' };

--- a/netlify/functions/qbo-pos-preview.mjs
+++ b/netlify/functions/qbo-pos-preview.mjs
@@ -1,0 +1,146 @@
+// /api/qbo-pos-preview — list open QBO PurchaseOrders for the
+// "Pull from QBO" picker. Marks each PO as already-imported (shadow table) or
+// already-managed-in-BRIX (ops.purchase_orders.qbo_purchase_order_id set), so
+// the UI can disable / hide rows the operator shouldn't pick again.
+
+import { createClient } from '@supabase/supabase-js';
+import { qboQuery } from './qbo-helpers.mjs';
+
+const SUPABASE_URL = 'https://gfsdpwiqzshhexkofiif.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdmc2Rwd2lxenNoaGV4a29maWlmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU1OTUyMzcsImV4cCI6MjA5MTE3MTIzN30.AygnPJwQ5NfIeKwPtkO6tgVYmkV3MAxL1lMFwN9HPnY';
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Content-Type': 'application/json',
+};
+
+const json = (d, s = 200) => new Response(JSON.stringify(d), { status: s, headers: CORS });
+
+// Pull POs in pages of 1000 (QBO max). Most realms have <500 PO history so
+// one page is usually enough.
+async function fetchAllPurchaseOrders() {
+  const all = [];
+  let startPos = 1;
+  const pageSize = 1000;
+  while (true) {
+    const res = await qboQuery(
+      `SELECT * FROM PurchaseOrder ORDER BY MetaData.LastUpdatedTime DESC STARTPOSITION ${startPos} MAXRESULTS ${pageSize}`
+    );
+    const rows = res?.QueryResponse?.PurchaseOrder || [];
+    all.push(...rows);
+    if (rows.length < pageSize) break;
+    startPos += pageSize;
+  }
+  return all;
+}
+
+// QBO PurchaseOrder exposes POStatus on the entity ("Open" / "Closed") but it's
+// not always populated in the query response — the source-of-truth is whether
+// every line has a fully-linked Bill. For the picker we keep it simple: treat
+// LinkedTxn containing any Bill as "partial or fully received", and rely on
+// POStatus where present.
+function deriveStatus(po) {
+  if (typeof po.POStatus === 'string' && po.POStatus.length > 0) return po.POStatus;
+  const linkedBills = (po.LinkedTxn || []).filter((t) => t.TxnType === 'Bill');
+  return linkedBills.length > 0 ? 'PartiallyBilled' : 'Open';
+}
+
+export default async function handler(req) {
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: CORS });
+  if (req.method !== 'GET') return json({ error: 'GET only' }, 405);
+
+  // Bearer-only auth — matches the Brixpense submitter endpoints. Any
+  // logged-in employee with @brixbev.com can see the picker; the actual
+  // import endpoint adds role-based gates.
+  const authHeader = req.headers.get('authorization') || '';
+  if (!authHeader.startsWith('Bearer ')) return json({ error: 'Unauthorized — Bearer token required' }, 401);
+
+  const sb = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    db: { schema: 'ops' },
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { headers: { Authorization: authHeader } },
+  });
+
+  let qboPos = [];
+  try {
+    qboPos = await fetchAllPurchaseOrders();
+  } catch (e) {
+    console.error('qbo-pos-preview: QBO query failed', e);
+    return json({ error: e?.message || 'QBO query failed' }, 502);
+  }
+
+  // Cross-reference with what's already in BRIX so the UI can show status
+  // chips. Two separate sources we care about:
+  //   1. ops.qbo_purchase_orders — previously imported via this picker
+  //   2. ops.purchase_orders.qbo_purchase_order_id — BRIX-native POs that
+  //      have been pushed to QBO (those already count in fn_items_master's
+  //      brix_on_order CTE, so re-importing would be redundant)
+  const ids = qboPos.map((p) => p.Id);
+  const [{ data: already, error: e1 }, { data: brixLinked, error: e2 }] = await Promise.all([
+    sb.from('qbo_purchase_orders').select('qbo_id, imported_at, last_synced_at').in('qbo_id', ids),
+    sb.from('purchase_orders').select('qbo_purchase_order_id').not('qbo_purchase_order_id', 'is', null).in('qbo_purchase_order_id', ids),
+  ]);
+  if (e1 || e2) {
+    console.error('qbo-pos-preview: cross-reference query failed', e1, e2);
+    return json({ error: 'Cross-reference query failed' }, 500);
+  }
+  const alreadyMap = new Map((already || []).map((r) => [r.qbo_id, r]));
+  const brixLinkedSet = new Set((brixLinked || []).map((r) => r.qbo_purchase_order_id));
+
+  const items = qboPos.map((po) => {
+    const lines = (po.Line || [])
+      .filter((l) => l.DetailType === 'ItemBasedExpenseLineDetail' || l.DetailType === 'AccountBasedExpenseLineDetail')
+      .map((l, i) => {
+        const ib = l.ItemBasedExpenseLineDetail;
+        const ab = l.AccountBasedExpenseLineDetail;
+        return {
+          line_num: l.LineNum || i + 1,
+          description: l.Description || '',
+          amount: l.Amount ?? null,
+          qbo_item_id: ib?.ItemRef?.value || null,
+          qbo_item_name: ib?.ItemRef?.name || null,
+          qty: ib?.Qty ?? null,
+          unit_cost: ib?.UnitPrice ?? null,
+          account_id: ab?.AccountRef?.value || null,
+          account_name: ab?.AccountRef?.name || null,
+        };
+      });
+    const status = deriveStatus(po);
+    const importRow = alreadyMap.get(po.Id);
+    return {
+      qbo_id: po.Id,
+      doc_number: po.DocNumber || null,
+      vendor_id: po.VendorRef?.value || null,
+      vendor_name: po.VendorRef?.name || null,
+      txn_date: po.TxnDate || null,
+      total_amt: po.TotalAmt ?? null,
+      status,
+      memo: po.Memo || po.PrivateNote || null,
+      line_count: lines.length,
+      lines,
+      already_imported: !!importRow,
+      imported_at: importRow?.imported_at || null,
+      last_synced_at: importRow?.last_synced_at || null,
+      brix_native: brixLinkedSet.has(po.Id),
+    };
+  });
+
+  // Sort: open + not-yet-imported first (the ones the picker is for), then
+  // newest first within each bucket.
+  items.sort((a, b) => {
+    const aPick = a.status === 'Open' && !a.already_imported && !a.brix_native ? 0 : 1;
+    const bPick = b.status === 'Open' && !b.already_imported && !b.brix_native ? 0 : 1;
+    if (aPick !== bPick) return aPick - bPick;
+    return String(b.txn_date || '').localeCompare(String(a.txn_date || ''));
+  });
+
+  return json({
+    count: items.length,
+    open_pickable: items.filter((i) => i.status === 'Open' && !i.already_imported && !i.brix_native).length,
+    items,
+  });
+}
+
+export const config = { path: '/api/qbo-pos-preview' };

--- a/supabase/migrations/20260516b_qbo_purchase_orders_shadow.sql
+++ b/supabase/migrations/20260516b_qbo_purchase_orders_shadow.sql
@@ -1,0 +1,52 @@
+-- Shadow tables for QBO-direct purchase orders. The existing ops.purchase_orders
+-- table is for BRIX-native POs (operator creates in BRIX, pushes to QBO). These
+-- shadow tables mirror QBO POs created directly in QBO so they can count toward
+-- the inventory On Order calculation in fn_items_master.
+--
+-- Read-only mirror — operator imports via the "Pull POs from QBO" picker on
+-- the Production page. Source of truth stays in QBO; re-pull to refresh.
+--
+-- Already applied to the live DB on 2026-05-16 via Supabase MCP.
+
+CREATE TABLE IF NOT EXISTS ops.qbo_purchase_orders (
+  qbo_id text PRIMARY KEY,
+  doc_number text,
+  qbo_vendor_id text,
+  vendor_name text,
+  txn_date date,
+  po_status text,
+  total_amt numeric,
+  memo text,
+  sync_token text,
+  raw jsonb,
+  imported_at timestamptz DEFAULT now(),
+  imported_by uuid,
+  last_synced_at timestamptz DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS ops.qbo_purchase_order_lines (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  qbo_po_id text NOT NULL REFERENCES ops.qbo_purchase_orders(qbo_id) ON DELETE CASCADE,
+  line_num integer,
+  qbo_item_id text,
+  description text,
+  qty numeric,
+  unit_cost numeric,
+  amount numeric
+);
+
+CREATE INDEX IF NOT EXISTS qbo_po_lines_item_idx ON ops.qbo_purchase_order_lines (qbo_item_id);
+CREATE INDEX IF NOT EXISTS qbo_pos_status_idx ON ops.qbo_purchase_orders (po_status);
+CREATE INDEX IF NOT EXISTS qbo_pos_vendor_idx ON ops.qbo_purchase_orders (qbo_vendor_id);
+
+ALTER TABLE ops.qbo_purchase_orders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ops.qbo_purchase_order_lines ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS qbo_pos_read ON ops.qbo_purchase_orders;
+CREATE POLICY qbo_pos_read ON ops.qbo_purchase_orders FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS qbo_po_lines_read ON ops.qbo_purchase_order_lines;
+CREATE POLICY qbo_po_lines_read ON ops.qbo_purchase_order_lines FOR SELECT USING (true);
+
+COMMENT ON TABLE ops.qbo_purchase_orders IS 'Shadow mirror of QBO-direct PurchaseOrders. Read-only; populated via the import picker on the Production page.';
+COMMENT ON TABLE ops.qbo_purchase_order_lines IS 'Line items of imported QBO POs. Feeds the on_order CTE in fn_items_master alongside BRIX-native ops.purchase_order_lines.';


### PR DESCRIPTION
## Why

> "On the inventory page in the margin program is the on hand column wired up to current purchase orders that are opened" → "Maybe we should sync those so that they match" → "Can I get a choice of what to pull in?"

The inventory page's **On Order** column was sourced solely from `ops.purchase_orders` (BRIX-native POs created via the production PO module). QBO POs created directly in QuickBooks — AC CALDERONI, SUN PLUS, THE HUB DESIGN INNOVATION, ~$80K+ outstanding — were invisible to `fn_items_master`, so the reorder math (`suggested_order_qty`) double-bought items that already had open POs in QBO.

## What

Operator-driven **per-PO picker** that mirrors selected QBO POs into shadow tables. Per-PO checkboxes (chosen design), shadow table destination (chosen design), reachable from a new "Pull POs from QBO" button on the Production → Purchase Orders tab.

### Schema (migration `20260516b` — applied live via Supabase MCP)
- `ops.qbo_purchase_orders` — header keyed by QBO `Id`. Stores `DocNumber`, `VendorRef`, `TxnDate`, `POStatus`, `TotalAmt`, memo, `SyncToken`, raw payload, `imported_at/_by`, `last_synced_at`.
- `ops.qbo_purchase_order_lines` — one row per item-based line, indexed on `qbo_item_id` for the `fn_items_master` join.

### `fn_items_master` (live)
The `on_order` CTE now `UNION ALL`s **both**:
- `ops.purchase_order_lines` (BRIX-native, unchanged)
- `ops.qbo_purchase_order_lines` joined to `ops.qbo_purchase_orders` where `po_status='Open'`

De-dup: any QBO `Id` already linked to a BRIX-native PO via `ops.purchase_orders.qbo_purchase_order_id` is excluded from the shadow-table CTE.

### Backend
- **`GET /api/qbo-pos-preview`** — fetches QBO PurchaseOrders, marks each as `already_imported` (shadow table) or `brix_native` (existing BRIX link). Bearer-only auth (matches Brixpense submitter pattern).
- **`POST /api/qbo-pos-import`** — accepts `{ids: [...]}`, upserts headers by `qbo_id`, replaces lines wholesale. Returns `{requested, imported, skipped, missing, details}`.

### Frontend (`app/` — the Margin Control SPA)
- `src/lib/qboPosPicker.ts` — typed fetch wrappers.
- `src/pages/production/QboPosPickerModal.tsx` — search, per-PO checkbox, expand-to-preview-lines, totals summary, Import N selected button. Hides BRIX-native rows always; toggles "Show already-imported."
- `src/pages/production/PurchaseOrdersTab.tsx` — new "Pull POs from QBO" button in the toolbar, between "Pull Vendors from QBO" and "New PO."

`netlify.toml`: explicit redirects for both `/api` routes, placed before the `/expense/*` SPA fallback per the `f7b332d` pattern.

## Test plan

- [ ] Open `/margin/` → Production → Purchase Orders → click "Pull POs from QBO" → modal opens, lists open QBO POs (AC CALDERONI, SUN PLUS, etc.) with vendor / date / total / line count.
- [ ] Expand a PO row → shows item lines (item name, qty, unit cost, amount). Lines without an `ItemRef` show an amber "won't count toward On Order" note.
- [ ] Check 2-3 POs → "Import 3 selected" → toast confirms, rows flip to "imported" status.
- [ ] Inventory page → On Order column for the items on those POs now reflects the imported quantities.
- [ ] Re-open the picker → imported POs are hidden by default; toggle "Show already-imported" to see them; re-import refreshes the snapshot.

## Followup (out of scope)

Scheduled nightly re-sync of imported POs so `po_status` flips `Closed` automatically when QBO bills land. Today the operator clicks "Pull POs from QBO" again to refresh.

---
_Generated by [Claude Code](https://claude.ai/code/session_012iWSo6eNQAbMQTUdu16gwA)_