### PR TITLE
margin/production: WO Create — target UoM dropdown + auto-scaling (Phase 2a)

### DIFF
--- a/app/src/lib/uom.ts
+++ b/app/src/lib/uom.ts
@@ -81,26 +81,26 @@ export function convertQty(
   }
 
   // Cross-family bridge: count ↔ volume via the BOM yield definition.
-  if (bridge && bridge.yieldQty > 0) {
+  // bridge.finishedVolPerYieldGal is "gal of finished product per 1
+  // yield_uom unit" — explicitly per-unit semantics, matching the column
+  // comment on ops.product_bom.finished_vol_per_yield_gal and the BomsTab
+  // input label ("1 {yield_uom} produces ___ gal"). The yieldQty factor
+  // does NOT appear here — applying it would double-count for yield_qty>1
+  // BOMs (e.g. 2 cases/batch at 2.25 gal/case = 4.5 gal/batch; without the
+  // fix, "1000 gal" stored as 888.88 case instead of the correct 444.44).
+  if (bridge && bridge.yieldQty > 0 && bridge.finishedVolPerYieldGal) {
     const yieldGroup = uomGroup(bridge.yieldUom);
-    // Bridge: 1 yield = bridge.yieldQty (yieldUom). For "case → gal" or
-    // "gal → case" we need a yield expressed in the target group OR the
-    // optional finishedVolPerYieldGal hint.
-    if (yieldGroup === 'count' && gFrom === 'volume') {
-      // gal → case (when 1 case = X gal finished)
+    if (yieldGroup === 'count' && gFrom === 'volume' && to === bridge.yieldUom) {
+      // gal-family → yield_uom (e.g. fl_oz → case): convert input to gal
+      // first, then divide by per-unit bridge.
       const gal = qty * VOLUME[from] / VOLUME.gal;
-      if (bridge.finishedVolPerYieldGal) {
-        const yields = gal / bridge.finishedVolPerYieldGal;
-        if (to === bridge.yieldUom) return yields * bridge.yieldQty;
-      }
+      return gal / bridge.finishedVolPerYieldGal;
     }
-    if (yieldGroup === 'count' && gTo === 'volume') {
-      // case → gal (when 1 case = X gal finished)
-      if (from === bridge.yieldUom && bridge.finishedVolPerYieldGal) {
-        const yields = qty / bridge.yieldQty;
-        const gal = yields * bridge.finishedVolPerYieldGal;
-        return gal * VOLUME.gal / VOLUME[to];
-      }
+    if (yieldGroup === 'count' && gTo === 'volume' && from === bridge.yieldUom) {
+      // yield_uom → gal-family (e.g. case → fl_oz): multiply by per-unit
+      // bridge first, then convert from gal to the target volume unit.
+      const gal = qty * bridge.finishedVolPerYieldGal;
+      return gal * VOLUME.gal / VOLUME[to];
     }
   }
 

--- a/app/src/pages/production/WorkOrdersTab.tsx
+++ b/app/src/pages/production/WorkOrdersTab.tsx
@@ -83,14 +83,19 @@ export function WorkOrdersTab({
     },
     { field: 'finished_label', headerName: 'Finished SKU', flex: 1, minWidth: 200,
       renderCell: (p) => <span style={{ fontWeight: 600 }}>{String(p.value)}</span> },
-    { field: 'qty_to_produce', headerName: 'Qty', width: 130, cellClassName: 'mn',
+    { field: 'qty_to_produce', headerName: 'Qty', type: 'number', width: 130, cellClassName: 'mn',
       renderCell: (p) => {
         const bom = bomById.get(p.row.bom_id);
         const u = bom?.yield_uom || 'each';
         return <span>{fmtNum(Number(p.value ?? 0))} <span style={{ color: 'var(--mt)' }}>{u}</span></span>;
       } },
-    { field: 'qty_produced_actual', headerName: 'Actual', type: 'number', width: 90, cellClassName: 'mn',
-      valueFormatter: (v) => v == null ? '—' : fmtNum(Number(v)) },
+    { field: 'qty_produced_actual', headerName: 'Actual', type: 'number', width: 110, cellClassName: 'mn',
+      renderCell: (p) => {
+        if (p.value == null) return <span style={{ color: 'var(--mt)' }}>—</span>;
+        const bom = bomById.get(p.row.bom_id);
+        const u = bom?.yield_uom || 'each';
+        return <span>{fmtNum(Number(p.value))} <span style={{ color: 'var(--mt)' }}>{u}</span></span>;
+      } },
     { field: 'location_label', headerName: 'Location', width: 130 },
     { field: 'scheduled_date', headerName: 'Scheduled', width: 110,
       valueFormatter: (v) => v ? String(v) : '—' },

--- a/app/src/pages/production/WorkOrdersTab.tsx
+++ b/app/src/pages/production/WorkOrdersTab.tsx
@@ -382,9 +382,17 @@ function WorkOrderDetailModal({
   }
 
   async function doClose() {
+    // qty_to_produce is stored in BOM yield_uom (see CreateWorkOrderForm —
+    // operator-typed qty gets converted client-side). Without explicit UoM
+    // disclosure here the operator can type their actual yield in target_uom
+    // (e.g. 'gal') and have fn_close_work_order write it as yield_uom (e.g.
+    // 'case'), inflating finished-good inventory by the conversion factor.
+    const u = bom?.yield_uom || 'each';
+    const targetStr = bom ? fmtQty(Number(wo!.qty_to_produce), u) : String(wo!.qty_to_produce);
+    const enteredAs = wo!.target_uom && wo!.target_uom !== u ? ` (entered as ${wo!.target_uom})` : '';
     const actualStr = prompt(
       `Close ${wo!.batch_code} — finished qty produced?\n\n` +
-      `Target was ${wo!.qty_to_produce}. Enter actual yield.`,
+      `Target was ${targetStr}${enteredAs}. Enter actual yield in ${u}.`,
       String(wo!.qty_to_produce)
     );
     if (actualStr == null) return;
@@ -470,8 +478,8 @@ function WorkOrderDetailModal({
       <h1>Work Order · ${escapeHtml(wo.batch_code)}</h1>
       <div class="meta">
         <div class="kv"><div class="lbl">Finished SKU</div>${escapeHtml(finished?.item_name ?? wo.finished_qbo_item_id)}</div>
-        <div class="kv"><div class="lbl">BOM</div>v${escapeHtml(bom.version)} · yield ${bom.yield_qty}/batch</div>
-        <div class="kv"><div class="lbl">Qty target / actual</div>${fmtNum(Number(wo.qty_to_produce))} / ${wo.qty_produced_actual == null ? '—' : fmtNum(Number(wo.qty_produced_actual))}</div>
+        <div class="kv"><div class="lbl">BOM</div>v${escapeHtml(bom.version)} · yield ${escapeHtml(fmtQty(Number(bom.yield_qty), bom.yield_uom || 'each'))}/batch</div>
+        <div class="kv"><div class="lbl">Qty target / actual</div>${escapeHtml(fmtQty(Number(wo.qty_to_produce), bom.yield_uom || 'each'))} / ${wo.qty_produced_actual == null ? '—' : escapeHtml(fmtQty(Number(wo.qty_produced_actual), bom.yield_uom || 'each'))}${wo.target_uom && wo.target_uom !== (bom.yield_uom || 'each') ? ` <span style="color:#64748b">(entered as ${escapeHtml(wo.target_uom)})</span>` : ''}</div>
         <div class="kv"><div class="lbl">Production location</div>${escapeHtml(loc?.name ?? '?')} · ${escapeHtml(loc?.code ?? '')}</div>
         <div class="kv"><div class="lbl">Status</div>${wo.status.toUpperCase()}</div>
         <div class="kv"><div class="lbl">Scheduled / Closed</div>${escapeHtml(wo.scheduled_date ?? '—')} / ${wo.closed_at ? new Date(wo.closed_at).toLocaleDateString() : '—'}</div>

--- a/app/src/pages/production/WorkOrdersTab.tsx
+++ b/app/src/pages/production/WorkOrdersTab.tsx
@@ -87,14 +87,18 @@ export function WorkOrdersTab({
       renderCell: (p) => {
         const bom = bomById.get(p.row.bom_id);
         const u = bom?.yield_uom || 'each';
-        return <span>{fmtNum(Number(p.value ?? 0))} <span style={{ color: 'var(--mt)' }}>{u}</span></span>;
+        // Match the modal Meta + print summary which use fmtQty (2 decimal
+        // places). The grid used to round to 0 — fine when qty_to_produce
+        // was always an integer, but cross-family WOs now persist
+        // fractional values (e.g. 444.44 case for "1000 gal").
+        return <span>{fmtNum(Number(p.value ?? 0), 2)} <span style={{ color: 'var(--mt)' }}>{u}</span></span>;
       } },
     { field: 'qty_produced_actual', headerName: 'Actual', type: 'number', width: 110, cellClassName: 'mn',
       renderCell: (p) => {
         if (p.value == null) return <span style={{ color: 'var(--mt)' }}>—</span>;
         const bom = bomById.get(p.row.bom_id);
         const u = bom?.yield_uom || 'each';
-        return <span>{fmtNum(Number(p.value))} <span style={{ color: 'var(--mt)' }}>{u}</span></span>;
+        return <span>{fmtNum(Number(p.value), 2)} <span style={{ color: 'var(--mt)' }}>{u}</span></span>;
       } },
     { field: 'location_label', headerName: 'Location', width: 130 },
     { field: 'scheduled_date', headerName: 'Scheduled', width: 110,

--- a/app/src/pages/production/WorkOrdersTab.tsx
+++ b/app/src/pages/production/WorkOrdersTab.tsx
@@ -13,6 +13,7 @@ import { useToast } from '../../lib/toast';
 import { btnPrimary, btnSecondary, btnDanger, inp } from '../../lib/styles';
 import { fmtNum, fm } from '../../lib/formatters';
 import { GRID_SX } from '../stock/stockStyles';
+import { UOM_OPTIONS, convertQty, fmtQty, uomGroup } from '../../lib/uom';
 import type { ProductionItemLookup } from './ProductionPage';
 
 const STATUS_COLOR: Record<WorkOrderStatus, string> = {
@@ -82,8 +83,12 @@ export function WorkOrdersTab({
     },
     { field: 'finished_label', headerName: 'Finished SKU', flex: 1, minWidth: 200,
       renderCell: (p) => <span style={{ fontWeight: 600 }}>{String(p.value)}</span> },
-    { field: 'qty_to_produce', headerName: 'Qty', type: 'number', width: 90, cellClassName: 'mn',
-      valueFormatter: (v) => fmtNum(Number(v ?? 0)) },
+    { field: 'qty_to_produce', headerName: 'Qty', width: 130, cellClassName: 'mn',
+      renderCell: (p) => {
+        const bom = bomById.get(p.row.bom_id);
+        const u = bom?.yield_uom || 'each';
+        return <span>{fmtNum(Number(p.value ?? 0))} <span style={{ color: 'var(--mt)' }}>{u}</span></span>;
+      } },
     { field: 'qty_produced_actual', headerName: 'Actual', type: 'number', width: 90, cellClassName: 'mn',
       valueFormatter: (v) => v == null ? '—' : fmtNum(Number(v)) },
     { field: 'location_label', headerName: 'Location', width: 130 },
@@ -91,7 +96,7 @@ export function WorkOrdersTab({
       valueFormatter: (v) => v ? String(v) : '—' },
     { field: 'created_at', headerName: 'Created', width: 160,
       valueFormatter: (v) => v ? new Date(String(v)).toLocaleString() : '—' },
-  ], []);
+  ], [bomById]);
 
   const activeBoms = boms.filter((b) => b.is_active);
 
@@ -177,22 +182,56 @@ function CreateWorkOrderForm({
   const toast = useToast();
   const [bomId, setBomId] = useState('');
   const [qty, setQty] = useState<string>('');
+  const [targetUom, setTargetUom] = useState<string>('');
   const [locId, setLocId] = useState('');
   const [scheduled, setScheduled] = useState('');
   const [notes, setNotes] = useState('');
   const [saving, setSaving] = useState(false);
 
-  const canSave = !!bomId && Number(qty) > 0 && !!locId;
   const selectedBom = boms.find((b) => b.id === bomId);
   const selectedFinished = selectedBom ? itemLookup.byId.get(selectedBom.finished_qbo_item_id) : null;
 
+  // When the operator picks a BOM, default target_uom to the BOM's yield_uom
+  // — most WOs are "make N of whatever this BOM yields" and only the cross-
+  // family case (e.g. case-yield BOM, "make 1000 gal") needs a different unit.
+  useEffect(() => {
+    if (selectedBom) setTargetUom(selectedBom.yield_uom || 'each');
+    else setTargetUom('');
+  }, [selectedBom?.id, selectedBom?.yield_uom]);
+
+  // Convert operator-typed qty (in target_uom) → BOM yield_uom so
+  // fn_consume_work_order's existing (qty_to_produce / yield_qty) math is
+  // correct without changing the SQL. Stays in sync with ScaleBomPanel by
+  // using the same lib/uom.ts helpers.
+  const yieldQtyNum = selectedBom ? Number(selectedBom.yield_qty) : 0;
+  const yieldUom = selectedBom?.yield_uom || 'each';
+  const bridgeGal = selectedBom?.finished_vol_per_yield_gal == null
+    ? undefined
+    : Number(selectedBom.finished_vol_per_yield_gal);
+  const qtyNum = Number(qty);
+  const effectiveQtyInYieldUom = selectedBom && qtyNum > 0 && targetUom
+    ? convertQty(qtyNum, targetUom, yieldUom, {
+        yieldQty: yieldQtyNum, yieldUom, finishedVolPerYieldGal: bridgeGal,
+      })
+    : null;
+  const batches = effectiveQtyInYieldUom != null && yieldQtyNum > 0
+    ? effectiveQtyInYieldUom / yieldQtyNum
+    : 0;
+  const conversionFailed = !!selectedBom && qtyNum > 0 && targetUom !== yieldUom && effectiveQtyInYieldUom == null;
+
+  const canSave = !!bomId && qtyNum > 0 && !!locId && effectiveQtyInYieldUom != null;
+
   async function submit() {
-    if (!canSave) return;
+    if (!canSave || effectiveQtyInYieldUom == null) return;
     setSaving(true);
     try {
       await createWorkOrder({
         bom_id: bomId,
-        qty_to_produce: Number(qty),
+        // Store the converted qty in yield_uom so the consumption math
+        // works without touching fn_consume_work_order. target_uom is the
+        // audit trail of what the operator typed.
+        qty_to_produce: effectiveQtyInYieldUom,
+        target_uom: targetUom || null,
         production_location_id: locId,
         scheduled_date: scheduled || null,
         notes: notes || null,
@@ -227,8 +266,15 @@ function CreateWorkOrderForm({
           </select>
         </LField>
         <LField label="Qty to produce">
-          <input type="number" min={0.0001} step="any" style={inp()}
-            value={qty} onChange={(e) => setQty(e.target.value)} />
+          <div style={{ display: 'flex', gap: 6 }}>
+            <input type="number" min={0.0001} step="any" style={{ ...inp(), flex: 1 }}
+              value={qty} onChange={(e) => setQty(e.target.value)} />
+            <select value={targetUom} onChange={(e) => setTargetUom(e.target.value)}
+              style={{ ...inp(), width: 100 }} disabled={!selectedBom}>
+              {!selectedBom && <option value="">—</option>}
+              {UOM_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+          </div>
         </LField>
         <LField label="Production location">
           <select style={inp()} value={locId} onChange={(e) => setLocId(e.target.value)}>
@@ -244,11 +290,27 @@ function CreateWorkOrderForm({
       {selectedBom && (
         <div style={{
           marginTop: 12, padding: 10,
-          background: 'rgba(91,181,240,0.04)', border: '1px solid var(--bd)', borderRadius: 4,
-          fontSize: 11, color: 'var(--mt)',
+          background: conversionFailed ? 'rgba(230,170,90,0.06)' : 'rgba(91,181,240,0.04)',
+          border: '1px solid var(--bd)', borderRadius: 4,
+          fontSize: 11, color: conversionFailed ? 'var(--am)' : 'var(--mt)',
         }}>
-          BOM yield: <strong style={{ color: 'var(--tx)' }}>{selectedBom.yield_qty}</strong> {selectedFinished?.item_name ?? ''} per batch
-          {Number(qty) > 0 && <> · running <strong style={{ color: 'var(--tx)' }}>{(Number(qty) / Number(selectedBom.yield_qty)).toFixed(2)}</strong> batches</>}
+          BOM yield: <strong style={{ color: 'var(--tx)' }}>{fmtQty(yieldQtyNum, yieldUom)}</strong> {selectedFinished?.item_name ?? ''} per batch
+          {qtyNum > 0 && effectiveQtyInYieldUom != null && (
+            <> · running <strong style={{ color: 'var(--tx)' }}>{batches.toFixed(2)}</strong> batches
+              {targetUom !== yieldUom && (
+                <> · stored as <strong style={{ color: 'var(--tx)' }}>{fmtQty(effectiveQtyInYieldUom, yieldUom)}</strong></>
+              )}
+            </>
+          )}
+          {conversionFailed && (
+            <> · can't convert <strong>{targetUom}</strong> → <strong>{yieldUom}</strong>.
+              {uomGroup(targetUom) === 'volume' && uomGroup(yieldUom) === 'count' && bridgeGal == null
+                ? <> Set "1 {yieldUom} produces ___ gal" on the BOM first.</>
+                : uomGroup(targetUom) === 'count' && uomGroup(yieldUom) === 'count'
+                  ? <> Type the qty in {yieldUom} — no fixed conversion between each and case.</>
+                  : <> Type the qty in {yieldUom}.</>}
+            </>
+          )}
         </div>
       )}
 
@@ -451,8 +513,18 @@ function WorkOrderDetailModal({
         </div>
 
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 10, fontSize: 12, marginBottom: 14 }}>
-          <Meta label="BOM" value={bom ? `v${bom.version} · yield ${bom.yield_qty}/batch` : '?'} />
-          <Meta label="Qty (target / actual)" value={`${fmtNum(Number(wo.qty_to_produce))} / ${wo.qty_produced_actual == null ? '—' : fmtNum(Number(wo.qty_produced_actual))}`} />
+          <Meta label="BOM" value={bom ? `v${bom.version} · yield ${fmtQty(Number(bom.yield_qty), bom.yield_uom || 'each')}/batch` : '?'} />
+          <Meta label="Qty (target / actual)" value={(() => {
+            const u = bom?.yield_uom || 'each';
+            const stored = `${fmtQty(Number(wo.qty_to_produce), u)} / ${wo.qty_produced_actual == null ? '—' : fmtQty(Number(wo.qty_produced_actual), u)}`;
+            // If the operator typed a different unit at create time, show
+            // both for audit. wo.target_uom is informational; the stored
+            // value is what fn_consume_work_order will multiply.
+            if (wo.target_uom && bom && wo.target_uom !== (bom.yield_uom || 'each')) {
+              return `${stored}  (entered as ${wo.target_uom})`;
+            }
+            return stored;
+          })()} />
           <Meta label="Batches" value={batches > 0 ? batches.toFixed(2) : '—'} />
           <Meta label="Location" value={loc ? `${loc.code} — ${loc.name}` : '?'} />
           <Meta label="Scheduled" value={wo.scheduled_date ?? '—'} />


### PR DESCRIPTION
## Why

Phase 2a of the BOM UoM rollout from #86.

#86 added UoM columns + the "Scale this BOM" calculator. But the actual Work Order Create form still took a dimensionless qty — operators couldn't type "make 1000 gal cola" against a case-yield BOM the same way the BOM scaler let them.

This wires it through.

## How it works

The form computes the equivalent qty in BOM `yield_uom` **client-side at create time** using `lib/uom.ts`'s `convertQty()` (same path the `ScaleBomPanel` uses). `qty_to_produce` is then submitted in `yield_uom`, with `target_uom` carrying the operator's original typed unit as audit metadata.

**This means `fn_consume_work_order` / `fn_close_work_order` stay unchanged.** Their `(qty_to_produce / yield_qty) * qty_per * (1 + scrap_pct)` formula remains correct because `qty_to_produce` is always already in `yield_uom` by the time it hits the DB. No SQL migration needed in this PR.

## What

### `app/src/pages/production/WorkOrdersTab.tsx`

**Create form:**
- New UoM dropdown next to "Qty to produce", defaulted to the selected BOM's `yield_uom`
- Live preview shows running batches + `"stored as 444.44 case"` sub-line when the operator typed a cross-family unit
- Same amber hint variants as `ScaleBomPanel` for incompatible UoMs (missing bridge / same-count / generic)
- Create button disabled when conversion fails

**WO list:**
- Qty column renders `"1000 gal"` instead of dimensionless `1000`

**WO detail modal:**
- Qty cell shows `yield_uom` and appends `"(entered as gal)"` when `target_uom != yield_uom`
- BOM yield line uses `fmtQty` for consistency with the rest of the production area

### No schema changes

The column already exists (`work_orders.target_uom`, added in #86), the RPC already accepts it (`fn_create_work_order(p_target_uom)`), and the consumption math is intentionally untouched.

## Example

```
BOM: COLA-12-24 case
  yield: 1 case (= 2.25 gal of finished product)
  Cola syrup: 0.375 gal per yield

New WO:
  Qty to produce: [1000] [gal]
  → running 444.44 batches · stored as 444.44 case

On Consume:
  fn_consume_work_order: (444.44 / 1) * 0.375 * (1 + 0) = 166.67 gal syrup ✓
```

The same WO created the old way (typing 444 in case units) produces the same syrup draw — no behavior change for existing workflows.

## Test plan

- [ ] `/margin/` → Production → Work Orders → New WO → pick a case-yield BOM with `finished_vol_per_yield_gal` set → switch UoM to `gal`, type `1000` → preview shows runs + "stored as N case" → Create
- [ ] WO list shows qty in the BOM's `yield_uom`
- [ ] WO detail modal shows `"N case (entered as gal)"` for cross-family WOs
- [ ] Existing case-or-gal-typed WOs render with the right unit, no regressions
- [ ] Picking an incompatible UoM shows the amber hint and disables Create

## Out of scope

- **Phase 2b** — UoM on PO line quantities + inventory movements + `qbo_items.UQCDisplayText` sync. Separate PR.
- **fn_consume_work_order UoM-awareness** — not needed for this approach; documented in the in-file comment.

---
_Generated by [Claude Code](https://claude.ai/code/session_012iWSo6eNQAbMQTUdu16gwA)_