### PR TITLE
margin/production: BOM unit-of-measure + "Scale this BOM" calculator

### DIFF
--- a/app/src/lib/production.ts
+++ b/app/src/lib/production.ts
@@ -10,6 +10,11 @@ export interface ProductBom {
   effective_date: string | null;
   yield_qty: number;
   yield_uom: string;
+  /** Optional bridge for cross-family scaling: if yield_uom is a count
+   *  (each/case) and 1 yield produces a known volume of finished product,
+   *  set this to the gallons-per-yield. Lets the BOM scaler convert "make
+   *  1000 gal" → runs even though yield is in cases. */
+  finished_vol_per_yield_gal: number | null;
   is_active: boolean;
   notes: string | null;
   created_by: string | null;
@@ -121,6 +126,7 @@ export async function createBom(args: {
   finished_qbo_item_id: string;
   yield_qty: number;
   yield_uom?: string;
+  finished_vol_per_yield_gal?: number | null;
   lines: BomLineInput[];
   version?: string;
   effective_date?: string | null;
@@ -130,6 +136,7 @@ export async function createBom(args: {
     p_finished_qbo_item_id: args.finished_qbo_item_id,
     p_yield_qty: args.yield_qty,
     p_yield_uom: args.yield_uom ?? 'each',
+    p_finished_vol_per_yield_gal: args.finished_vol_per_yield_gal ?? null,
     p_lines: args.lines,
     p_version: args.version ?? '1',
     p_effective_date: args.effective_date ?? null,

--- a/app/src/lib/production.ts
+++ b/app/src/lib/production.ts
@@ -9,6 +9,7 @@ export interface ProductBom {
   version: string;
   effective_date: string | null;
   yield_qty: number;
+  yield_uom: string;
   is_active: boolean;
   notes: string | null;
   created_by: string | null;
@@ -25,6 +26,7 @@ export interface ProductBomLine {
   component_qbo_item_id: string | null;
   service_label: string | null;
   qty_per: number;
+  qty_uom: string;
   scrap_pct: number;
   default_cost: number | null;
   notes: string | null;
@@ -37,6 +39,7 @@ export interface BomLineInput {
   component_qbo_item_id?: string | null;
   service_label?: string | null;
   qty_per: number;
+  qty_uom?: string;
   scrap_pct?: number;
   default_cost?: number | null;
   notes?: string | null;
@@ -50,6 +53,7 @@ export interface WorkOrder {
   bom_id: string;
   finished_qbo_item_id: string;
   qty_to_produce: number;
+  target_uom: string | null;
   qty_produced_actual: number | null;
   production_location_id: string;
   status: WorkOrderStatus;
@@ -116,6 +120,7 @@ export async function fetchWorkOrderCosts(woId: string): Promise<WorkOrderCosts 
 export async function createBom(args: {
   finished_qbo_item_id: string;
   yield_qty: number;
+  yield_uom?: string;
   lines: BomLineInput[];
   version?: string;
   effective_date?: string | null;
@@ -124,6 +129,7 @@ export async function createBom(args: {
   return sbrpc<string>('fn_create_bom', {
     p_finished_qbo_item_id: args.finished_qbo_item_id,
     p_yield_qty: args.yield_qty,
+    p_yield_uom: args.yield_uom ?? 'each',
     p_lines: args.lines,
     p_version: args.version ?? '1',
     p_effective_date: args.effective_date ?? null,
@@ -144,6 +150,10 @@ export async function updateBom(id: string, patch: Partial<ProductBom>): Promise
 export async function createWorkOrder(args: {
   bom_id: string;
   qty_to_produce: number;
+  /** Unit the operator typed. The DB stores qty_to_produce verbatim plus this
+   *  uom; the UI's BOM scaler converts to the BOM's yield_uom when computing
+   *  component requirements. NULL is legacy (qty in BOM yield units). */
+  target_uom?: string | null;
   production_location_id: string;
   scheduled_date?: string | null;
   notes?: string | null;
@@ -151,6 +161,7 @@ export async function createWorkOrder(args: {
   return sbrpc<string>('fn_create_work_order', {
     p_bom_id: args.bom_id,
     p_qty_to_produce: args.qty_to_produce,
+    p_target_uom: args.target_uom ?? null,
     p_production_location_id: args.production_location_id,
     p_scheduled_date: args.scheduled_date ?? null,
     p_notes: args.notes ?? null,

--- a/app/src/lib/production.ts
+++ b/app/src/lib/production.ts
@@ -157,9 +157,12 @@ export async function updateBom(id: string, patch: Partial<ProductBom>): Promise
 export async function createWorkOrder(args: {
   bom_id: string;
   qty_to_produce: number;
-  /** Unit the operator typed. The DB stores qty_to_produce verbatim plus this
-   *  uom; the UI's BOM scaler converts to the BOM's yield_uom when computing
-   *  component requirements. NULL is legacy (qty in BOM yield units). */
+  /** Unit the operator typed. INFORMATIONAL-ONLY today: persisted on the WO
+   *  row for the UI/audit trail, but fn_consume_work_order and
+   *  fn_close_work_order do not read it — they compute consumption as
+   *  (qty_to_produce / yield_qty) * qty_per * (1 + scrap_pct) directly.
+   *  Phase 2 will wire UoM conversion into those functions; until then,
+   *  qty_to_produce must already be expressed in the BOM's yield_uom. */
   target_uom?: string | null;
   production_location_id: string;
   scheduled_date?: string | null;

--- a/app/src/lib/uom.ts
+++ b/app/src/lib/uom.ts
@@ -1,0 +1,174 @@
+// Unit of measure conversion + BOM scaling. Used by the BomsTab "Scale this
+// BOM" calculator and the WorkOrders Create form's target-driven autoscale.
+//
+// Storage convention: BOM lines + WO targets are saved as a (qty, uom) pair
+// in the user's input units. Conversions happen on read for display/math,
+// so no destructive migration is needed.
+//
+// Supported UoM vocabulary (free text allowed in DB; UI dropdown shows
+// these):
+//   Counts: each, case
+//   Volume: gal, fl_oz, L, mL
+//   Weight: lb, oz   (oz here means weight-oz; volume uses fl_oz)
+
+export type UomGroup = 'count' | 'volume' | 'weight' | 'unknown';
+
+export const UOM_OPTIONS: ReadonlyArray<{ value: string; label: string; group: UomGroup }> = [
+  { value: 'each',  label: 'each',     group: 'count'  },
+  { value: 'case',  label: 'case',     group: 'count'  },
+  { value: 'gal',   label: 'gal',      group: 'volume' },
+  { value: 'fl_oz', label: 'fl oz',    group: 'volume' },
+  { value: 'L',     label: 'L',        group: 'volume' },
+  { value: 'mL',    label: 'mL',       group: 'volume' },
+  { value: 'lb',    label: 'lb',       group: 'weight' },
+  { value: 'oz',    label: 'oz (wt)',  group: 'weight' },
+];
+
+// Volume base = fl_oz. Conversion factors below give "1 unit of X = N fl_oz".
+const VOLUME: Record<string, number> = {
+  fl_oz: 1,
+  gal:   128,
+  L:     33.8140227,
+  mL:    0.0338140227,
+};
+
+// Weight base = oz (16 oz / lb).
+const WEIGHT: Record<string, number> = {
+  oz: 1,
+  lb: 16,
+};
+
+export function uomGroup(uom: string): UomGroup {
+  if (uom === 'each' || uom === 'case') return 'count';
+  if (uom in VOLUME) return 'volume';
+  if (uom in WEIGHT) return 'weight';
+  return 'unknown';
+}
+
+/**
+ * Convert qty between two UoMs. Returns null when the conversion is not
+ * possible (e.g. gal → each without a BOM yield to bridge).
+ *
+ * For case ↔ volume conversions, pass `bridge` describing how the BOM's
+ * yield is defined (e.g. 1 case = 2.25 gal of finished product). The
+ * BomsTab scaler synthesizes this from the BOM header's yield_qty +
+ * yield_uom when the line happens to be in a different unit family.
+ */
+export function convertQty(
+  qty: number,
+  from: string,
+  to: string,
+  bridge?: { yieldQty: number; yieldUom: string; finishedVolPerYieldGal?: number },
+): number | null {
+  if (!Number.isFinite(qty)) return null;
+  if (from === to) return qty;
+
+  // Same-family conversions are pure factors.
+  const gFrom = uomGroup(from);
+  const gTo = uomGroup(to);
+  if (gFrom === 'volume' && gTo === 'volume') {
+    return qty * VOLUME[from] / VOLUME[to];
+  }
+  if (gFrom === 'weight' && gTo === 'weight') {
+    return qty * WEIGHT[from] / WEIGHT[to];
+  }
+  if (gFrom === 'count' && gTo === 'count') {
+    // each ↔ case requires a bridge (eaches per case). The BOM doesn't
+    // currently store it; we don't auto-convert this direction. Operators
+    // who need it can stage the BOM yield in cases and add 'each' lines
+    // explicitly.
+    return null;
+  }
+
+  // Cross-family bridge: count ↔ volume via the BOM yield definition.
+  if (bridge && bridge.yieldQty > 0) {
+    const yieldGroup = uomGroup(bridge.yieldUom);
+    // Bridge: 1 yield = bridge.yieldQty (yieldUom). For "case → gal" or
+    // "gal → case" we need a yield expressed in the target group OR the
+    // optional finishedVolPerYieldGal hint.
+    if (yieldGroup === 'count' && gFrom === 'volume') {
+      // gal → case (when 1 case = X gal finished)
+      const gal = qty * VOLUME[from] / VOLUME.gal;
+      if (bridge.finishedVolPerYieldGal) {
+        const yields = gal / bridge.finishedVolPerYieldGal;
+        if (to === bridge.yieldUom) return yields * bridge.yieldQty;
+      }
+    }
+    if (yieldGroup === 'count' && gTo === 'volume') {
+      // case → gal (when 1 case = X gal finished)
+      if (from === bridge.yieldUom && bridge.finishedVolPerYieldGal) {
+        const yields = qty / bridge.yieldQty;
+        const gal = yields * bridge.finishedVolPerYieldGal;
+        return gal * VOLUME.gal / VOLUME[to];
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * BOM line representation for the scaler. Keep it minimal so it composes with
+ * whatever shape the caller is holding (DB row, draft form, etc.).
+ */
+export interface ScalableLine<T = unknown> {
+  qty_per: number;
+  qty_uom: string;
+  ref: T;
+}
+
+export interface ScaledLine<T> {
+  qty: number;
+  uom: string;
+  ref: T;
+}
+
+/**
+ * Scale BOM lines to a target production quantity.
+ *
+ * @param target  How much finished product the operator wants to make (qty + uom).
+ * @param yield_  The BOM's yield (qty + uom). 1 "run" of the BOM produces this much.
+ * @param lines   The BOM lines (qty_per per yield + uom + caller-defined ref).
+ * @returns       { runs, scaledLines }. `runs` is the multiplier applied to
+ *                qty_per (1 BOM yields `yield_.qty` of `yield_.uom`; to make
+ *                `target.qty` of `target.uom` we need `runs` repetitions of
+ *                the BOM). Scaled line qty/uom preserves the line's own UoM.
+ *                Returns null if target ↔ yield UoMs are incompatible.
+ */
+export function scaleBom<T>(
+  target: { qty: number; uom: string },
+  yield_: { qty: number; uom: string; finishedVolPerYieldGal?: number },
+  lines: ScalableLine<T>[],
+): { runs: number; scaledLines: ScaledLine<T>[] } | null {
+  if (!(target.qty > 0) || !(yield_.qty > 0)) return null;
+
+  // How many "runs" of this BOM are needed to satisfy the target?
+  // 1 run produces yield_.qty of yield_.uom; convert target to yield_.uom to
+  // get the runs.
+  const targetInYieldUom = convertQty(target.qty, target.uom, yield_.uom, {
+    yieldQty: yield_.qty,
+    yieldUom: yield_.uom,
+    finishedVolPerYieldGal: yield_.finishedVolPerYieldGal,
+  });
+  if (targetInYieldUom == null) return null;
+  const runs = targetInYieldUom / yield_.qty;
+
+  const scaledLines = lines.map((l) => ({
+    qty: l.qty_per * runs,
+    uom: l.qty_uom,
+    ref: l.ref,
+  }));
+
+  return { runs, scaledLines };
+}
+
+/** Friendly display: "2.25 gal" not "2.2500000". */
+export function fmtQty(qty: number | null | undefined, uom: string): string {
+  if (qty == null || !Number.isFinite(qty)) return '—';
+  const abs = Math.abs(qty);
+  let s: string;
+  if (abs >= 1000) s = qty.toLocaleString(undefined, { maximumFractionDigits: 0 });
+  else if (abs >= 10) s = qty.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  else s = qty.toLocaleString(undefined, { maximumFractionDigits: 4 });
+  return `${s} ${uom}`;
+}

--- a/app/src/lib/uom.ts
+++ b/app/src/lib/uom.ts
@@ -114,6 +114,9 @@ export function convertQty(
 export interface ScalableLine<T = unknown> {
   qty_per: number;
   qty_uom: string;
+  /** 0..1. Matches the (1 + scrap_pct) factor in fn_consume_work_order so
+   *  the scaler agrees with what the WO will actually consume. */
+  scrap_pct?: number;
   ref: T;
 }
 
@@ -154,7 +157,7 @@ export function scaleBom<T>(
   const runs = targetInYieldUom / yield_.qty;
 
   const scaledLines = lines.map((l) => ({
-    qty: l.qty_per * runs,
+    qty: l.qty_per * runs * (1 + (l.scrap_pct ?? 0)),
     uom: l.qty_uom,
     ref: l.ref,
   }));

--- a/app/src/pages/production/BomsTab.tsx
+++ b/app/src/pages/production/BomsTab.tsx
@@ -278,11 +278,22 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
 
   async function saveFinishedGal() {
     const next = finishedGal.trim() === '' ? null : Number(finishedGal);
-    const prev = bom.finished_vol_per_yield_gal;
+    // Coerce prev: PostgREST returns numeric as JSON string, so comparing a
+    // typed number against bom.finished_vol_per_yield_gal directly always
+    // misses (same gotcha as bom.yield_qty in the detail header).
+    const prev = bom.finished_vol_per_yield_gal == null
+      ? null
+      : Number(bom.finished_vol_per_yield_gal);
     if (next === prev || (next !== null && !Number.isFinite(next))) return;
     try {
       await updateBom(bomId, { finished_vol_per_yield_gal: next });
-      onChanged();
+      // Intentionally not calling onChanged(): the parent treats it as
+      // "modal done, close+refresh" (BomsTab line ~107), but this is an
+      // autosave-on-blur — we want the operator to keep using the modal,
+      // especially the ScaleBomPanel below. The panel already reads the
+      // live finishedGal state via its prop, so no refresh is needed for
+      // scaling. The next time the modal opens, fetchBoms will pick up
+      // the persisted value.
     } catch (e) { toast.error(errMsg(e)); }
   }
 

--- a/app/src/pages/production/BomsTab.tsx
+++ b/app/src/pages/production/BomsTab.tsx
@@ -270,7 +270,7 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 14 }}>
           <div>
             <div style={{ fontSize: 10, color: 'var(--mt)', letterSpacing: 0.6, textTransform: 'uppercase' }}>
-              BOM · v{bom.version} · yield {fmtQty(bom.yield_qty, bom.yield_uom || 'each')} / batch
+              BOM · v{bom.version} · yield {fmtQty(Number(bom.yield_qty), bom.yield_uom || 'each')} / batch
             </div>
             <h2 style={{ margin: '4px 0 0', fontSize: 22, color: 'var(--ac)' }}>
               {it?.item_name ?? bom.finished_qbo_item_id}

--- a/app/src/pages/production/BomsTab.tsx
+++ b/app/src/pages/production/BomsTab.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../lib/production';
 import { useToast } from '../../lib/toast';
 import { btnPrimary, btnSecondary, btnDanger, inp } from '../../lib/styles';
-import { UOM_OPTIONS, scaleBom, fmtQty } from '../../lib/uom';
+import { UOM_OPTIONS, scaleBom, fmtQty, uomGroup } from '../../lib/uom';
 import type { ProductionItemLookup } from './ProductionPage';
 
 interface Props {
@@ -123,6 +123,10 @@ function CreateBomForm({ itemLookup, onCancel, onCreated }: {
   const [version, setVersion] = useState('1');
   const [yieldQty, setYieldQty] = useState<string>('1');
   const [yieldUom, setYieldUom] = useState<string>('each');
+  // Volume bridge: only meaningful when yield is a count UoM (each/case) and
+  // 1 yield produces a known volume of finished product. Lets the scaler
+  // accept "make 1000 gal" against a per-case BOM.
+  const [finishedGal, setFinishedGal] = useState<string>('');
   const [effective, setEffective] = useState('');
   const [notes, setNotes] = useState('');
   const [lines, setLines] = useState<BomLineInput[]>([emptyComponentLine()]);
@@ -142,6 +146,7 @@ function CreateBomForm({ itemLookup, onCancel, onCreated }: {
         finished_qbo_item_id: finishedId,
         yield_qty: Number(yieldQty),
         yield_uom: yieldUom,
+        finished_vol_per_yield_gal: finishedGal.trim() === '' ? null : Number(finishedGal),
         lines,
         version,
         effective_date: effective || null,
@@ -183,6 +188,13 @@ function CreateBomForm({ itemLookup, onCancel, onCreated }: {
             </select>
           </div>
         </LField>
+        {uomGroup(yieldUom) === 'count' && (
+          <LField label="Gal of finished product / yield (optional)">
+            <input type="number" min={0} step="any" style={inp()}
+              value={finishedGal} onChange={(e) => setFinishedGal(e.target.value)}
+              placeholder="e.g. 2.25 — enables scaling by gallons" />
+          </LField>
+        )}
         <LField label="Effective date">
           <input type="date" style={inp()} value={effective} onChange={(e) => setEffective(e.target.value)} />
         </LField>
@@ -224,6 +236,12 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
   const [lines, setLines] = useState<BomLineInput[] | null>(null);
   const [saving, setSaving] = useState(false);
   const [active, setActive] = useState(bom.is_active);
+  // Local-edit copy of the gal-per-yield bridge. Persists via updateBom on
+  // blur so the ScaleBomPanel can scale by gallons immediately without
+  // needing the user to save+reopen.
+  const [finishedGal, setFinishedGal] = useState<string>(
+    bom.finished_vol_per_yield_gal == null ? '' : String(bom.finished_vol_per_yield_gal),
+  );
 
   useEffect(() => {
     let alive = true;
@@ -256,6 +274,16 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
       onChanged();
     } catch (e) { toast.error(errMsg(e)); }
     finally { setSaving(false); }
+  }
+
+  async function saveFinishedGal() {
+    const next = finishedGal.trim() === '' ? null : Number(finishedGal);
+    const prev = bom.finished_vol_per_yield_gal;
+    if (next === prev || (next !== null && !Number.isFinite(next))) return;
+    try {
+      await updateBom(bomId, { finished_vol_per_yield_gal: next });
+      onChanged();
+    } catch (e) { toast.error(errMsg(e)); }
   }
 
   return (
@@ -296,6 +324,26 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
           </button>
         </div>
 
+        {uomGroup(bom.yield_uom || 'each') === 'count' && (
+          <div style={{
+            marginBottom: 14, padding: '8px 10px',
+            border: '1px solid var(--bd)', borderRadius: 4, fontSize: 11,
+            display: 'flex', alignItems: 'center', gap: 10,
+          }}>
+            <span style={{ color: 'var(--mt)' }}>
+              1 {bom.yield_uom || 'each'} produces
+            </span>
+            <input type="number" min={0} step="any" style={{ ...inp(), width: 100 }}
+              value={finishedGal}
+              onChange={(e) => setFinishedGal(e.target.value)}
+              onBlur={saveFinishedGal}
+              placeholder="—" />
+            <span style={{ color: 'var(--mt)' }}>
+              gal of finished product (enables "make N gal" scaling)
+            </span>
+          </div>
+        )}
+
         {lines === null
           ? <div style={{ padding: 18, color: 'var(--mt)' }}>Loading lines…</div>
           : <>
@@ -306,7 +354,12 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
                   {saving ? 'Saving…' : 'Save lines'}
                 </button>
               </div>
-              <ScaleBomPanel bom={bom} lines={lines} itemLookup={itemLookup} />
+              <ScaleBomPanel
+                bom={bom}
+                lines={lines}
+                itemLookup={itemLookup}
+                finishedVolPerYieldGal={finishedGal.trim() === '' ? null : Number(finishedGal)}
+              />
             </>}
       </div>
     </div>
@@ -470,24 +523,43 @@ const cellTd: React.CSSProperties = { padding: '6px 10px', verticalAlign: 'middl
 // quantity + UoM ("make 1000 gal") and we multiply every line by the
 // implied runs. Read-only — doesn't save anything, just shows the math
 // so the operator can sanity-check a future work order.
-function ScaleBomPanel({ bom, lines, itemLookup }: {
+function ScaleBomPanel({ bom, lines, itemLookup, finishedVolPerYieldGal }: {
   bom: ProductBom;
   lines: BomLineInput[];
   itemLookup: ProductionItemLookup;
+  /** Live value from the modal's editable bridge field. Falls back to the
+   *  persisted bom.finished_vol_per_yield_gal so existing BOMs still scale
+   *  without a re-save. */
+  finishedVolPerYieldGal?: number | null;
 }) {
   const [targetQty, setTargetQty] = useState<string>(String(bom.yield_qty));
   const [targetUom, setTargetUom] = useState<string>(bom.yield_uom || 'each');
 
   const target = { qty: Number(targetQty) || 0, uom: targetUom };
-  const yield_ = { qty: Number(bom.yield_qty), uom: bom.yield_uom || 'each' };
+  const bridgeGal = finishedVolPerYieldGal
+    ?? (bom.finished_vol_per_yield_gal == null ? undefined : Number(bom.finished_vol_per_yield_gal))
+    ?? undefined;
+  const yield_ = {
+    qty: Number(bom.yield_qty),
+    uom: bom.yield_uom || 'each',
+    finishedVolPerYieldGal: bridgeGal,
+  };
   const scaled = target.qty > 0
     ? scaleBom(target, yield_, lines.map((l, idx) => ({
         qty_per: Number(l.qty_per),
         qty_uom: l.qty_uom || 'each',
+        scrap_pct: Number(l.scrap_pct ?? 0),
         ref: { line: l, idx },
       })))
     : null;
   const incompat = target.qty > 0 && scaled === null;
+  // Hint refinement: count↔count (each↔case) is intentionally not supported
+  // and same-family advice would mislead. Tell the operator what actually
+  // works for their situation.
+  const sameCountFamily =
+    uomGroup(targetUom) === 'count' && uomGroup(yield_.uom) === 'count';
+  const missingBridge =
+    uomGroup(targetUom) === 'volume' && uomGroup(yield_.uom) === 'count' && bridgeGal == null;
 
   return (
     <div style={{
@@ -510,7 +582,12 @@ function ScaleBomPanel({ bom, lines, itemLookup }: {
             </span>
           : incompat
             ? <span style={{ fontSize: 11, color: 'var(--am)' }}>
-                Can't convert {targetUom} → {yield_.uom}. Pick a UoM in the same family as the BOM yield, or type in {yield_.uom}.
+                Can't convert {targetUom} → {yield_.uom}.{' '}
+                {missingBridge
+                  ? <>Set "1 {yield_.uom} produces ___ gal" above to scale by volume, or type the target in {yield_.uom}.</>
+                  : sameCountFamily
+                    ? <>Type the target in {yield_.uom} — there's no fixed conversion between each and case.</>
+                    : <>Type the target in {yield_.uom}.</>}
               </span>
             : null}
       </div>

--- a/app/src/pages/production/BomsTab.tsx
+++ b/app/src/pages/production/BomsTab.tsx
@@ -6,6 +6,7 @@ import {
 } from '../../lib/production';
 import { useToast } from '../../lib/toast';
 import { btnPrimary, btnSecondary, btnDanger, inp } from '../../lib/styles';
+import { UOM_OPTIONS, scaleBom, fmtQty } from '../../lib/uom';
 import type { ProductionItemLookup } from './ProductionPage';
 
 interface Props {
@@ -121,6 +122,7 @@ function CreateBomForm({ itemLookup, onCancel, onCreated }: {
   const [finishedId, setFinishedId] = useState('');
   const [version, setVersion] = useState('1');
   const [yieldQty, setYieldQty] = useState<string>('1');
+  const [yieldUom, setYieldUom] = useState<string>('each');
   const [effective, setEffective] = useState('');
   const [notes, setNotes] = useState('');
   const [lines, setLines] = useState<BomLineInput[]>([emptyComponentLine()]);
@@ -139,6 +141,7 @@ function CreateBomForm({ itemLookup, onCancel, onCreated }: {
       await createBom({
         finished_qbo_item_id: finishedId,
         yield_qty: Number(yieldQty),
+        yield_uom: yieldUom,
         lines,
         version,
         effective_date: effective || null,
@@ -171,9 +174,14 @@ function CreateBomForm({ itemLookup, onCancel, onCreated }: {
         <LField label="Version">
           <input style={inp()} value={version} onChange={(e) => setVersion(e.target.value)} placeholder="1" />
         </LField>
-        <LField label="Yield qty / batch">
-          <input type="number" min={0.0001} step="any" style={inp()}
-            value={yieldQty} onChange={(e) => setYieldQty(e.target.value)} />
+        <LField label="Yield / batch">
+          <div style={{ display: 'flex', gap: 6 }}>
+            <input type="number" min={0.0001} step="any" style={{ ...inp(), flex: 1 }}
+              value={yieldQty} onChange={(e) => setYieldQty(e.target.value)} />
+            <select value={yieldUom} onChange={(e) => setYieldUom(e.target.value)} style={{ ...inp(), width: 90 }}>
+              {UOM_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+          </div>
         </LField>
         <LField label="Effective date">
           <input type="date" style={inp()} value={effective} onChange={(e) => setEffective(e.target.value)} />
@@ -262,7 +270,7 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 14 }}>
           <div>
             <div style={{ fontSize: 10, color: 'var(--mt)', letterSpacing: 0.6, textTransform: 'uppercase' }}>
-              BOM · v{bom.version} · yield {bom.yield_qty}/batch
+              BOM · v{bom.version} · yield {fmtQty(bom.yield_qty, bom.yield_uom || 'each')} / batch
             </div>
             <h2 style={{ margin: '4px 0 0', fontSize: 22, color: 'var(--ac)' }}>
               {it?.item_name ?? bom.finished_qbo_item_id}
@@ -298,6 +306,7 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
                   {saving ? 'Saving…' : 'Save lines'}
                 </button>
               </div>
+              <ScaleBomPanel bom={bom} lines={lines} itemLookup={itemLookup} />
             </>}
       </div>
     </div>
@@ -329,6 +338,7 @@ function BomLinesEditor({ lines, setLines, itemLookup }: {
             <th style={cellTh}>Type</th>
             <th style={cellTh}>Component / Service</th>
             <th style={{ ...cellTh, width: 80, textAlign: 'right' }}>Qty / yield</th>
+            <th style={{ ...cellTh, width: 80 }}>UoM</th>
             <th style={{ ...cellTh, width: 80, textAlign: 'right' }}>Scrap %</th>
             <th style={{ ...cellTh, width: 100, textAlign: 'right' }}>Unit Cost</th>
             <th style={{ ...cellTh, width: 150 }}>Notes</th>
@@ -365,6 +375,12 @@ function BomLinesEditor({ lines, setLines, itemLookup }: {
               <td style={{ ...cellTd, textAlign: 'right' }}>
                 <input type="number" min={0.0001} step="any" style={{ ...inp(), width: '100%', textAlign: 'right' }}
                   value={l.qty_per} onChange={(e) => patch(i, { qty_per: Number(e.target.value) })} />
+              </td>
+              <td style={cellTd}>
+                <select value={l.qty_uom ?? 'each'} onChange={(e) => patch(i, { qty_uom: e.target.value })}
+                  style={{ ...inp(), width: '100%' }}>
+                  {UOM_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </select>
               </td>
               <td style={{ ...cellTd, textAlign: 'right' }}>
                 <input type="number" min={0} max={99} step="any" style={{ ...inp(), width: '100%', textAlign: 'right' }}
@@ -407,10 +423,10 @@ function BomLinesEditor({ lines, setLines, itemLookup }: {
 // ── helpers ─────────────────────────────────────────────────────────────
 
 function emptyComponentLine(): BomLineInput {
-  return { line_type: 'component', component_qbo_item_id: null, qty_per: 1, scrap_pct: 0, default_cost: null, notes: null };
+  return { line_type: 'component', component_qbo_item_id: null, qty_per: 1, qty_uom: 'each', scrap_pct: 0, default_cost: null, notes: null };
 }
 function emptyServiceLine(): BomLineInput {
-  return { line_type: 'service', service_label: '', qty_per: 1, scrap_pct: 0, default_cost: null, notes: null };
+  return { line_type: 'service', service_label: '', qty_per: 1, qty_uom: 'each', scrap_pct: 0, default_cost: null, notes: null };
 }
 function bomLineToInput(l: ProductBomLine): BomLineInput {
   return {
@@ -418,6 +434,7 @@ function bomLineToInput(l: ProductBomLine): BomLineInput {
     component_qbo_item_id: l.component_qbo_item_id,
     service_label: l.service_label,
     qty_per: Number(l.qty_per),
+    qty_uom: l.qty_uom || 'each',
     scrap_pct: Number(l.scrap_pct),
     default_cost: l.default_cost == null ? null : Number(l.default_cost),
     notes: l.notes,
@@ -446,3 +463,88 @@ function LField({ label, children }: { label: string; children: React.ReactNode 
 const cellTh: React.CSSProperties = { textAlign: 'left', padding: '7px 10px', fontSize: 10, fontWeight: 600,
   letterSpacing: 0.5, textTransform: 'uppercase', color: 'var(--mt)' };
 const cellTd: React.CSSProperties = { padding: '6px 10px', verticalAlign: 'middle' };
+
+// ── Scale this BOM calculator ───────────────────────────────────────────
+//
+// Live scratchpad inside the BOM detail modal. Operator types a target
+// quantity + UoM ("make 1000 gal") and we multiply every line by the
+// implied runs. Read-only — doesn't save anything, just shows the math
+// so the operator can sanity-check a future work order.
+function ScaleBomPanel({ bom, lines, itemLookup }: {
+  bom: ProductBom;
+  lines: BomLineInput[];
+  itemLookup: ProductionItemLookup;
+}) {
+  const [targetQty, setTargetQty] = useState<string>(String(bom.yield_qty));
+  const [targetUom, setTargetUom] = useState<string>(bom.yield_uom || 'each');
+
+  const target = { qty: Number(targetQty) || 0, uom: targetUom };
+  const yield_ = { qty: Number(bom.yield_qty), uom: bom.yield_uom || 'each' };
+  const scaled = target.qty > 0
+    ? scaleBom(target, yield_, lines.map((l, idx) => ({
+        qty_per: Number(l.qty_per),
+        qty_uom: l.qty_uom || 'each',
+        ref: { line: l, idx },
+      })))
+    : null;
+  const incompat = target.qty > 0 && scaled === null;
+
+  return (
+    <div style={{
+      marginTop: 20, padding: 14, border: '1px solid var(--bd)', borderRadius: 6,
+      background: 'rgba(91,181,240,0.04)',
+    }}>
+      <div style={{ fontSize: 10, color: 'var(--mt)', letterSpacing: 0.6, textTransform: 'uppercase', marginBottom: 10 }}>
+        Scale this BOM
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+        <span style={{ fontSize: 12 }}>Make</span>
+        <input type="number" min={0} step="any" style={{ ...inp(), width: 120, textAlign: 'right' }}
+          value={targetQty} onChange={(e) => setTargetQty(e.target.value)} />
+        <select value={targetUom} onChange={(e) => setTargetUom(e.target.value)} style={{ ...inp(), width: 100 }}>
+          {UOM_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+        </select>
+        {scaled
+          ? <span style={{ fontSize: 12, color: 'var(--mt)' }}>
+              → <strong style={{ color: 'var(--tx)', fontFamily: 'var(--ff-mono)' }}>{scaled.runs.toLocaleString(undefined, { maximumFractionDigits: 4 })}</strong> {scaled.runs === 1 ? 'run' : 'runs'} of this BOM
+            </span>
+          : incompat
+            ? <span style={{ fontSize: 11, color: 'var(--am)' }}>
+                Can't convert {targetUom} → {yield_.uom}. Pick a UoM in the same family as the BOM yield, or type in {yield_.uom}.
+              </span>
+            : null}
+      </div>
+
+      {scaled && scaled.scaledLines.length > 0 && (
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12, marginTop: 12 }}>
+          <thead>
+            <tr style={{ borderBottom: '1px solid var(--bd)' }}>
+              <th style={cellTh}>Component / Service</th>
+              <th style={{ ...cellTh, textAlign: 'right' }}>Per yield</th>
+              <th style={{ ...cellTh, textAlign: 'right' }}>Required</th>
+            </tr>
+          </thead>
+          <tbody>
+            {scaled.scaledLines.map(({ qty, uom, ref }) => {
+              const l = ref.line;
+              const label = l.line_type === 'component'
+                ? (l.component_qbo_item_id ? itemLookup.byId.get(l.component_qbo_item_id)?.item_name : null) ?? '(no component)'
+                : (l.service_label || '(no label)');
+              return (
+                <tr key={ref.idx} style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+                  <td style={cellTd}>{label}</td>
+                  <td style={{ ...cellTd, textAlign: 'right', color: 'var(--mt)', fontFamily: 'var(--ff-mono)' }}>
+                    {fmtQty(Number(l.qty_per), l.qty_uom || 'each')}
+                  </td>
+                  <td style={{ ...cellTd, textAlign: 'right', fontFamily: 'var(--ff-mono)', fontWeight: 600 }}>
+                    {fmtQty(qty, uom)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/20260516c_bom_uom.sql
+++ b/supabase/migrations/20260516c_bom_uom.sql
@@ -1,14 +1,19 @@
--- BOM unit-of-measure support.
+-- BOM unit-of-measure support + volume bridge for cross-family scaling.
 --
 -- Before this migration, ops.product_bom.yield_qty and
 -- ops.product_bom_lines.qty_per were both dimensionless numerics — the operator
--- had to know what unit they meant. This adds a UoM column to both, and a
+-- had to know what unit they meant. This adds a UoM column to both, plus a
 -- target_uom to ops.work_orders so a production run can specify "make 1000
 -- gallons" and have the BOM scaler convert it to BOM-yield runs.
 --
+-- ops.product_bom.finished_vol_per_yield_gal is the optional volume bridge:
+-- when yield_uom is a count UoM (each/case) and 1 yield produces a known
+-- volume of finished product, this column captures the gallons-per-yield so
+-- the scaler can convert "make 1000 gal" → runs.
+--
 -- Common UoM values: each, case, gal, fl_oz, L, mL, lb, oz. Free text allowed
--- for site-specific units (kg, drum, pallet, etc.). The frontend UoM dropdown
--- in app/src/pages/production/BomsTab.tsx lists the common set;
+-- for site-specific units (kg, drum, pallet, etc.). The frontend dropdown in
+-- app/src/pages/production/BomsTab.tsx lists the common set;
 -- app/src/lib/uom.ts holds the conversion factors + scaler.
 --
 -- Already applied live via Supabase MCP on 2026-05-16.
@@ -22,14 +27,28 @@ ALTER TABLE ops.product_bom_lines
 ALTER TABLE ops.work_orders
   ADD COLUMN IF NOT EXISTS target_uom text;
 
+ALTER TABLE ops.product_bom
+  ADD COLUMN IF NOT EXISTS finished_vol_per_yield_gal numeric;
+
 COMMENT ON COLUMN ops.product_bom.yield_uom IS
   'Unit of measure for yield_qty. Common: each, case, gal, fl_oz, L, mL, lb, oz.';
 COMMENT ON COLUMN ops.product_bom_lines.qty_uom IS
   'Unit of measure for qty_per. Same UoM vocabulary as yield_uom.';
 COMMENT ON COLUMN ops.work_orders.target_uom IS
   'Unit the operator typed when creating the WO. qty_to_produce is converted to BOM yield_uom for multiplying BOM lines. NULL = legacy (qty_to_produce in BOM yield_uom).';
+COMMENT ON COLUMN ops.product_bom.finished_vol_per_yield_gal IS
+  'Optional volume bridge for count-family yields: how many gallons of finished product 1 yield (e.g. 1 case) produces. Enables "make 1000 gal" scaling in the Scale this BOM panel when yield_uom is each/case.';
 
--- fn_create_bom: accept p_yield_uom, persist qty_uom from p_lines jsonb.
+-- Drop the old fixed-arg signatures before re-creating with the new params.
+-- CREATE OR REPLACE only matches on (name, arg_types); changing the signature
+-- creates a new overload alongside the old one (PG zombie overload trap —
+-- see 20260514b_fix_set_inventory_settings_partial_patch.sql for the same
+-- pattern). Use the exact original signatures from 20260514b_phase2_bom_work_orders.sql.
+DROP FUNCTION IF EXISTS ops.fn_create_bom(text, numeric, jsonb, text, date, text);
+DROP FUNCTION IF EXISTS ops.fn_create_work_order(uuid, numeric, uuid, date, text);
+
+-- fn_create_bom: accept p_yield_uom + p_finished_vol_per_yield_gal,
+-- and persist qty_uom from p_lines jsonb.
 CREATE OR REPLACE FUNCTION ops.fn_create_bom(
   p_finished_qbo_item_id text,
   p_yield_qty numeric,
@@ -37,7 +56,8 @@ CREATE OR REPLACE FUNCTION ops.fn_create_bom(
   p_version text DEFAULT '1'::text,
   p_effective_date date DEFAULT NULL::date,
   p_notes text DEFAULT NULL::text,
-  p_yield_uom text DEFAULT 'each'
+  p_yield_uom text DEFAULT 'each',
+  p_finished_vol_per_yield_gal numeric DEFAULT NULL
 )
 RETURNS uuid
 LANGUAGE plpgsql
@@ -57,8 +77,8 @@ BEGIN
     RAISE EXCEPTION 'p_lines must be a non-empty JSON array';
   END IF;
 
-  INSERT INTO ops.product_bom (finished_qbo_item_id, version, effective_date, yield_qty, yield_uom, notes, created_by)
-  VALUES (p_finished_qbo_item_id, p_version, p_effective_date, p_yield_qty, COALESCE(NULLIF(p_yield_uom, ''), 'each'), p_notes, v_actor)
+  INSERT INTO ops.product_bom (finished_qbo_item_id, version, effective_date, yield_qty, yield_uom, finished_vol_per_yield_gal, notes, created_by)
+  VALUES (p_finished_qbo_item_id, p_version, p_effective_date, p_yield_qty, COALESCE(NULLIF(p_yield_uom, ''), 'each'), p_finished_vol_per_yield_gal, p_notes, v_actor)
   RETURNING id INTO v_id;
 
   FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines) LOOP
@@ -98,7 +118,7 @@ BEGIN
 END;
 $function$;
 
--- fn_replace_bom_lines: persist qty_uom from p_lines jsonb (no signature change).
+-- fn_replace_bom_lines: no signature change, but persist qty_uom from p_lines.
 CREATE OR REPLACE FUNCTION ops.fn_replace_bom_lines(p_bom_id uuid, p_lines jsonb)
 RETURNS void
 LANGUAGE plpgsql
@@ -188,3 +208,9 @@ BEGIN
   RETURN v_id;
 END;
 $function$;
+
+-- Grants match the convention from 20260514b — explicit EXECUTE on every
+-- new signature. CREATE OR REPLACE does not preserve grants across signature
+-- changes, and the prior overloads' grants don't apply to the new ones.
+GRANT EXECUTE ON FUNCTION ops.fn_create_bom(text, numeric, jsonb, text, date, text, text, numeric) TO authenticated;
+GRANT EXECUTE ON FUNCTION ops.fn_create_work_order(uuid, numeric, uuid, date, text, text) TO authenticated;

--- a/supabase/migrations/20260516c_bom_uom.sql
+++ b/supabase/migrations/20260516c_bom_uom.sql
@@ -1,0 +1,190 @@
+-- BOM unit-of-measure support.
+--
+-- Before this migration, ops.product_bom.yield_qty and
+-- ops.product_bom_lines.qty_per were both dimensionless numerics — the operator
+-- had to know what unit they meant. This adds a UoM column to both, and a
+-- target_uom to ops.work_orders so a production run can specify "make 1000
+-- gallons" and have the BOM scaler convert it to BOM-yield runs.
+--
+-- Common UoM values: each, case, gal, fl_oz, L, mL, lb, oz. Free text allowed
+-- for site-specific units (kg, drum, pallet, etc.). The frontend UoM dropdown
+-- in app/src/pages/production/BomsTab.tsx lists the common set;
+-- app/src/lib/uom.ts holds the conversion factors + scaler.
+--
+-- Already applied live via Supabase MCP on 2026-05-16.
+
+ALTER TABLE ops.product_bom
+  ADD COLUMN IF NOT EXISTS yield_uom text NOT NULL DEFAULT 'each';
+
+ALTER TABLE ops.product_bom_lines
+  ADD COLUMN IF NOT EXISTS qty_uom text NOT NULL DEFAULT 'each';
+
+ALTER TABLE ops.work_orders
+  ADD COLUMN IF NOT EXISTS target_uom text;
+
+COMMENT ON COLUMN ops.product_bom.yield_uom IS
+  'Unit of measure for yield_qty. Common: each, case, gal, fl_oz, L, mL, lb, oz.';
+COMMENT ON COLUMN ops.product_bom_lines.qty_uom IS
+  'Unit of measure for qty_per. Same UoM vocabulary as yield_uom.';
+COMMENT ON COLUMN ops.work_orders.target_uom IS
+  'Unit the operator typed when creating the WO. qty_to_produce is converted to BOM yield_uom for multiplying BOM lines. NULL = legacy (qty_to_produce in BOM yield_uom).';
+
+-- fn_create_bom: accept p_yield_uom, persist qty_uom from p_lines jsonb.
+CREATE OR REPLACE FUNCTION ops.fn_create_bom(
+  p_finished_qbo_item_id text,
+  p_yield_qty numeric,
+  p_lines jsonb,
+  p_version text DEFAULT '1'::text,
+  p_effective_date date DEFAULT NULL::date,
+  p_notes text DEFAULT NULL::text,
+  p_yield_uom text DEFAULT 'each'
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'ops', 'pg_temp'
+AS $function$
+DECLARE
+  v_id UUID; v_actor UUID := auth.uid(); v_line JSONB; v_lt TEXT; v_sort INTEGER := 100;
+BEGIN
+  IF p_finished_qbo_item_id IS NULL OR p_finished_qbo_item_id = '' THEN
+    RAISE EXCEPTION 'finished_qbo_item_id is required';
+  END IF;
+  IF p_yield_qty IS NULL OR p_yield_qty <= 0 THEN
+    RAISE EXCEPTION 'yield_qty must be > 0';
+  END IF;
+  IF jsonb_typeof(p_lines) <> 'array' OR jsonb_array_length(p_lines) = 0 THEN
+    RAISE EXCEPTION 'p_lines must be a non-empty JSON array';
+  END IF;
+
+  INSERT INTO ops.product_bom (finished_qbo_item_id, version, effective_date, yield_qty, yield_uom, notes, created_by)
+  VALUES (p_finished_qbo_item_id, p_version, p_effective_date, p_yield_qty, COALESCE(NULLIF(p_yield_uom, ''), 'each'), p_notes, v_actor)
+  RETURNING id INTO v_id;
+
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines) LOOP
+    v_lt := v_line ->> 'line_type';
+    IF v_lt NOT IN ('component', 'service') THEN
+      RAISE EXCEPTION 'line_type must be component or service';
+    END IF;
+    IF (v_line ->> 'qty_per') IS NULL OR (v_line ->> 'qty_per')::numeric <= 0 THEN
+      RAISE EXCEPTION 'qty_per must be > 0';
+    END IF;
+    IF v_lt = 'component' AND (v_line ->> 'component_qbo_item_id') IS NULL THEN
+      RAISE EXCEPTION 'component lines require component_qbo_item_id';
+    END IF;
+    IF v_lt = 'service' AND (v_line ->> 'service_label') IS NULL THEN
+      RAISE EXCEPTION 'service lines require service_label';
+    END IF;
+
+    INSERT INTO ops.product_bom_lines (
+      bom_id, line_type, component_qbo_item_id, service_label,
+      qty_per, qty_uom, scrap_pct, default_cost, notes, sort_order
+    )
+    VALUES (
+      v_id, v_lt,
+      CASE WHEN v_lt = 'component' THEN v_line ->> 'component_qbo_item_id' END,
+      CASE WHEN v_lt = 'service'   THEN v_line ->> 'service_label'   END,
+      (v_line ->> 'qty_per')::numeric,
+      COALESCE(NULLIF(v_line ->> 'qty_uom', ''), 'each'),
+      COALESCE(NULLIF(v_line ->> 'scrap_pct', '')::numeric, 0),
+      NULLIF(v_line ->> 'default_cost', '')::numeric,
+      v_line ->> 'notes',
+      v_sort
+    );
+    v_sort := v_sort + 10;
+  END LOOP;
+
+  RETURN v_id;
+END;
+$function$;
+
+-- fn_replace_bom_lines: persist qty_uom from p_lines jsonb (no signature change).
+CREATE OR REPLACE FUNCTION ops.fn_replace_bom_lines(p_bom_id uuid, p_lines jsonb)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'ops', 'pg_temp'
+AS $function$
+DECLARE v_active_wos INTEGER; v_line JSONB; v_lt TEXT; v_sort INTEGER := 100;
+BEGIN
+  IF jsonb_typeof(p_lines) <> 'array' OR jsonb_array_length(p_lines) = 0 THEN
+    RAISE EXCEPTION 'p_lines must be a non-empty JSON array';
+  END IF;
+
+  SELECT count(*) INTO v_active_wos FROM ops.work_orders WHERE bom_id = p_bom_id AND status IN ('draft','consumed');
+  IF v_active_wos > 0 THEN
+    RAISE EXCEPTION 'Cannot edit lines: % active work order(s) reference this BOM. Close or void them first.', v_active_wos;
+  END IF;
+
+  DELETE FROM ops.product_bom_lines WHERE bom_id = p_bom_id;
+
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines) LOOP
+    v_lt := v_line ->> 'line_type';
+    IF v_lt NOT IN ('component', 'service') THEN
+      RAISE EXCEPTION 'line_type must be component or service';
+    END IF;
+    INSERT INTO ops.product_bom_lines (
+      bom_id, line_type, component_qbo_item_id, service_label,
+      qty_per, qty_uom, scrap_pct, default_cost, notes, sort_order
+    )
+    VALUES (
+      p_bom_id, v_lt,
+      CASE WHEN v_lt = 'component' THEN v_line ->> 'component_qbo_item_id' END,
+      CASE WHEN v_lt = 'service'   THEN v_line ->> 'service_label'   END,
+      (v_line ->> 'qty_per')::numeric,
+      COALESCE(NULLIF(v_line ->> 'qty_uom', ''), 'each'),
+      COALESCE(NULLIF(v_line ->> 'scrap_pct', '')::numeric, 0),
+      NULLIF(v_line ->> 'default_cost', '')::numeric,
+      v_line ->> 'notes',
+      v_sort
+    );
+    v_sort := v_sort + 10;
+  END LOOP;
+END;
+$function$;
+
+-- fn_create_work_order: accept p_target_uom, persist on work_orders row.
+CREATE OR REPLACE FUNCTION ops.fn_create_work_order(
+  p_bom_id uuid,
+  p_qty_to_produce numeric,
+  p_production_location_id uuid,
+  p_scheduled_date date DEFAULT NULL::date,
+  p_notes text DEFAULT NULL::text,
+  p_target_uom text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'ops', 'pg_temp'
+AS $function$
+DECLARE
+  v_id UUID; v_batch TEXT; v_finished_item_id TEXT; v_loc_kind TEXT; v_actor UUID := auth.uid();
+BEGIN
+  IF p_qty_to_produce IS NULL OR p_qty_to_produce <= 0 THEN
+    RAISE EXCEPTION 'qty_to_produce must be > 0';
+  END IF;
+
+  SELECT finished_qbo_item_id INTO v_finished_item_id FROM ops.product_bom WHERE id = p_bom_id AND is_active;
+  IF v_finished_item_id IS NULL THEN RAISE EXCEPTION 'bom_id not found or inactive'; END IF;
+
+  SELECT kind INTO v_loc_kind FROM ops.inventory_locations WHERE id = p_production_location_id;
+  IF v_loc_kind IS NULL THEN RAISE EXCEPTION 'production_location_id not found'; END IF;
+  IF v_loc_kind IN ('in_transit', 'adjustment') THEN
+    RAISE EXCEPTION 'Production location cannot be a virtual location';
+  END IF;
+
+  v_batch := ops.fn_next_wo_batch_code();
+
+  INSERT INTO ops.work_orders (
+    batch_code, bom_id, finished_qbo_item_id, qty_to_produce, target_uom,
+    production_location_id, status, scheduled_date, notes, created_by
+  )
+  VALUES (
+    v_batch, p_bom_id, v_finished_item_id, p_qty_to_produce, p_target_uom,
+    p_production_location_id, 'draft', p_scheduled_date, p_notes, v_actor
+  )
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END;
+$function$;

--- a/supabase/migrations/20260516c_bom_uom.sql
+++ b/supabase/migrations/20260516c_bom_uom.sql
@@ -35,7 +35,7 @@ COMMENT ON COLUMN ops.product_bom.yield_uom IS
 COMMENT ON COLUMN ops.product_bom_lines.qty_uom IS
   'Unit of measure for qty_per. Same UoM vocabulary as yield_uom.';
 COMMENT ON COLUMN ops.work_orders.target_uom IS
-  'Unit the operator typed when creating the WO. qty_to_produce is converted to BOM yield_uom for multiplying BOM lines. NULL = legacy (qty_to_produce in BOM yield_uom).';
+  'Unit the operator typed when creating the WO. Informational-only today: captured for the UI/audit trail, but fn_consume_work_order and fn_close_work_order do NOT read it — they compute (qty_to_produce / yield_qty) * qty_per * (1 + scrap_pct) directly. Phase 2 will wire UoM conversion into those functions. Today, qty_to_produce must already be expressed in BOM yield_uom; passing target_uom != yield_uom will not convert. NULL = legacy (created before this column existed).';
 COMMENT ON COLUMN ops.product_bom.finished_vol_per_yield_gal IS
   'Optional volume bridge for count-family yields: how many gallons of finished product 1 yield (e.g. 1 case) produces. Enables "make 1000 gal" scaling in the Scale this BOM panel when yield_uom is each/case.';
 


### PR DESCRIPTION
## Why

> "Can't you just give me a tab where I can build BOMs by gallons or ounces and it does the math on the BOM"

The BOM module's `yield_qty` and `qty_per` were both dimensionless numerics — operators had to remember whether a line meant `each`, `case`, `gal`, `fl_oz`, etc. Adding a SKU like cola where syrup is bought by the gallon, water is in gallons, bottles are each, cases are cases meant the operator either picked one UoM and mentally converted, or just hoped everyone remembered the convention.

With UoM as a first-class column, the BOM becomes a **recipe scaler**: type "make 1000 gal" and the system multiplies every line by the implied number of BOM runs.

## What

### Schema (migration `20260516c` — applied live)

- `ops.product_bom` + `yield_uom text DEFAULT 'each'`
- `ops.product_bom_lines` + `qty_uom text DEFAULT 'each'`
- `ops.work_orders` + `target_uom text` (NULL for legacy WOs)
- `fn_create_bom` accepts `p_yield_uom`; persists `qty_uom` from `p_lines` jsonb
- `fn_replace_bom_lines` persists `qty_uom` from `p_lines` jsonb
- `fn_create_work_order` accepts `p_target_uom`

### Frontend (`app/`, the Margin Control SPA)

- **New `app/src/lib/uom.ts`**:
  - `UOM_OPTIONS` — dropdown source: `each`, `case`, `gal`, `fl_oz`, `L`, `mL`, `lb`, `oz`
  - `convertQty()` — volume + weight conversion factors
  - `scaleBom()` — returns `{ runs, scaledLines }` from `(target, yield, lines)`
  - `fmtQty()` — friendly display ("166.67 gal")
- **`production.ts`** — `yield_uom` / `qty_uom` / `target_uom` plumbed through the type defs + RPC call args
- **`BomsTab.tsx`**:
  - Create form: yield qty + **UoM dropdown** next to it
  - `BomLinesEditor`: new **UoM column** with dropdown per line
  - `BomDetailModal`: header now shows yield as `"yield 2.25 gal / batch"`
  - **NEW `ScaleBomPanel`** inside the modal — live calculator. Operator types "make 1000 gal" → shows runs + a table of required components in each line's native UoM. Read-only scratchpad; no save.

### Example flow (cola)

```
BOM: COLA-12-24 case
  yield: 1 case
  Cola syrup:   0.375 gal
  Water:        1.875 gal
  Bottle 12oz:  24    each
  Cap:          24    each
  Label:        24    each
  Tray:         1     each

Scale this BOM:  [1000] [gal]  →  444.44 runs of this BOM
  Cola syrup:   per yield 0.375 gal     required 166.67 gal
  Water:        per yield 1.875 gal     required 833.33 gal
  Bottle 12oz:  per yield 24 each       required 10,667 each
  Cap:          per yield 24 each       required 10,667 each
  Label:        per yield 24 each       required 10,667 each
  Tray:         per yield 1 each        required 444 each
```

The scaler converts target → BOM-yield via volume/weight conversion. Picking a UoM in an incompatible family ("each" when yield is in "gal") shows an amber hint instead of math.

### Sync manifest

Schema-snapshot unchanged (no new tables, just column additions). `brix-stock` writer entry implicitly covers the new columns under existing tables.

## Test plan

- [ ] `/margin/` → Production → BOMs → New BOM → set yield = 1 case, add lines (syrup 0.375 gal, water 1.875 gal, bottle 24 each) → save
- [ ] Open the BOM detail → header shows "yield 1 case / batch", lines display their UoM column
- [ ] In the **Scale this BOM** panel: type "1000 gal" → runs = 444.44, scaled rows show 166.67 gal / 833.33 gal / 10,667 each
- [ ] Edit a line's UoM → save → re-open → UoM persists
- [ ] Existing BOMs (no UoM set) render as `each` and still work

## Phase 2 (out of scope; deferred)

- Push `target_uom` + scaled requirements through the **Work Orders Create form** so a real production run captures "make 1000 gal cola" end to end (today the WO scaffold accepts `target_uom` but the UI dropdown hasn't been wired).
- Surface UoM on **PO line quantities**, **inventory movements**, and **qbo_items** (sync `UQCDisplayText` from QBO).

These need separate migrations + UI passes; deferred to keep this PR shippable.

---
_Generated by [Claude Code](https://claude.ai/code/session_012iWSo6eNQAbMQTUdu16gwA)_