### PR TITLE
brand: unify wordmark to BriXRefractor, enlarge across surfaces

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -26,11 +26,10 @@ function Splash() {
   return (
     <div className="splash" role="status" aria-label="Loading BRIX Refractor">
       <div>
-        <BrixMark size={88} title="Brix Beverage" />
-        <div className="splash-brand" style={{ marginTop: 18 }}>
-          BRI<span style={{ color: 'var(--ac)' }}>X</span>
+        <BrixMark size={96} title="Brix Beverage" />
+        <div className="splash-brand" style={{ marginTop: 22 }}>
+          Bri<span style={{ color: 'var(--ac)' }}>XR</span>efractor
         </div>
-        <div className="splash-sub">Refractor</div>
       </div>
     </div>
   );

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -83,13 +83,9 @@ export function Layout({ current, onNav, userEmail, onLogout, children }: Layout
         </button>
 
         <div className="brand">
-          <BrixMark size={collapsed ? 32 : 38} className="brand-mark-svg" title="Brix Beverage" />
+          <BrixMark size={collapsed ? 32 : 40} className="brand-mark-svg" title="Brix Beverage" />
           <div>
-            <div className="brand-mark">BRI<span className="brand-bx">X</span></div>
-            <div className="brand-sub">
-              <span className="status-dot" aria-hidden="true" />
-              Refractor
-            </div>
+            <div className="brand-mark">Bri<span className="brand-bx">XR</span>efractor</div>
           </div>
         </div>
         <nav className="nav">

--- a/app/src/pages/LoginPage.css
+++ b/app/src/pages/LoginPage.css
@@ -10,12 +10,13 @@
 }
 .splash-brand {
   font-family: var(--ff-display);
-  font-size: 72px;
+  font-size: 84px;
   font-weight: 800;
-  letter-spacing: 8px;
+  letter-spacing: 0.5px;
   color: var(--tx);
   line-height: 1;
   display: inline-block;
+  white-space: nowrap;
   text-shadow:
     0 0 24px rgba(230, 238, 247, 0.30),
     0 0 48px rgba(91, 181, 240, 0.20);
@@ -103,12 +104,13 @@
 }
 
 .login-brand-mark {
-  font-size: 64px;
+  font-size: 76px;
   font-weight: 800;
-  letter-spacing: 10px;
+  letter-spacing: 0.5px;
   color: var(--tx);
   line-height: 1;
   margin-top: 8px;
+  white-space: nowrap;
   text-shadow:
     0 0 24px rgba(230, 238, 247, 0.32),
     0 0 48px rgba(91, 181, 240, 0.20);
@@ -277,10 +279,10 @@
 }
 
 @media (max-width: 480px) {
-  .login-brand-mark { font-size: 48px; letter-spacing: 6px }
+  .login-brand-mark { font-size: 42px; letter-spacing: 0.5px }
   .login-form { padding: 22px 18px 18px }
   .login-tagline { font-size: 16px }
-  .splash-brand { font-size: 52px; letter-spacing: 6px }
+  .splash-brand { font-size: 46px; letter-spacing: 0.5px }
   .login-brand-marks { gap: 18px }
   .login-mark--alameda img { transform: scale(0.85) }
   .login-mark--brix img    { transform: scale(0.85) }

--- a/app/src/pages/LoginPage.tsx
+++ b/app/src/pages/LoginPage.tsx
@@ -39,11 +39,7 @@ export function LoginPage() {
           </div>
 
           <div className="brand-mark login-brand-mark">
-            BRI<span className="brand-bx">X</span>
-          </div>
-          <div className="login-brand-sub">
-            <span className="status-dot" aria-hidden="true" />
-            Refractor
+            Bri<span className="brand-bx">XR</span>efractor
           </div>
           <div className="login-tagline">
             Real-time margin, cost coverage, and customer health.

--- a/app/src/styles/theme.css
+++ b/app/src/styles/theme.css
@@ -227,14 +227,15 @@ td.mn, th.mn {
   height: 1px;
   background: var(--glass-edge-line);
 }
-.brand-mark-svg { flex: none; width: 36px; height: 36px }
+.brand-mark-svg { flex: none; width: 40px; height: 40px }
 .brand-mark {
   font-family: var(--ff-display);
-  font-size: 20px;
+  font-size: 22px;
   font-weight: 800;
-  letter-spacing: 1.5px;
+  letter-spacing: 0.2px;
   color: var(--tx);
   line-height: 1;
+  white-space: nowrap;
 }
 .brand-mark .brand-bx { color: var(--ac) }
 @keyframes shimmer-text {


### PR DESCRIPTION
## Why

Sky asked to make the BRIX Refractor logo larger, with the "BX" and "Refractor" parts both bigger, and try a unified `BriXRefractor` wordmark with the **XR** cluster as the accent — the X+R consonant pair sits at the seam where "BriX" and "Refractor" overlap.

## What

Single-line wordmark across sidebar / splash / login. Drops the two-line stack and the status-dot sub-line. Accent stays brand green (`var(--ac)`) — confirmed with Sky over Red.

### Size + tracking
| Surface | font-size | letter-spacing | mark size |
|---|---|---|---|
| Sidebar | 20 → 22px | 1.5 → 0.2px | SVG 36 → 40px |
| Splash | 72 → 84px | 8 → 0.5px | BrixMark 88 → 96px |
| Login (desktop) | 64 → 76px | 10 → 0.5px | — |
| Login (≤480px) | 48 → 42px | 6 → 0.5px | — |
| Splash (≤480px) | 52 → 46px | 6 → 0.5px | — |

Mixed-case wordmarks need tight tracking, not the wide all-caps spacing the old "BRIX" used. `white-space: nowrap` everywhere so the wordmark never wraps mid-letter when the parent shrinks. Mobile sizes intentionally come *down* slightly because the new 13-char string is much wider than 4-char "BRIX" — at the old mobile sizes it would overflow a 360px viewport.

### Cleanup later
Unused `.brand-sub` / `.splash-sub` / `.login-brand-sub` CSS rules left in place. Harmless dead style, removing them is a separate janitorial pass.

## Test plan

- [ ] Sidebar shows `BriXRefractor` with green XR after Netlify rebuild
- [ ] Splash shows the new wordmark, much larger and centered
- [ ] Login page shows the new wordmark, no overflow at 360px and 480px widths
- [ ] Collapsed sidebar still shows only the SVG mark, no text

https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H)_