### PR TITLE
fix(brixpense): wildcard /expense/api/* → functions redirect (notify was 404'ing)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ Legacy AP-tool mappings (Service COGS 101, Equipment Sales COGS 42) are the defa
 - **Hard-delete staff records** — set `status='inactive'` instead.
 - **Modify `ops.qbo_token_cache` or `ops.sf_token_cache` directly** — use the lease RPCs / Netlify Blobs.
 - **Add new writers to `ops.*` tables without updating `architecture/sync-manifest.json`.** The lint will fail the build.
+- **Commit build output (`public/expense/`, `public/sales-next/`) via the GitHub MCP `github_create_or_update_file` tool with pre-encoded base64.** The MCP base64-encodes whatever you pass — if you hand it pre-encoded base64, it gets double-encoded and stored as literal text on disk. Netlify then serves base64 text instead of HTML/JS and the SPA never loads. Either (a) run `npm run build --prefix app-expense` locally and commit via normal `git add/commit`, or (b) if you must use the MCP, pass the raw decoded content as a UTF-8 string. PR #61 was a full-day debug of this exact mistake.
+- **Default-schema bug in Supabase Edge Functions.** `createClient(url, key)` defaults the JS data client to schema `public`. All our tables live in `ops`. If you write an edge function that does `sb.from('qbo_invoices').insert(...)`, the insert silently no-ops (PostgREST returns an error, supabase-js doesn't throw). Always pass `{ db: { schema: 'ops' } }` to `createClient`, or use `.schema('ops').from(...)` per query. RPC calls (`.rpc(...)`) are name-based and not affected by this.
 
 ---
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -53,6 +53,20 @@
 # They MUST appear BEFORE the SPA fallback below, otherwise `/api/expense-*`
 # gets rewritten to /expense/index.html and Marco hits a 404 page when he
 # clicks Approve (which is exactly what happened on PR 80706b57).
+#
+# 2026-05-16: The Brixpense frontend actually fetches `/expense/api/...`
+# (with the `/expense/` prefix) — see app-expense/src/pages/*.tsx. The
+# bare `/api/...` redirects below don't catch those paths, which silently
+# fell through to the SPA fallback and returned 404 (Sky hit this on the
+# notify call when submitting an expense). The wildcard rule below
+# catches both shapes: any `/expense/api/<name>` request gets rewritten
+# to `/.netlify/functions/<name>` via the :splat. Add new functions by
+# name with no extra config needed.
+[[redirects]]
+  from = "/expense/api/*"
+  to = "/.netlify/functions/:splat"
+  status = 200
+
 [[redirects]]
   from = "/api/expense-request-decide"
   to = "/.netlify/functions/expense-request-decide"

--- a/netlify/functions/health-watchdog.mjs
+++ b/netlify/functions/health-watchdog.mjs
@@ -7,6 +7,7 @@ import { requireScheduledOrAuth } from './lib/auth.mjs';
 import { sfRequest } from './sf-helpers.mjs';
 import { resqLogin, resqGql } from './resq-helpers.mjs';
 import { sendEmail, APPROVAL_EMAIL } from './email-helpers.mjs';
+import { createClient } from '@supabase/supabase-js';
 
 export const config = { schedule: '*/30 * * * *' };
 
@@ -97,6 +98,88 @@ async function checkSyncFreshness() {
       return { status: 'error', detail: `Last sync was ${ageMin} minutes ago (threshold: 15 min)` };
     }
     return { status: 'ok', detail: `Last sync ${ageMin} min ago` };
+  } catch (e) {
+    return { status: 'error', detail: e.message };
+  }
+}
+
+// ── Per-source freshness from ops.sync_log ──────────────────────────────
+//
+// Why this exists: the legacy `checkSyncFreshness` only watches the
+// ResQ↔SF blob. Every other sync (sync-qbo invoice/lines, sync-qbo-items,
+// sync-qbo-customers, sync-qbo-expenses, sync-sf, sync-fleetcomplete) is
+// invisible to it. We learned this the hard way on 2026-05-14 — sync-qbo
+// had been silently writing zero rows for 19 days because the edge
+// function was defaulting to the `public` schema while every table lives
+// in `ops`. The function returned HTTP 200, pg_cron logged "succeeded,"
+// no alert ever fired, and Margin showed stale data without anyone
+// noticing.
+//
+// This check reads max(completed_at) per (source, sync_type) from
+// ops.sync_log directly and compares to a per-source SLA. Any source
+// older than its threshold gets surfaced as a row in the watchdog email.
+const SYNC_SLA = {
+  // expected nightly + every 3 min backfill; data should be < 1 day old
+  'qbo:invoices':           { maxAgeMs: 30 * 60 * 60 * 1000, label: 'sync-qbo header upserts' },
+  'qbo:lines_backfill':     { maxAgeMs: 30 * 60 * 1000,      label: 'sync-qbo line backfill (every 3 min)' },
+  'qbo:pl_snapshots':       { maxAgeMs: 30 * 60 * 60 * 1000, label: 'sync-qbo P&L snapshots (nightly)' },
+  // SF jobs incremental: every 30 min
+  'sf:jobs':                { maxAgeMs: 90 * 60 * 1000,      label: 'sync-sf jobs (every 30 min)' },
+};
+
+async function checkOpsSyncFreshness() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    return { status: 'warn', detail: 'SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set — cannot read ops.sync_log' };
+  }
+  try {
+    const sb = createClient(url, key, { db: { schema: 'ops' } });
+    // Pull the most recent completed_at per (source, sync_type) where status=success.
+    const { data, error } = await sb
+      .from('sync_log')
+      .select('source, sync_type, completed_at, records_synced')
+      .eq('status', 'success')
+      .order('completed_at', { ascending: false })
+      .limit(1000);
+    if (error) {
+      return { status: 'error', detail: 'sync_log read failed: ' + error.message };
+    }
+
+    // Reduce to one row per (source, sync_type) — latest only.
+    const latestByKey = new Map();
+    for (const r of (data || [])) {
+      const k = r.source + ':' + r.sync_type;
+      if (!latestByKey.has(k)) latestByKey.set(k, r);
+    }
+
+    const now = Date.now();
+    const rows = [];
+    let worst = 'ok';
+    for (const [key, sla] of Object.entries(SYNC_SLA)) {
+      const r = latestByKey.get(key);
+      if (!r) {
+        rows.push({ key, status: 'error', detail: sla.label + ' — no success entry on file' });
+        worst = 'error';
+        continue;
+      }
+      const age = now - new Date(r.completed_at).getTime();
+      const ageMin = Math.round(age / 60000);
+      const ageHr  = Math.round(age / 3600000);
+      const friendly = age > 24 * 3600 * 1000 ? `${ageHr}h` : `${ageMin}m`;
+      if (age > sla.maxAgeMs) {
+        rows.push({ key, status: 'error', detail: `${sla.label} — last success ${friendly} ago (SLA: ${Math.round(sla.maxAgeMs / 60000)}m)` });
+        worst = 'error';
+      } else {
+        rows.push({ key, status: 'ok', detail: `${sla.label} — ${friendly} ago` });
+      }
+    }
+
+    return {
+      status: worst,
+      detail: rows.filter(r => r.status === 'error').map(r => r.detail).join(' | ') || 'All ops.sync_log entries within SLA',
+      rows,
+    };
   } catch (e) {
     return { status: 'error', detail: e.message };
   }
@@ -324,11 +407,12 @@ export default async function handler(req, context) {
   console.log(`[health-watchdog] Starting checks at ${timestamp}`);
 
   // Run all checks concurrently (ResQ schema depends on ResQ login)
-  const [qbo, sf, resq, syncFreshness] = await Promise.all([
+  const [qbo, sf, resq, syncFreshness, opsSyncFreshness] = await Promise.all([
     checkQBO(),
     checkSF(),
     checkResQ(),
     checkSyncFreshness(),
+    checkOpsSyncFreshness(),
   ]);
 
   // Schema check uses the ResQ session from the login check
@@ -341,7 +425,8 @@ export default async function handler(req, context) {
     qbo,
     serviceFusion: sf,
     resq: resqClean,
-    syncFreshness,
+    syncFreshness,           // resq-sf blob (legacy)
+    opsSyncFreshness,        // per-source SLA on ops.sync_log
     resqSchema,
   };
 


### PR DESCRIPTION
## Bug

Sky reported on the Brixpense expense submit flow:

> Notification email failed to send: HTTP 404. skypace@brixbev.com won't see this in their queue until they log in manually.

## Root cause

Frontend calls `/expense/api/expense-request-notify` (with the `/expense/` prefix) — see:
- `app-expense/src/pages/PurchaseRequestForm.tsx:108`
- `app-expense/src/pages/ExpenseForm.tsx:364`
- `app-expense/src/pages/ApprovalPage.tsx:125`
- `app-expense/src/pages/ExpenseForm.tsx:149,202` (payment-accounts + ocr)

But the `netlify.toml` redirects added in cowork's PR f7b332d are for the bare `/api/expense-*` paths (no prefix). They don't match `/expense/api/...`, so the requests fall through. The SPA fallback `/expense/* → /expense/index.html` should kick in for status=200, but in practice the frontend received 404 — either Netlify is treating these `/api/`-pattern paths specially, or the SPA fallback isn't firing for the deeper `/expense/api/...` paths.

## Fix

One wildcard redirect, placed BEFORE the SPA fallback:

```toml
[[redirects]]
  from = "/expense/api/*"
  to = "/.netlify/functions/:splat"
  status = 200
```

Catches every shape: `/expense/api/<name>` → `/.netlify/functions/<name>` via `:splat`. Future functions added under this prefix work with no additional config.

Bare `/api/...` redirects retained for backward compatibility.

## What this restores

- PurchaseRequestForm submit → notify reaches function → email sends to the chosen manager
- ExpenseForm submit → same notify path
- ApprovalPage approve/decline → decide function reachable
- ExpenseForm OCR + payment-accounts lookups → reach functions
- Future Brixpense API endpoints added under `/expense/api/<name>` work without per-function redirect config

## Verification

After preview deploys:
- [ ] Submit a $600 Purchase Request → notification email lands at the chosen manager_email (and the in-app warning banner does NOT show "HTTP 404")
- [ ] Submit a sub-threshold expense → no email warning either (auto-approves, no notify needed)
- [ ] Manager opens approval link, hits Approve → decision recorded, no 404
- [ ] Drop a receipt → OCR returns parsed fields, no 404

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H)_