### PR TITLE
ops(health): per-source freshness check + 2 gotcha notes in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ Legacy AP-tool mappings (Service COGS 101, Equipment Sales COGS 42) are the defa
 - **Hard-delete staff records** — set `status='inactive'` instead.
 - **Modify `ops.qbo_token_cache` or `ops.sf_token_cache` directly** — use the lease RPCs / Netlify Blobs.
 - **Add new writers to `ops.*` tables without updating `architecture/sync-manifest.json`.** The lint will fail the build.
+- **Commit build output (`public/expense/`, `public/sales-next/`) via the GitHub MCP `github_create_or_update_file` tool with pre-encoded base64.** The MCP base64-encodes whatever you pass — if you hand it pre-encoded base64, it gets double-encoded and stored as literal text on disk. Netlify then serves base64 text instead of HTML/JS and the SPA never loads. Either (a) run `npm run build --prefix app-expense` locally and commit via normal `git add/commit`, or (b) if you must use the MCP, pass the raw decoded content as a UTF-8 string. PR #61 was a full-day debug of this exact mistake.
+- **Default-schema bug in Supabase Edge Functions.** `createClient(url, key)` defaults the JS data client to schema `public`. All our tables live in `ops`. If you write an edge function that does `sb.from('qbo_invoices').insert(...)`, the insert silently no-ops (PostgREST returns an error, supabase-js doesn't throw). Always pass `{ db: { schema: 'ops' } }` to `createClient`, or use `.schema('ops').from(...)` per query. RPC calls (`.rpc(...)`) are name-based and not affected by this.
 
 ---
 

--- a/netlify/functions/health-watchdog.mjs
+++ b/netlify/functions/health-watchdog.mjs
@@ -7,6 +7,7 @@ import { requireScheduledOrAuth } from './lib/auth.mjs';
 import { sfRequest } from './sf-helpers.mjs';
 import { resqLogin, resqGql } from './resq-helpers.mjs';
 import { sendEmail, APPROVAL_EMAIL } from './email-helpers.mjs';
+import { createClient } from '@supabase/supabase-js';
 
 export const config = { schedule: '*/30 * * * *' };
 
@@ -97,6 +98,88 @@ async function checkSyncFreshness() {
       return { status: 'error', detail: `Last sync was ${ageMin} minutes ago (threshold: 15 min)` };
     }
     return { status: 'ok', detail: `Last sync ${ageMin} min ago` };
+  } catch (e) {
+    return { status: 'error', detail: e.message };
+  }
+}
+
+// ── Per-source freshness from ops.sync_log ──────────────────────────────
+//
+// Why this exists: the legacy `checkSyncFreshness` only watches the
+// ResQ↔SF blob. Every other sync (sync-qbo invoice/lines, sync-qbo-items,
+// sync-qbo-customers, sync-qbo-expenses, sync-sf, sync-fleetcomplete) is
+// invisible to it. We learned this the hard way on 2026-05-14 — sync-qbo
+// had been silently writing zero rows for 19 days because the edge
+// function was defaulting to the `public` schema while every table lives
+// in `ops`. The function returned HTTP 200, pg_cron logged "succeeded,"
+// no alert ever fired, and Margin showed stale data without anyone
+// noticing.
+//
+// This check reads max(completed_at) per (source, sync_type) from
+// ops.sync_log directly and compares to a per-source SLA. Any source
+// older than its threshold gets surfaced as a row in the watchdog email.
+const SYNC_SLA = {
+  // expected nightly + every 3 min backfill; data should be < 1 day old
+  'qbo:invoices':           { maxAgeMs: 30 * 60 * 60 * 1000, label: 'sync-qbo header upserts' },
+  'qbo:lines_backfill':     { maxAgeMs: 30 * 60 * 1000,      label: 'sync-qbo line backfill (every 3 min)' },
+  'qbo:pl_snapshots':       { maxAgeMs: 30 * 60 * 60 * 1000, label: 'sync-qbo P&L snapshots (nightly)' },
+  // SF jobs incremental: every 30 min
+  'sf:jobs':                { maxAgeMs: 90 * 60 * 1000,      label: 'sync-sf jobs (every 30 min)' },
+};
+
+async function checkOpsSyncFreshness() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    return { status: 'warn', detail: 'SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set — cannot read ops.sync_log' };
+  }
+  try {
+    const sb = createClient(url, key, { db: { schema: 'ops' } });
+    // Pull the most recent completed_at per (source, sync_type) where status=success.
+    const { data, error } = await sb
+      .from('sync_log')
+      .select('source, sync_type, completed_at, records_synced')
+      .eq('status', 'success')
+      .order('completed_at', { ascending: false })
+      .limit(1000);
+    if (error) {
+      return { status: 'error', detail: 'sync_log read failed: ' + error.message };
+    }
+
+    // Reduce to one row per (source, sync_type) — latest only.
+    const latestByKey = new Map();
+    for (const r of (data || [])) {
+      const k = r.source + ':' + r.sync_type;
+      if (!latestByKey.has(k)) latestByKey.set(k, r);
+    }
+
+    const now = Date.now();
+    const rows = [];
+    let worst = 'ok';
+    for (const [key, sla] of Object.entries(SYNC_SLA)) {
+      const r = latestByKey.get(key);
+      if (!r) {
+        rows.push({ key, status: 'error', detail: sla.label + ' — no success entry on file' });
+        worst = 'error';
+        continue;
+      }
+      const age = now - new Date(r.completed_at).getTime();
+      const ageMin = Math.round(age / 60000);
+      const ageHr  = Math.round(age / 3600000);
+      const friendly = age > 24 * 3600 * 1000 ? `${ageHr}h` : `${ageMin}m`;
+      if (age > sla.maxAgeMs) {
+        rows.push({ key, status: 'error', detail: `${sla.label} — last success ${friendly} ago (SLA: ${Math.round(sla.maxAgeMs / 60000)}m)` });
+        worst = 'error';
+      } else {
+        rows.push({ key, status: 'ok', detail: `${sla.label} — ${friendly} ago` });
+      }
+    }
+
+    return {
+      status: worst,
+      detail: rows.filter(r => r.status === 'error').map(r => r.detail).join(' | ') || 'All ops.sync_log entries within SLA',
+      rows,
+    };
   } catch (e) {
     return { status: 'error', detail: e.message };
   }
@@ -324,11 +407,12 @@ export default async function handler(req, context) {
   console.log(`[health-watchdog] Starting checks at ${timestamp}`);
 
   // Run all checks concurrently (ResQ schema depends on ResQ login)
-  const [qbo, sf, resq, syncFreshness] = await Promise.all([
+  const [qbo, sf, resq, syncFreshness, opsSyncFreshness] = await Promise.all([
     checkQBO(),
     checkSF(),
     checkResQ(),
     checkSyncFreshness(),
+    checkOpsSyncFreshness(),
   ]);
 
   // Schema check uses the ResQ session from the login check
@@ -341,7 +425,8 @@ export default async function handler(req, context) {
     qbo,
     serviceFusion: sf,
     resq: resqClean,
-    syncFreshness,
+    syncFreshness,           // resq-sf blob (legacy)
+    opsSyncFreshness,        // per-source SLA on ops.sync_log
     resqSchema,
   };
 


### PR DESCRIPTION
## Why this PR

Sky asked why health-watchdog reported green while sync-qbo had been silently writing zero rows for 19 days. This PR adds the surface that should have made the failure visible, plus two notes in CLAUDE.md so neither this nor PR #61's base64-corruption mistake recur.

The actual fix to sync-qbo is **already live** as edge-function `sync-qbo v36` (deployed via the Supabase MCP) — see "Companion fix" below.

## What changed

### 1. `netlify/functions/health-watchdog.mjs` — `checkOpsSyncFreshness()`
- Reads max(completed_at) per (source, sync_type) from `ops.sync_log`
- Compares to per-source SLA:
  | Key | SLA | Why |
  |---|---|---|
  | `qbo:invoices` | 30 hours | Daily QBO header upsert (mode=fast at 9:00 UTC) |
  | `qbo:lines_backfill` | 30 minutes | Every 3 min cron |
  | `qbo:pl_snapshots` | 30 hours | Daily P&L snapshot pass |
  | `sf:jobs` | 90 minutes | Every 30 min cron |
- Any source missing a recent success returns `error` with the actionable detail (age + threshold + label)
- Wired into the existing handler alongside the legacy `checkSyncFreshness` (which only watched the ResQ-SF blob)
- Uses `SUPABASE_SERVICE_ROLE_KEY` (server-side only) with `{ db: { schema: 'ops' } }` — the same fix pattern the edge function got

### 2. `CLAUDE.md` "Do not" — two new entries
- **MCP base64 gotcha** (PR #61 was a full-day debug of this): `github_create_or_update_file` base64-encodes whatever you pass; pre-encoded base64 gets double-encoded and stored as literal text on disk. Symptom: Netlify serves base64 text instead of HTML/JS and the SPA never loads.
- **Supabase Edge Function default-schema gotcha** (sync-qbo v?? through v35 was a no-op for 19 days because of this): `createClient(url, key)` defaults to `schema='public'`. Our tables live in `ops`. Always pass `{ db: { schema: 'ops' } }` or use `.schema('ops').from(...)`. RPCs work either way because they're name-based and we have `public.*` wrappers.

## Companion fix (already deployed, not in this PR)

`sync-qbo` edge function deployed as **v36** via the Supabase MCP. Single one-line change in `getSB()`:

```ts
return createClient(
  Deno.env.get("SUPABASE_URL") || "",
  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "",
  { db: { schema: "ops" } },   // <- added
);
```

Symptom before fix: every `sb.from('qbo_invoices')` etc. silently resolved to `public.qbo_invoices` (nonexistent), returned empty, function returned 200, pg_cron logged "succeeded," nothing was actually written. Last successful sync_log entry was 2026-04-26.

Within 3 min of v36 deploying, the next `mode=lines` cron should write a real entry to `ops.sync_log`. The nightly `mode=fast` cron at 9:00 UTC will start re-syncing invoice headers for the current month.

## Test plan

- [ ] After ~3 min, check `SELECT max(completed_at) FROM ops.sync_log WHERE source='qbo'` — should be within the last few minutes, not 19 days ago
- [ ] Tomorrow morning after 9:00 UTC, confirm `ops.qbo_invoices.synced_at` advances (was stuck at 2026-04-26)
- [ ] Trigger health-watchdog manually (POST to `/.netlify/functions/health-watchdog?refresh=1` as a superadmin) — `opsSyncFreshness` row should appear in the response
- [ ] Manifest lint stays green: `node architecture/lint-manifest.mjs`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H)_