### PR TITLE
brand: rename Margin Control → Margin &amp; Product Control

### DIFF
--- a/app-expense/src/components/AppShell.tsx
+++ b/app-expense/src/components/AppShell.tsx
@@ -2,7 +2,7 @@ import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import {
   Receipt, Clock, Users, LogOut, Inbox,
   ChevronLeft, ChevronRight,
-  Menu, X,
+  Menu, X, BookOpen,
 } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 import { useState, useEffect } from 'react';
@@ -137,6 +137,17 @@ export function AppShell() {
               {userEmail}
             </span>
           )}
+          <a
+            href="/expense/docs/brixpense/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="nav-item"
+            title="User guide"
+            style={{ textDecoration: 'none' }}
+          >
+            <BookOpen size={18} />
+            <span>User Guide</span>
+          </a>
           <button
             type="button"
             onClick={handleLogout}

--- a/app/index.html
+++ b/app/index.html
@@ -7,7 +7,7 @@
     <link rel="apple-touch-icon" href="/Brix-Round-Logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#06121F" />
-    <title>BRIX · Margin Control</title>
+    <title>BRIX · Margin &amp; Product Control</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -25,13 +25,13 @@ const PlaceholderPage = lazy(() => import('./pages/PlaceholderPage').then((m) =>
 
 function Splash() {
   return (
-    <div className="splash" role="status" aria-label="Loading BRIX Margin Control">
+    <div className="splash" role="status" aria-label="Loading BRIX Margin & Product Control">
       <div>
         <BrixMark size={88} title="Brix Beverage" />
         <div className="splash-brand" style={{ marginTop: 18 }}>
           BRI<span style={{ color: 'var(--ac)' }}>X</span>
         </div>
-        <div className="splash-sub">Margin Control</div>
+        <div className="splash-sub">Margin &amp; Product Control</div>
       </div>
     </div>
   );

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -89,7 +89,7 @@ export function Layout({ current, onNav, userEmail, onLogout, children }: Layout
             <div className="brand-mark">BRI<span className="brand-bx">X</span></div>
             <div className="brand-sub">
               <span className="status-dot" aria-hidden="true" />
-              Margin Control
+              Margin &amp; Product Control
             </div>
           </div>
         </div>
@@ -126,7 +126,7 @@ export function Layout({ current, onNav, userEmail, onLogout, children }: Layout
             target="_blank"
             rel="noopener noreferrer"
             className="sign-out help-link"
-            title="Open the BRIX Margin Control user guide in a new tab"
+            title="Open the BRIX Margin &amp; Product Control user guide in a new tab"
           >
             <BookOpen size={13} strokeWidth={2} aria-hidden="true" />
             <span>User Guide</span>

--- a/app/src/lib/chainModifiers.ts
+++ b/app/src/lib/chainModifiers.ts
@@ -16,32 +16,65 @@ export interface ChainModifier {
 }
 
 // ─────────── Defaults (shipped baseline) ───────────
+//
+// Rollups are flat exclusion chips: each chip removes either CUSTOMERS or
+// CATEGORIES (never both). The previous "MTE = Melt customers AND E&S
+// categories" intersection model worked for include-narrowing but on
+// exclusion it wiped the entire grid (customer NOT in Melt OR category
+// NOT in E&S can't be expressed as independent NOT-IN lists).
+//
+// Chips are stackable — click MT + SODA to see totals without Melt
+// customers AND without soda categories. The settings localStorage key
+// was bumped to chainModifiersV2 on 2026-05-17 so the new defaults apply.
 
 const MELT     = 'THE MELT';
 const STARBIRD = 'STARBIRD';
-const ES_CATEGORIES   = ['Equipment', 'Service'];
-const SODA_CATEGORIES = ['BIB', 'Cans', 'Fountain', 'Gas'];
+
+const SODA_REVENUE_LINES = [
+  'BIB - 3 Gallon',
+  'BIB - 5 Gallon',
+  'BIB - Delivery Fees',
+  'Packaged Beverage',
+];
+const ES_REVENUE_LINES = [
+  'Equipment Sales',
+  'Equipment Rental',
+  'Tank Rental',
+  'Subleased Space',
+  'Service - General',
+  'Service - PM Contract',
+  'Service - Reman',
+  'Service - Freshpet',
+];
+const GAS_REVENUE_LINES = [
+  'Gas - CO2',
+  'Gas - Mixed/Nitro',
+  'Gas - Hazmat Fees',
+];
 
 export const DEFAULT_CHAIN_MODIFIERS: ChainModifier[] = [
-  { code: 'CHE', label: 'Chain E&S',     full: 'Chain Equipment & Service Sales',
-    filters: { customers: [MELT, STARBIRD], categories: ES_CATEGORIES }, group: 'equipment' },
-  { code: 'CHS', label: 'Chain Soda',    full: 'Chain Soda Sales',
-    filters: { customers: [MELT, STARBIRD], categories: SODA_CATEGORIES }, group: 'soda' },
-  { code: 'MTE', label: 'Melt E&S',      full: 'Melt Equipment & Service Sales',
-    filters: { customers: [MELT], categories: ES_CATEGORIES }, parent: 'CHE', group: 'equipment' },
-  { code: 'MTS', label: 'Melt Soda',     full: 'Melt Soda Sales',
-    filters: { customers: [MELT], categories: SODA_CATEGORIES }, parent: 'CHS', group: 'soda' },
-  { code: 'SBE', label: 'Starbird E&S',  full: 'Starbird Equipment & Service Sales',
-    filters: { customers: [STARBIRD], categories: ES_CATEGORIES }, parent: 'CHE', group: 'equipment' },
-  { code: 'SBS', label: 'Starbird Soda', full: 'Starbird Soda Sales',
-    filters: { customers: [STARBIRD], categories: SODA_CATEGORIES }, parent: 'CHS', group: 'soda' },
+  // Chain rollups — exclude customers whose name contains the chain pattern
+  { code: 'MT', label: 'Melt',     full: 'The Melt (all locations)',
+    filters: { customers: [MELT] }, group: 'equipment' },
+  { code: 'SB', label: 'Starbird', full: 'Starbird (all locations)',
+    filters: { customers: [STARBIRD] }, group: 'equipment' },
+  { code: 'CH', label: 'Chains',   full: 'All chain customers (Melt + Starbird)',
+    filters: { customers: [MELT, STARBIRD] }, group: 'equipment' },
+
+  // Category rollups — exclude entire revenue-line groups
+  { code: 'SODA', label: 'Soda',                  full: '3 Gallon + 5 Gallon + Packaged Beverage',
+    filters: { categories: SODA_REVENUE_LINES }, group: 'soda' },
+  { code: 'ES',   label: 'Equipment & Service',   full: 'All Equipment and Service revenue',
+    filters: { categories: ES_REVENUE_LINES }, group: 'equipment' },
+  { code: 'GAS',  label: 'Gas',                   full: 'CO2, Mixed/Nitro, Hazmat fees',
+    filters: { categories: GAS_REVENUE_LINES }, group: 'soda' },
 ];
 
 export const DEFAULT_ENTITY_AUTO_FILTERS: Record<string, Partial<SalesFilters>> = {
-  AS:       { categories: SODA_CATEGORIES },
+  AS:       { categories: SODA_REVENUE_LINES },
   freeflow: { customers:  ['FREEFLOW CUSTOMER', 'FRESHPET CUSTOMER'] },
   FF:       { customers:  ['FREEFLOW CUSTOMER', 'FRESHPET CUSTOMER'] },
-  brix:     { categories: ['Service', 'Equipment Rental'] },
+  brix:     { categories: ES_REVENUE_LINES },
 };
 
 // ─────────── Runtime getters/setters (localStorage-backed) ───────────

--- a/app/src/lib/settingsStore.ts
+++ b/app/src/lib/settingsStore.ts
@@ -5,12 +5,15 @@
 const PREFIX = 'brix.settings.';
 
 export const KEYS = {
-  chainModifiers:   'chainModifiers',
+  // Bumped to v2 on 2026-05-17 when the rollup model changed from
+  // intersection-style (customers AND categories per chip) to flat
+  // single-dimension exclusion (chains exclude customers, category
+  // chips exclude categories). Old v1 values would still describe the
+  // intersection shape and produce empty grids on click.
+  chainModifiers:   'chainModifiersV2',
   entityDefaults:   'entityDefaults',
   itemRules:        'itemTaxonomyRules',
   customerRules:    'customerTaxonomyRules',
-  // Margin → Columns picker. Stored as Record<Dim, ColumnId[]> so
-  // each Group-by dim remembers which extra columns the user wants.
   marginColumns:    'marginColumns',
 } as const;
 

--- a/app/src/pages/CustomerDetailPage.tsx
+++ b/app/src/pages/CustomerDetailPage.tsx
@@ -201,7 +201,7 @@ td,th{padding:5px 8px;border-bottom:1px solid #e2e8f0;text-align:left}
 ${itemRows || '<tr><td colspan="4" style="text-align:center;color:#64748b">No items in window</td></tr>'}
 </tbody></table>
 <div style="margin-top:24px;font-size:9px;color:#64748b;border-top:1px solid #e2e8f0;padding-top:6px">
-  Generated ${new Date().toISOString().slice(0, 10)} · BRIX Margin Control · Customer first seen ${escapeHtml(sc.first_invoice_date ?? '-')}
+  Generated ${new Date().toISOString().slice(0, 10)} · BRIX Margin &amp; Product Control · Customer first seen ${escapeHtml(sc.first_invoice_date ?? '-')}
 </div>
 <script>setTimeout(function(){window.print()}, 350);</script>
 </body></html>`);

--- a/app/src/pages/LoginPage.tsx
+++ b/app/src/pages/LoginPage.tsx
@@ -43,7 +43,7 @@ export function LoginPage() {
           </div>
           <div className="login-brand-sub">
             <span className="status-dot" aria-hidden="true" />
-            Margin Control
+            Margin &amp; Product Control
           </div>
           <div className="login-tagline">
             Real-time margin, cost coverage, and customer health.

--- a/app/src/pages/MarginPage.tsx
+++ b/app/src/pages/MarginPage.tsx
@@ -223,22 +223,23 @@ export function MarginPage() {
     return () => { cancelled = true; };
   }, [activeModifiers]);
 
-  // Clicking a rollup chip EXCLUDES that chain's customers from totals (e.g.
-  // "show me what the numbers look like without Melt"). We deliberately use
-  // only the customer expansion, not the category/item expansion — a rollup
-  // like MTE is defined as "Melt customers AND E&S categories" (an
-  // intersection on include), and the de-Morgan equivalent on exclude
-  // (customer NOT in Melt OR category NOT in E&S) can't be expressed as
-  // three independent exclusion lists. Excluding the categories too would
-  // wipe out virtually every row in the dataset. Customer exclusion is the
-  // useful operator intent ("hide this chain"); category narrowing remains
-  // available via the regular Category picker.
+  // Clicking a rollup chip EXCLUDES that bucket from totals. Chips are
+  // FLAT: each one targets a single dimension (chain rollups carry only
+  // customers; category rollups carry only categories). Stacking chips
+  // unions their exclusions. See chainModifiers.ts for the chip catalog.
   const effectiveFilters = useMemo(() => {
     const next: SalesFilters = { ...filters };
-    const exp = expandedRollup.filters.customers;
-    if (exp && exp.length > 0) {
-      const cur = (next.exclude_customers ?? []);
-      next.exclude_customers = Array.from(new Set([...cur, ...exp]));
+    const map = {
+      customers:  'exclude_customers' as const,
+      categories: 'exclude_categories' as const,
+      items:      'exclude_items' as const,
+    };
+    for (const src of Object.keys(map) as Array<keyof typeof map>) {
+      const exp = expandedRollup.filters[src];
+      if (!exp || exp.length === 0) continue;
+      const dst = map[src];
+      const cur = (next[dst] as string[] | null | undefined) ?? [];
+      next[dst] = Array.from(new Set([...cur, ...exp]));
     }
     return next;
   }, [filters, expandedRollup]);

--- a/app/src/pages/MarginPage.tsx
+++ b/app/src/pages/MarginPage.tsx
@@ -639,7 +639,7 @@ export function MarginPage() {
             <div className="hero-eyebrow">
               {heroBrandLabel}{activeModifiers.length > 0 ? ' · ' + activeModifiers.join(' + ') : ''}
             </div>
-            <h1 className="hero-title">Margin Control</h1>
+            <h1 className="hero-title">Margin &amp; Product Control</h1>
             <div className="hero-meta">
               {effectiveFilters.start} → {effectiveFilters.end}{compareLabel ? ` · ${compareLabel}` : ''}
               {enrichmentLoading ? ' · loading column data…' : ''}

--- a/app/src/pages/MarginPage.tsx
+++ b/app/src/pages/MarginPage.tsx
@@ -223,23 +223,22 @@ export function MarginPage() {
     return () => { cancelled = true; };
   }, [activeModifiers]);
 
-  // Clicking a rollup chip EXCLUDES that chain's revenue from totals (e.g.
-  // "show me what the numbers look like without Melt"). Customers /
-  // categories / items resolved by fn_preview_rollup_match get pushed into
-  // the exclude_* filter slots that fn_sales_pivot + fn_sales_totals read.
+  // Clicking a rollup chip EXCLUDES that chain's customers from totals (e.g.
+  // "show me what the numbers look like without Melt"). We deliberately use
+  // only the customer expansion, not the category/item expansion — a rollup
+  // like MTE is defined as "Melt customers AND E&S categories" (an
+  // intersection on include), and the de-Morgan equivalent on exclude
+  // (customer NOT in Melt OR category NOT in E&S) can't be expressed as
+  // three independent exclusion lists. Excluding the categories too would
+  // wipe out virtually every row in the dataset. Customer exclusion is the
+  // useful operator intent ("hide this chain"); category narrowing remains
+  // available via the regular Category picker.
   const effectiveFilters = useMemo(() => {
     const next: SalesFilters = { ...filters };
-    const excludeMap = {
-      customers:  'exclude_customers' as const,
-      categories: 'exclude_categories' as const,
-      items:      'exclude_items' as const,
-    };
-    for (const src of Object.keys(excludeMap) as Array<keyof typeof excludeMap>) {
-      const exp = expandedRollup.filters[src];
-      if (!exp || exp.length === 0) continue;
-      const dst = excludeMap[src];
-      const cur = (next[dst] as string[] | null | undefined) ?? [];
-      next[dst] = Array.from(new Set([...cur, ...exp]));
+    const exp = expandedRollup.filters.customers;
+    if (exp && exp.length > 0) {
+      const cur = (next.exclude_customers ?? []);
+      next.exclude_customers = Array.from(new Set([...cur, ...exp]));
     }
     return next;
   }, [filters, expandedRollup]);

--- a/docs/brixpense/user-guide.md
+++ b/docs/brixpense/user-guide.md
@@ -1,0 +1,205 @@
+# Brixpense — User Guide
+
+> **Live URL:** `alamedapointbg.com/expense/`
+> **This guide:** `alamedapointbg.com/expense/docs/brixpense/`
+> **Editable source:** `apbg-billing/docs/brixpense/user-guide.md` on GitHub. The viewer fetches this file at runtime — edit it, push, and the guide updates on the next Netlify deploy.
+
+Brixpense is the internal app for submitting receipts and purchase requests, getting approvals, and pushing approved purchases into QuickBooks as Bills. It's the same Supabase login you use for everything else on alamedapointbg.
+
+There are two kinds of submissions:
+
+| Type | When to use it | What happens |
+|---|---|---|
+| **Expense** | You already paid for it — submitting a receipt so we can record the cost and reimburse you if needed. | Auto-approved on submit. Posted to QuickBooks as a Purchase right away. No email goes to anyone. |
+| **Purchase Request (PR)** | You want to buy something but haven't yet — you need pre-approval. | Routes to an approver you pick from a dropdown. They get an email + see it in their queue. Once approved, you come back, click **Log Receipt**, and it becomes a real expense in QuickBooks. |
+
+---
+
+## Getting started
+
+### Sign in
+
+1. Open **alamedapointbg.com/expense/**.
+2. Email + password — same login as Margin Control and the gateway.
+3. You'll land on the home screen with two big buttons: **New Expense** and **New Purchase Request**.
+
+If your email isn't recognized, ask Sky or Whitney to add you in the admin panel.
+
+### Sidebar (left)
+
+- **Home** — landing screen
+- **New** — start an expense or PR
+- **Pending** — your in-flight submissions (PRs awaiting approval, expenses still processing)
+- **History** — everything you've ever submitted
+- **Queue** — *(approvers only)* — purchase requests waiting on you
+- **Settings** — *(admins only)* — manager allowlist, payment accounts, tags, COGS accounts
+
+---
+
+## Submitting an expense (you already paid)
+
+**Use this when:** you bought something, you have the receipt, and you want it on the books.
+
+### Step-by-step
+
+1. Click **New Expense** from the home screen.
+2. **Snap the receipt.** Phone camera, drag-and-drop, or file upload — all work.
+3. Brixpense runs the receipt through **OCR** (Claude API) and pre-fills:
+   - Vendor name
+   - Total amount
+   - Date
+   - Line items if visible
+4. Check the auto-filled fields. Edit anything that looks wrong.
+5. **Entity** — `Brix / Alameda Soda`, `FreeFlow`, or `Shared`. This determines which legal entity owns the expense.
+6. **Department** — filtered based on entity (e.g. FreeFlow gets `service` / `reman` / `ops` / `freeflow`; Brix gets `delivery` / `service` / `ops` / `melt`).
+7. **COGS / expense account** — what bucket this hits in QuickBooks. The dropdown sorts the most likely accounts first based on the department you picked.
+8. **Paid with** — which payment account (credit card, bank, petty cash) you used.
+9. **Submit.**
+
+The expense auto-approves and gets posted to QuickBooks as a Purchase within seconds. You'll see a success toast. No email goes to anyone.
+
+### Where it shows up
+
+- Your **History** page — under "Expenses, auto-approved."
+- QuickBooks — as a Purchase transaction with the receipt attached as an attachment (visible on the QBO record).
+- `ops.expense_requests` in Supabase — `status='posted'`, `decided_by='system (auto-approve)'`.
+
+---
+
+## Submitting a purchase request (you need pre-approval)
+
+**Use this when:** you want to buy something and need someone with budget authority to sign off first.
+
+### Step-by-step
+
+1. Click **New Purchase Request** from the home screen.
+2. Fill in:
+   - **Vendor** — who you'd be paying
+   - **Estimated total** — your best guess
+   - **What you're buying** — line items, descriptions, why
+   - **Entity / Department / COGS** — same as for an expense
+3. **Approver** — pick one from the dropdown. This list is the **manager allowlist** from `ops.expense_settings.manager_emails`. Whoever you pick gets:
+   - An email with a link to `/expense/queue`
+   - A row in their personal Queue page
+4. **Submit.**
+
+You'll see your request on the **Pending** page with status `pending`. You can't approve your own PR — that's enforced both in the UI and in the database.
+
+### What happens next
+
+The approver gets an email and signs into Brixpense. They see your PR in their **Queue** with a Review button.
+
+If they **approve** — your PR moves to `awaiting_invoice`. You'll get notified, and the row on your **Pending** page now shows a **Log Receipt** button (see "After your PR is approved" below).
+
+If they **deny** — your PR moves to `denied`. You'll get an email with their note explaining why.
+
+---
+
+## For approvers: reviewing a purchase request
+
+**You're an approver if** your email is in `ops.expense_settings.manager_emails`. If it isn't and you think it should be, ask Sky.
+
+### The Queue page
+
+`/expense/queue` lists every PR awaiting your decision. Each row shows submitter, vendor, total, date, and a **Review** button.
+
+### The Review screen
+
+`/expense/review/:id` opens the full PR:
+
+- Submitter, vendor, total, line items, memo
+- Receipt preview (if attached)
+- Entity / Department / COGS routing
+- **Approve** and **Deny** buttons + a notes textbox
+- Optional **Signature** capture
+
+### Approve
+
+Click **Approve**. The PR flips to `awaiting_invoice` and the submitter gets notified. No QBO posting happens yet — Brixpense holds the PR until the submitter logs the actual receipt (see next section).
+
+### Deny
+
+Type a note explaining why, then click **Deny**. The submitter gets an email with your note. The PR is final at this point; if they want to resubmit, they need to start fresh.
+
+### Guardrails
+
+- You **cannot approve your own PR** — the API rejects it with `403 self_approval_forbidden`.
+- You **must be in the allowlist** — the API checks `lower(caller.email) == lower(manager_email)` against the chosen approver. RLS enforces the same.
+- No magic-link tokens, no anonymous approval path — approvers always sign in.
+
+---
+
+## After your PR is approved: Log Receipt
+
+**Use this when:** an approved PR is `awaiting_invoice` and you've now actually purchased the thing. Closes the requisition→bill loop without forcing POs.
+
+### How to find it
+
+The **Pending** page shows your approved PRs in the `awaiting_invoice` status. Each one has a **Log Receipt** button on the right.
+
+### What clicking Log Receipt does
+
+Opens the New Expense form, **pre-filled from the PR** — vendor, total, COGS, department, customer, job, tag, memo, even line items. You snap the actual receipt, tweak any final numbers that differ from the original estimate, and submit.
+
+The new expense gets:
+- A `linked_pr_id` pointing back at the original PR
+- The QuickBooks Purchase PrivateNote prepended with `PR approved by <name> on <date> | linked PR: <short>` so auditors can trace the chain
+
+And the original PR row gets flipped to `status='fulfilled'` so it stops showing in your Pending list.
+
+---
+
+## History
+
+Everything you've ever submitted, newest first. Filter by status (draft / pending / approved / denied / awaiting_invoice / fulfilled / posted), date range, or vendor.
+
+Click any row to open the detail page. From there you can re-open it as a new expense (useful for recurring vendors), see the QBO Purchase if posted, or download the receipt attachment.
+
+---
+
+## Tips & shortcuts
+
+- **Mobile-first.** Snap a receipt on your phone right after a purchase. It takes less than a minute end-to-end.
+- **Receipt OCR isn't perfect.** Always glance over the auto-filled fields before submitting. Vendor and total are usually right; line items can drift.
+- **Multiple receipts on one expense.** Drop additional files in the receipt area before submitting. They all attach to the same Brixpense row and the QBO Purchase.
+- **Resubmit a denied PR.** Open it from History → click "Duplicate as new PR." Pre-fills everything; you just change what you need and pick a fresh approver.
+- **Tax / no-tax line items.** Brixpense doesn't track tax separately by default — if you need a line broken out, add a second line item for the tax portion (vendor field "Sales tax").
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| OCR didn't fill anything in | Receipt photo was blurry or skewed | Re-take the photo. Bright, flat, the whole receipt in frame. |
+| Approver dropdown is empty | Your role doesn't have access to the allowlist, OR `ops.expense_settings.manager_emails` hasn't been seeded | Ask Sky to seed `manager_emails` in `ops.expense_settings` |
+| "You cannot approve your own request" | Self-approval is blocked at the API + RLS | Pick a different approver, or have someone else approve |
+| PR stuck on `pending` | Approver hasn't acted, or their email bounced | Ping them directly, or ask Sky to reassign in `ops.expense_requests` |
+| Submitted PR but Log Receipt button doesn't show | PR is still `pending` or `denied` — the button only appears on `awaiting_invoice` rows | Wait for approval, or open the PR in History to see its current status |
+| QBO Purchase wasn't created after auto-approve | Vendor name didn't match any QBO vendor (or QBO API was throttling) | Open the row in History, check the error in the audit log. Usually the fix is creating the vendor in QBO and re-running the post via the admin Master Control panel. |
+| Login loops | Browser blocked Supabase third-party cookies | Allow cookies for `gfsdpwiqzshhexkofiif.supabase.co` |
+
+If you hit something not on this list, message Sky on Slack with a screenshot of the row + the URL.
+
+---
+
+## How the plumbing works (for the curious)
+
+| Component | Lives at |
+|---|---|
+| Brixpense React SPA | `apbg-billing/app-expense/` → built into `public/expense/` → served at `/expense/` |
+| Supabase tables | `ops.expense_requests`, `ops.expense_request_attachments`, `ops.expense_request_approvals`, `ops.expense_settings` |
+| Receipt OCR | Anthropic Claude API via the `process-inbound` Netlify Function |
+| Approval routing email | Resend (or SendGrid) via the `expense-request-notify` Netlify Function |
+| Approve / Deny endpoint | `expense-request-decide` — Bearer JWT auth, self-approval + allowlist guards, RLS belt-and-suspenders |
+| QBO Bill creation | `expense-request-link-bill` — Vendor match + POST `/bill` to QuickBooks, with PR audit notes in PrivateNote |
+
+Detailed architecture is in [`architecture/BRIXPENSE.md`](https://github.com/skypace/apbg-billing/blob/main/architecture/BRIXPENSE.md).
+
+---
+
+## Change log
+
+| Date | Change |
+|---|---|
+| 2026-05-17 | Initial scaffold. Covers Sign-in, Submit an Expense, Submit a PR, Approve/Deny, Log Receipt, History, Tips, Troubleshooting. |

--- a/docs/margin-control/user-guide.md
+++ b/docs/margin-control/user-guide.md
@@ -1,10 +1,10 @@
-# BRIX Margin Control — User Guide
+# BRIX Margin & Product Control — User Guide
 
 > **Live URL:** `alamedapointbg.com/margin/`
 > **This guide:** `alamedapointbg.com/margin/docs/margin-control/`
 > **Editable source:** `apbg-billing/docs/margin-control/user-guide.md` on GitHub. The viewer fetches this file at runtime — edit it, push, and the guide updates on the next Netlify deploy.
 
-BRIX Margin Control is the internal margin / sales / customer analytics tool. It reads QuickBooks invoice and item data through a curated `ops.*` schema in Supabase and renders 9 dashboards around it. This guide covers what each page does, the controls on it, and the workflows people use it for.
+BRIX Margin & Product Control is the internal margin / sales / customer / product analytics tool. It reads QuickBooks invoice and item data through a curated `ops.*` schema in Supabase and renders 9 dashboards around it. This guide covers what each page does, the controls on it, and the workflows people use it for.
 
 ---
 
@@ -297,5 +297,6 @@ If you're ever debugging a number that doesn't match QBO live, the canonical aut
 
 | Date | Change |
 |---|---|
+| 2026-05-17 | Renamed app from **Margin Control** to **Margin & Product Control** — reflects the broader scope (items / inventory / categories / rollups in addition to margin). Hub card on alamedapointbg.com now sits alongside a new **Brixpense** card. |
 | 2026-05-17 | Added **Chain Rollup picker (exclude)** section under Margin — clicking a chip subtracts that chain's revenue from totals. Added **What's behind the curtain** explainer for the new polymorphic sync (Sales Receipts, Credit Memos, Refund Receipts, Discounts) and the self-healing rolling refresh. Added troubleshooting rows for unmapped income accounts and stale lines. |
 | 2026-05-11 | Initial scaffold. Covers Getting Started + Overview + Margin + Customers + Customer Detail + Compare + Inventory + Reports + Tips. Operations / Plans / Settings flagged as in progress. |

--- a/netlify.toml
+++ b/netlify.toml
@@ -95,6 +95,16 @@
   to = "/api/:splat"
   status = 200
 
+# Brixpense user-guide viewer. Must come BEFORE the /expense/* SPA fallback
+# below — otherwise React Router would swallow it. The viewer lives at
+# /docs/brixpense/index.html (alongside the Margin viewer) and fetches its
+# markdown from ./user-guide.md at runtime; copied from docs/brixpense/ at
+# build time by the `cp -r docs/. public/docs/` step in [build].command.
+[[redirects]]
+  from = "/expense/docs/*"
+  to = "/docs/:splat"
+  status = 200
+
 # ── Expense app: SPA fallback ──
 # Any /expense/* path that doesn't match a static file or the rules above
 # rewrites to the SPA's index.html so React Router can handle deep links.

--- a/public/docs/brixpense/index.html
+++ b/public/docs/brixpense/index.html
@@ -1,0 +1,408 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Brixpense — User Guide</title>
+<meta name="description" content="User guide for Brixpense — the APBG internal expense + purchase request workflow.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/marked@12.0.0/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.9/dist/purify.min.js"></script>
+<style>
+:root{
+  --bg:#06121F;
+  --bg-elev:#0E2240;
+  --surface:#163052;
+  --surface-hover:#1E4068;
+  --border:#1B3A5E;
+  --border-strong:#2A5285;
+  --teal:#5BB5F0;
+  --teal-bright:#7CC5F5;
+  --teal-soft:#0E2240;
+  --text:#E6EEF7;
+  --text-2:#94A8BD;
+  --text-3:#6B8499;
+  --success:#2EB872;
+  --warning:#F4B400;
+  --error:#FF5A5F;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+html{scroll-behavior:smooth}
+@media (prefers-reduced-motion: reduce){
+  html{scroll-behavior:auto}
+  *,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}
+}
+html,body{
+  font-family:'DM Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  background:var(--bg);color:var(--text);min-height:100vh;
+  -webkit-font-smoothing:antialiased;font-size:15px;line-height:1.6;
+}
+
+.app{display:grid;grid-template-columns:300px 1fr;min-height:100vh}
+.sidebar{
+  background:linear-gradient(180deg, rgba(14, 36, 71, 0.85) 0%, rgba(11, 28, 57, 0.92) 100%);
+  backdrop-filter:blur(28px) saturate(180%);-webkit-backdrop-filter:blur(28px) saturate(180%);
+  border-right:1px solid var(--border);position:sticky;top:0;height:100vh;overflow-y:auto;
+  padding:20px 18px;
+}
+.content{padding:48px 56px 96px;max-width:880px}
+
+.brand{display:flex;align-items:center;gap:12px;padding:6px 8px 18px;border-bottom:1px solid var(--border);margin-bottom:14px}
+.brand-mark{width:38px;height:38px;border-radius:10px;background:linear-gradient(135deg,var(--teal),#003A49);display:flex;align-items:center;justify-content:center;font-weight:800;color:#fff;font-size:0.78rem;letter-spacing:0.04em;flex-shrink:0;box-shadow:0 0 18px rgba(91,181,240,0.35)}
+.brand-text{display:flex;flex-direction:column;min-width:0}
+.brand-title{font-size:0.92rem;font-weight:800;color:var(--text);letter-spacing:-0.01em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.brand-title b{color:var(--teal)}
+.brand-sub{font-size:0.66rem;color:var(--text-3);letter-spacing:0.08em;text-transform:uppercase;font-weight:600;font-family:'JetBrains Mono',monospace}
+.back-link{display:inline-flex;align-items:center;gap:6px;padding:4px 8px;margin:8px 0 14px;font-size:0.74rem;color:var(--text-2);text-decoration:none;border-radius:6px;font-weight:600;transition:all 0.15s}
+.back-link:hover{background:var(--surface);color:var(--text)}
+
+.search-wrap{position:relative;margin-bottom:18px}
+.search-input{
+  width:100%;padding:9px 12px 9px 34px;border:1px solid var(--border);border-radius:8px;
+  background:var(--surface);color:var(--text);font-size:0.82rem;outline:none;
+  transition:all 0.15s;font-family:inherit;
+}
+.search-input::placeholder{color:var(--text-3)}
+.search-input:focus{border-color:var(--teal);background:var(--surface-hover);box-shadow:0 0 0 3px rgba(91,181,240,0.18)}
+.search-icon{position:absolute;left:11px;top:50%;transform:translateY(-50%);color:var(--text-3);pointer-events:none}
+.search-meta{font-size:0.66rem;color:var(--text-3);margin-top:6px;padding-left:4px;font-family:'JetBrains Mono',monospace}
+
+.toc{list-style:none;display:flex;flex-direction:column;gap:1px}
+.toc li{display:flex}
+.toc a{
+  flex:1;padding:7px 10px;font-size:0.81rem;font-weight:500;color:var(--text-2);
+  text-decoration:none;border-radius:6px;transition:all 0.12s;letter-spacing:0.005em;
+  line-height:1.35;display:flex;align-items:center;gap:8px;
+}
+.toc a:hover{background:var(--surface);color:var(--text)}
+.toc a.active{background:rgba(91,181,240,0.18);color:var(--teal-bright);font-weight:600}
+.toc .level-3 a{padding-left:24px;font-size:0.76rem;color:var(--text-3)}
+.toc .level-3 a:hover{color:var(--text-2)}
+.toc .level-3 a.active{color:var(--teal-bright);background:transparent;font-weight:600}
+.toc-hidden{display:none!important}
+.toc-empty{padding:14px 10px;font-size:0.78rem;color:var(--text-3);font-style:italic}
+
+.sidebar-foot{margin-top:24px;padding-top:14px;border-top:1px solid var(--border);font-size:0.7rem;color:var(--text-3);line-height:1.5}
+.sidebar-foot a{color:var(--text-2);text-decoration:none}
+.sidebar-foot a:hover{color:var(--teal)}
+.sidebar-foot code{font-family:'JetBrains Mono',monospace;font-size:0.66rem;padding:1px 5px;background:var(--bg);border:1px solid var(--border);border-radius:3px}
+
+.content h1{font-size:2.1rem;font-weight:800;letter-spacing:-0.03em;color:var(--text);margin-bottom:8px;line-height:1.1}
+.content h2{font-size:1.45rem;font-weight:700;letter-spacing:-0.02em;color:var(--text);margin-top:48px;margin-bottom:14px;padding-bottom:10px;border-bottom:1px solid var(--border);scroll-margin-top:20px;position:relative}
+.content h3{font-size:1.08rem;font-weight:700;letter-spacing:-0.01em;color:var(--text);margin-top:30px;margin-bottom:10px;scroll-margin-top:20px;position:relative}
+.content h4{font-size:0.92rem;font-weight:700;color:var(--text);margin-top:22px;margin-bottom:8px}
+.content h2 .anchor,.content h3 .anchor{
+  position:absolute;left:-26px;top:50%;transform:translateY(-50%);
+  color:var(--text-3);text-decoration:none;font-weight:400;opacity:0;transition:opacity 0.15s;
+  font-size:0.85em;
+}
+.content h2:hover .anchor,.content h3:hover .anchor{opacity:1}
+.content h2 .anchor:hover,.content h3 .anchor:hover{color:var(--teal)}
+
+.content p{margin:0 0 14px;color:var(--text-2);line-height:1.65;font-size:0.93rem}
+.content strong{color:var(--text);font-weight:700}
+.content em{font-style:italic;color:var(--text)}
+.content a{color:var(--teal);text-decoration:none;border-bottom:1px solid transparent;transition:border-color 0.15s}
+.content a:hover{border-bottom-color:var(--teal)}
+
+.content ul,.content ol{margin:0 0 16px 0;padding-left:24px;color:var(--text-2);font-size:0.93rem;line-height:1.65}
+.content li{margin-bottom:6px}
+.content li::marker{color:var(--text-3)}
+
+.content blockquote{
+  border-left:3px solid var(--teal);background:var(--surface);
+  padding:14px 18px;margin:18px 0;border-radius:0 8px 8px 0;color:var(--text-2);
+}
+.content blockquote p{margin-bottom:8px}
+.content blockquote p:last-child{margin-bottom:0}
+.content blockquote strong{color:var(--text)}
+
+.content code{
+  font-family:'JetBrains Mono',monospace;font-size:0.84em;
+  background:var(--bg-elev);border:1px solid var(--border);
+  padding:1px 6px;border-radius:4px;color:var(--teal-bright);
+}
+.content pre{
+  background:var(--bg-elev);border:1px solid var(--border);border-radius:8px;
+  padding:16px 18px;margin:16px 0;overflow-x:auto;
+}
+.content pre code{background:transparent;border:none;padding:0;color:var(--text-2);font-size:0.82rem;line-height:1.5}
+
+.content hr{border:none;border-top:1px solid var(--border);margin:36px 0}
+
+.content table{width:100%;border-collapse:collapse;margin:16px 0;font-size:0.85rem}
+.content thead{background:var(--surface)}
+.content th,.content td{
+  padding:9px 14px;text-align:left;border-bottom:1px solid var(--border);vertical-align:top;
+}
+.content th{font-weight:700;color:var(--text-2);font-size:0.78rem;letter-spacing:0.02em;text-transform:uppercase}
+.content td{color:var(--text-2);line-height:1.5}
+.content td strong{color:var(--text)}
+.content tr:last-child td{border-bottom:none}
+
+.content-header{
+  display:flex;align-items:center;justify-content:space-between;gap:18px;flex-wrap:wrap;
+  padding-bottom:18px;margin-bottom:24px;border-bottom:1px solid var(--border);
+}
+.content-meta{display:flex;flex-direction:column;gap:4px}
+.crumb{font-size:0.68rem;color:var(--text-3);letter-spacing:0.08em;text-transform:uppercase;font-weight:700;font-family:'JetBrains Mono',monospace}
+.last-updated{font-size:0.72rem;color:var(--text-3);font-family:'JetBrains Mono',monospace}
+.actions{display:flex;gap:8px;flex-wrap:wrap}
+.action-btn{
+  display:inline-flex;align-items:center;gap:6px;padding:7px 12px;
+  background:var(--surface);border:1px solid var(--border);border-radius:7px;
+  color:var(--text-2);font-size:0.76rem;font-weight:600;cursor:pointer;
+  text-decoration:none;transition:all 0.15s;font-family:inherit;
+}
+.action-btn:hover{border-color:var(--teal);color:var(--text);background:var(--surface-hover)}
+
+.state{padding:40px 20px;text-align:center;color:var(--text-3);font-size:0.88rem}
+.state.error{color:#FCA5A5}
+.spinner{
+  width:24px;height:24px;border:2px solid var(--border);border-top-color:var(--teal);
+  border-radius:50%;animation:spin 0.8s linear infinite;margin:0 auto 12px;
+}
+@keyframes spin{to{transform:rotate(360deg)}}
+
+@media (max-width:900px){
+  .app{grid-template-columns:1fr}
+  .sidebar{position:fixed;top:0;left:0;width:280px;z-index:50;transform:translateX(-100%);transition:transform 0.2s;box-shadow:0 0 40px rgba(0,0,0,0.5)}
+  .sidebar.open{transform:translateX(0)}
+  .content{padding:24px 20px 64px}
+  .menu-btn{display:flex!important}
+  .scrim{display:none;position:fixed;inset:0;background:rgba(0,0,0,0.5);z-index:40}
+  .scrim.open{display:block}
+}
+.menu-btn{
+  display:none;position:fixed;top:14px;left:14px;z-index:60;
+  width:38px;height:38px;border-radius:8px;background:var(--surface);border:1px solid var(--border);
+  color:var(--text);align-items:center;justify-content:center;cursor:pointer;
+}
+
+@media print{
+  .app{display:block}
+  .sidebar,.scrim,.menu-btn,.actions{display:none!important}
+  .content{padding:0;max-width:100%;color:#000}
+  .content h1,.content h2,.content h3,.content h4,.content strong{color:#000}
+  .content p,.content li,.content td,.content blockquote{color:#222}
+  .content blockquote{background:#f5f5f5;border-left-color:#666}
+  .content code{background:#f0f0f0;color:#000;border:1px solid #ccc}
+  .content pre{background:#f5f5f5;border:1px solid #ddd}
+  .content a{color:#003A49;text-decoration:underline}
+  body{background:#fff}
+  html,body{font-size:11pt;line-height:1.45}
+}
+</style>
+</head>
+<body>
+
+<button class="menu-btn" id="menuBtn" aria-label="Open menu">
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+</button>
+<div class="scrim" id="scrim"></div>
+
+<div class="app">
+  <aside class="sidebar" id="sidebar">
+    <div class="brand">
+      <div class="brand-mark">BX</div>
+      <div class="brand-text">
+        <div class="brand-title">BRI<b>X</b>PENSE</div>
+        <div class="brand-sub">User Guide</div>
+      </div>
+    </div>
+
+    <a href="/expense/" class="back-link">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
+      Back to Brixpense
+    </a>
+
+    <div class="search-wrap">
+      <svg class="search-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input id="search" class="search-input" placeholder="Search the guide…" autocomplete="off">
+      <div class="search-meta" id="searchMeta">Press / to focus</div>
+    </div>
+
+    <ul class="toc" id="toc">
+      <li class="toc-empty">Loading…</li>
+    </ul>
+
+    <div class="sidebar-foot">
+      <div>Source: <code>docs/brixpense/<br>user-guide.md</code></div>
+      <div style="margin-top:6px">
+        <a id="editLink" href="https://github.com/skypace/apbg-billing/blob/main/docs/brixpense/user-guide.md" target="_blank" rel="noopener">Edit on GitHub →</a>
+      </div>
+    </div>
+  </aside>
+
+  <main class="content">
+    <div class="content-header">
+      <div class="content-meta">
+        <div class="crumb">Brixpense · Documentation</div>
+        <div class="last-updated" id="lastUpdated">—</div>
+      </div>
+      <div class="actions">
+        <a class="action-btn" href="/expense/" title="Open the app">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+          Open app
+        </a>
+        <button class="action-btn" id="printBtn" title="Print this guide">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
+          Print
+        </button>
+      </div>
+    </div>
+
+    <article id="doc">
+      <div class="state">
+        <div class="spinner"></div>
+        <div>Loading user guide…</div>
+      </div>
+    </article>
+  </main>
+</div>
+
+<script>
+marked.setOptions({ gfm: true, breaks: false, headerIds: true, mangle: false });
+
+async function loadGuide(){
+  const docEl = document.getElementById('doc');
+  try {
+    const res = await fetch('./user-guide.md?_=' + Date.now(), { cache: 'no-cache' });
+    if (!res.ok) throw new Error(`Failed to fetch user-guide.md (HTTP ${res.status})`);
+    const md = await res.text();
+    const rawHtml = marked.parse(md);
+    const safeHtml = DOMPurify.sanitize(rawHtml, { ADD_ATTR: ['target','rel'] });
+    docEl.innerHTML = safeHtml;
+    buildTOC();
+    addAnchors();
+    parseLastUpdated(md);
+    setupNavObserver();
+  } catch (err) {
+    console.error(err);
+    docEl.innerHTML = `<div class="state error">
+      <div style="font-size:1.2rem;margin-bottom:8px">⚠️ Couldn't load the user guide</div>
+      <div style="font-size:0.82rem">${err.message}</div>
+      <div style="font-size:0.78rem;margin-top:14px;color:var(--text-3)">
+        The viewer expects <code>./user-guide.md</code> next to this file.
+        Check the netlify.toml build step copies <code>docs/</code> → <code>public/docs/</code>.
+      </div>
+    </div>`;
+  }
+}
+
+function slugify(text){
+  return text.toLowerCase().trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function buildTOC(){
+  const toc = document.getElementById('toc');
+  toc.innerHTML = '';
+  const headings = document.querySelectorAll('#doc h2, #doc h3');
+  if (!headings.length) { toc.innerHTML = '<li class="toc-empty">No sections yet</li>'; return; }
+  const used = new Set();
+  headings.forEach(h => {
+    const text = h.textContent.trim();
+    let id = h.id || slugify(text);
+    let unique = id; let i = 2;
+    while (used.has(unique)) { unique = id + '-' + i; i++; }
+    h.id = unique; used.add(unique);
+    const li = document.createElement('li');
+    li.className = 'level-' + h.tagName[1];
+    const a = document.createElement('a');
+    a.href = '#' + unique;
+    a.textContent = text;
+    a.dataset.target = unique;
+    li.appendChild(a);
+    toc.appendChild(li);
+  });
+}
+
+function addAnchors(){
+  document.querySelectorAll('#doc h2, #doc h3').forEach(h => {
+    const a = document.createElement('a');
+    a.href = '#' + h.id;
+    a.className = 'anchor';
+    a.innerHTML = '#';
+    a.setAttribute('aria-label', 'Link to ' + h.textContent.trim());
+    h.appendChild(a);
+  });
+}
+
+function parseLastUpdated(md){
+  const re = /\|\s*(\d{4}-\d{2}-\d{2})\s*\|/g;
+  const dates = [];
+  let m;
+  while ((m = re.exec(md)) !== null) dates.push(m[1]);
+  if (dates.length) {
+    dates.sort();
+    document.getElementById('lastUpdated').textContent = 'Last updated ' + dates[dates.length - 1];
+  }
+}
+
+function setupNavObserver(){
+  const links = Array.from(document.querySelectorAll('.toc a'));
+  const headings = document.querySelectorAll('#doc h2, #doc h3');
+  if (!headings.length) return;
+  const obs = new IntersectionObserver((entries) => {
+    entries.forEach(en => {
+      if (en.isIntersecting) {
+        const id = en.target.id;
+        links.forEach(l => l.classList.toggle('active', l.dataset.target === id));
+      }
+    });
+  }, { rootMargin: '-15% 0px -70% 0px' });
+  headings.forEach(h => obs.observe(h));
+}
+
+function setupSearch(){
+  const input = document.getElementById('search');
+  const meta = document.getElementById('searchMeta');
+  input.addEventListener('input', () => {
+    const q = input.value.trim().toLowerCase();
+    const items = document.querySelectorAll('#toc li');
+    let visible = 0;
+    items.forEach(li => {
+      const text = li.textContent.toLowerCase();
+      const show = !q || text.includes(q);
+      li.classList.toggle('toc-hidden', !show);
+      if (show) visible++;
+    });
+    meta.textContent = q ? `${visible} section${visible === 1 ? '' : 's'} match` : 'Press / to focus';
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') {
+      if (e.key === 'Escape') { input.value=''; input.dispatchEvent(new Event('input')); input.blur(); }
+      return;
+    }
+    if (e.key === '/') { e.preventDefault(); input.focus(); }
+  });
+}
+
+function setupMobileMenu(){
+  const btn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('sidebar');
+  const scrim = document.getElementById('scrim');
+  btn.addEventListener('click', () => { sidebar.classList.add('open'); scrim.classList.add('open'); });
+  scrim.addEventListener('click', () => { sidebar.classList.remove('open'); scrim.classList.remove('open'); });
+  document.addEventListener('click', (e) => {
+    if (e.target.matches('.toc a')) {
+      sidebar.classList.remove('open');
+      scrim.classList.remove('open');
+    }
+  });
+}
+
+document.getElementById('printBtn').addEventListener('click', () => window.print());
+
+setupSearch();
+setupMobileMenu();
+loadGuide();
+</script>
+</body>
+</html>

--- a/public/docs/margin-control/index.html
+++ b/public/docs/margin-control/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>BRIX Margin Control — User Guide</title>
-<meta name="description" content="User guide for BRIX Margin Control — the APBG margin / sales / customer analytics tool.">
+<title>BRIX Margin &amp; Product Control — User Guide</title>
+<meta name="description" content="User guide for BRIX Margin &amp; Product Control — the APBG margin / sales / customer / product analytics tool.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
@@ -217,14 +217,14 @@ html,body{
     <div class="brand">
       <div class="brand-mark">BX</div>
       <div class="brand-text">
-        <div class="brand-title">Margin Control</div>
+        <div class="brand-title">Margin &amp; Product Control</div>
         <div class="brand-sub">User Guide</div>
       </div>
     </div>
 
     <a href="/margin/" class="back-link">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
-      Back to Margin Control
+      Back to Margin &amp; Product Control
     </a>
 
     <div class="search-wrap">
@@ -248,7 +248,7 @@ html,body{
   <main class="content">
     <div class="content-header">
       <div class="content-meta">
-        <div class="crumb">BRIX Margin Control · Documentation</div>
+        <div class="crumb">BRIX Margin &amp; Product Control · Documentation</div>
         <div class="last-updated" id="lastUpdated">—</div>
       </div>
       <div class="actions">


### PR DESCRIPTION
## Why

The app is no longer just margin analytics — it covers product master data, inventory, item categorization, chain rollups, and P&L alignment too. The name should reflect that.

## What

User-visible rename `Margin Control` → `Margin & Product Control` across:

- Sidebar header (`Layout.tsx`)
- Splash screen (`App.tsx`)
- Login page heading (`LoginPage.tsx`)
- Margin page hero title (`MarginPage.tsx`)
- Browser tab title (`app/index.html`)
- User-guide doc title + viewer chrome + meta description
- Customer detail PDF export footer
- User-guide change log entry

Left alone: variable names, CSS classes, internal comments, the `docs/margin-control/` directory path. Renaming those creates breakage risk for no user benefit; the URL stays `/margin/docs/margin-control/`.

## Companion change in apbg-gateway

`skypace/apbg-gateway` `public/index.html` gets a new **Brixpense** card in the Billing & Finance section (between BX Margin Control and Brix Monthly Invoices), plus a `receipt` icon added to `ICONS` and a `brixpense:'billing'` entry in `STATUS_MAP`. Pushed via the asm-mcp-tools MCP (separate repo, separate commit).

## Test plan

- [ ] After Netlify rebuilds, open `/margin/` → splash screen, sidebar header, hero, login all show "Margin & Product Control"
- [ ] Browser tab title reads `BRIX · Margin & Product Control`
- [ ] User guide at `/margin/docs/margin-control/` shows new title + matching viewer chrome
- [ ] After apbg-gateway rebuilds, `alamedapointbg.com/` shows a Brixpense card in Billing & Finance with the receipt icon, linking to `/expense/`

https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H)_