### PR TITLE
brand: rename app → BRIX Refractor

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -7,7 +7,7 @@
     <link rel="apple-touch-icon" href="/Brix-Round-Logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#06121F" />
-    <title>BRIX · Margin &amp; Product Control</title>
+    <title>BRIX Refractor</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -24,13 +24,13 @@ const PlaceholderPage = lazy(() => import('./pages/PlaceholderPage').then((m) =>
 
 function Splash() {
   return (
-    <div className="splash" role="status" aria-label="Loading BRIX Margin & Product Control">
+    <div className="splash" role="status" aria-label="Loading BRIX Refractor">
       <div>
         <BrixMark size={88} title="Brix Beverage" />
         <div className="splash-brand" style={{ marginTop: 18 }}>
           BRI<span style={{ color: 'var(--ac)' }}>X</span>
         </div>
-        <div className="splash-sub">Margin &amp; Product Control</div>
+        <div className="splash-sub">Refractor</div>
       </div>
     </div>
   );

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -88,7 +88,7 @@ export function Layout({ current, onNav, userEmail, onLogout, children }: Layout
             <div className="brand-mark">BRI<span className="brand-bx">X</span></div>
             <div className="brand-sub">
               <span className="status-dot" aria-hidden="true" />
-              Margin &amp; Product Control
+              Refractor
             </div>
           </div>
         </div>
@@ -125,7 +125,7 @@ export function Layout({ current, onNav, userEmail, onLogout, children }: Layout
             target="_blank"
             rel="noopener noreferrer"
             className="sign-out help-link"
-            title="Open the BRIX Margin &amp; Product Control user guide in a new tab"
+            title="Open the BRIX Refractor user guide in a new tab"
           >
             <BookOpen size={13} strokeWidth={2} aria-hidden="true" />
             <span>User Guide</span>

--- a/app/src/pages/CustomerDetailPage.tsx
+++ b/app/src/pages/CustomerDetailPage.tsx
@@ -201,7 +201,7 @@ td,th{padding:5px 8px;border-bottom:1px solid #e2e8f0;text-align:left}
 ${itemRows || '<tr><td colspan="4" style="text-align:center;color:#64748b">No items in window</td></tr>'}
 </tbody></table>
 <div style="margin-top:24px;font-size:9px;color:#64748b;border-top:1px solid #e2e8f0;padding-top:6px">
-  Generated ${new Date().toISOString().slice(0, 10)} · BRIX Margin &amp; Product Control · Customer first seen ${escapeHtml(sc.first_invoice_date ?? '-')}
+  Generated ${new Date().toISOString().slice(0, 10)} · BRIX Refractor · Customer first seen ${escapeHtml(sc.first_invoice_date ?? '-')}
 </div>
 <script>setTimeout(function(){window.print()}, 350);</script>
 </body></html>`);

--- a/app/src/pages/LoginPage.tsx
+++ b/app/src/pages/LoginPage.tsx
@@ -43,7 +43,7 @@ export function LoginPage() {
           </div>
           <div className="login-brand-sub">
             <span className="status-dot" aria-hidden="true" />
-            Margin &amp; Product Control
+            Refractor
           </div>
           <div className="login-tagline">
             Real-time margin, cost coverage, and customer health.

--- a/app/src/pages/MarginPage.tsx
+++ b/app/src/pages/MarginPage.tsx
@@ -639,7 +639,7 @@ export function MarginPage() {
             <div className="hero-eyebrow">
               {heroBrandLabel}{activeModifiers.length > 0 ? ' · ' + activeModifiers.join(' + ') : ''}
             </div>
-            <h1 className="hero-title">Margin &amp; Product Control</h1>
+            <h1 className="hero-title">Margin</h1>
             <div className="hero-meta">
               {effectiveFilters.start} → {effectiveFilters.end}{compareLabel ? ` · ${compareLabel}` : ''}
               {enrichmentLoading ? ' · loading column data…' : ''}

--- a/docs/margin-control/user-guide.md
+++ b/docs/margin-control/user-guide.md
@@ -1,10 +1,10 @@
-# BRIX Margin & Product Control — User Guide
+# BRIX Refractor — User Guide
 
 > **Live URL:** `alamedapointbg.com/margin/`
 > **This guide:** `alamedapointbg.com/margin/docs/margin-control/`
 > **Editable source:** `apbg-billing/docs/margin-control/user-guide.md` on GitHub. The viewer fetches this file at runtime — edit it, push, and the guide updates on the next Netlify deploy.
 
-BRIX Margin & Product Control is the internal margin / sales / customer / product analytics tool. It reads QuickBooks invoice and item data through a curated `ops.*` schema in Supabase and renders 9 dashboards around it. This guide covers what each page does, the controls on it, and the workflows people use it for.
+BRIX Refractor is the internal margin / product / customer analytics tool — named for the instrument that measures degrees Brix in a sample. It reads QuickBooks invoice and item data through a curated `ops.*` schema in Supabase and renders 9 dashboards around it. This guide covers what each page does, the controls on it, and the workflows people use it for.
 
 ---
 
@@ -297,6 +297,6 @@ If you're ever debugging a number that doesn't match QBO live, the canonical aut
 
 | Date | Change |
 |---|---|
-| 2026-05-17 | Renamed app from **Margin Control** to **Margin & Product Control** — reflects the broader scope (items / inventory / categories / rollups in addition to margin). Hub card on alamedapointbg.com now sits alongside a new **Brixpense** card. |
+| 2026-05-17 | App renamed to **BRIX Refractor** — short, on-brand (a refractometer is the instrument that reads degrees Brix), and reflects the broader scope (items / inventory / categories / rollups in addition to margin). Operations page removed; that dashboard lives at `alamedapointbg.com/operations/` now. Hub card on alamedapointbg.com sits alongside a new Brixpense card. |
 | 2026-05-17 | Added **Chain Rollup picker (exclude)** section under Margin — clicking a chip subtracts that chain's revenue from totals. Added **What's behind the curtain** explainer for the new polymorphic sync (Sales Receipts, Credit Memos, Refund Receipts, Discounts) and the self-healing rolling refresh. Added troubleshooting rows for unmapped income accounts and stale lines. |
 | 2026-05-11 | Initial scaffold. Covers Getting Started + Overview + Margin + Customers + Customer Detail + Compare + Inventory + Reports + Tips. Operations / Plans / Settings flagged as in progress. |

--- a/public/docs/margin-control/index.html
+++ b/public/docs/margin-control/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>BRIX Margin &amp; Product Control — User Guide</title>
-<meta name="description" content="User guide for BRIX Margin &amp; Product Control — the APBG margin / sales / customer / product analytics tool.">
+<title>BRIX Refractor — User Guide</title>
+<meta name="description" content="User guide for BRIX Refractor — the APBG margin / product / customer analytics tool.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
@@ -217,14 +217,14 @@ html,body{
     <div class="brand">
       <div class="brand-mark">BX</div>
       <div class="brand-text">
-        <div class="brand-title">Margin &amp; Product Control</div>
+        <div class="brand-title">Refractor</div>
         <div class="brand-sub">User Guide</div>
       </div>
     </div>
 
     <a href="/margin/" class="back-link">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
-      Back to Margin &amp; Product Control
+      Back to Refractor
     </a>
 
     <div class="search-wrap">
@@ -248,7 +248,7 @@ html,body{
   <main class="content">
     <div class="content-header">
       <div class="content-meta">
-        <div class="crumb">BRIX Margin &amp; Product Control · Documentation</div>
+        <div class="crumb">BRIX Refractor · Documentation</div>
         <div class="last-updated" id="lastUpdated">—</div>
       </div>
       <div class="actions">


### PR DESCRIPTION
## Why

"BRIX Margin & Product Control" was descriptive but bland. A refractometer is the instrument that reads degrees Brix in a sample, so **BRIX Refractor** is short, on-brand, and an insider beverage-industry wink.

## What

Renames the user-facing app name across:

- Sidebar sub-line (Layout.tsx)
- Splash screen sub-line (App.tsx)
- Login page sub-line (LoginPage.tsx)
- Browser tab title (app/index.html)
- User guide title + intro + viewer chrome + change log entry
- Customer detail PDF export footer
- Margin page hero h1 dropped to plain "Margin" (sub-page within Refractor — the app-level identity is already established in the sidebar)

The `/margin/` URL stays. Internal file paths (`docs/margin-control/`, `architecture/MARGIN-CONTROL.md`) also stay — renaming those creates breakage risk for no benefit.

## Companion change in apbg-gateway

Hub card renamed `BX Margin Control` → `BRIX Refractor`. Tag changed `Margin` → `Refractor`. Description updated to drop "Operations" (page removed earlier) and add "Plans · Production". Pushed via the asm-mcp-tools MCP.

## Test plan

- [ ] After Netlify rebuilds, open `/margin/` → splash, sidebar, login, browser tab all show "BRIX Refractor"
- [ ] Margin sub-page hero shows just "Margin"
- [ ] User guide at `/margin/docs/margin-control/` shows new title + chrome
- [ ] After gateway rebuilds, `alamedapointbg.com/` shows "BRIX Refractor" card in Billing & Finance

https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H)_