### PR TITLE
ui: dial logo back down; multi-line address on customer card

### DIFF
--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -83,7 +83,7 @@ export function Layout({ current, onNav, userEmail, onLogout, children }: Layout
         </button>
 
         <div className="brand">
-          <BrixMark size={collapsed ? 32 : 40} className="brand-mark-svg" title="Brix Beverage" />
+          <BrixMark size={collapsed ? 32 : 32} className="brand-mark-svg" title="Brix Beverage" />
           <div>
             <div className="brand-mark">Bri<span className="brand-bx">XR</span>efractor</div>
           </div>

--- a/app/src/pages/CustomerDetailPage.tsx
+++ b/app/src/pages/CustomerDetailPage.tsx
@@ -308,7 +308,17 @@ ${itemRows || '<tr><td colspan="4" style="text-align:center;color:#64748b">No it
         </div>
         <div>
           <div style={{ fontSize: 9, color: 'var(--mt)', textTransform: 'uppercase', letterSpacing: 1 }}>Address</div>
-          <div style={{ fontSize: 12, marginTop: 3 }}>{addr || '—'}</div>
+          {detail.bill_addr_line1 || detail.bill_addr_city || detail.bill_addr_state || detail.bill_addr_postal ? (
+            <div style={{ fontSize: 12, marginTop: 3, lineHeight: 1.45 }}>
+              {detail.bill_addr_line1 && <div>{detail.bill_addr_line1}</div>}
+              <div>
+                {[detail.bill_addr_city, detail.bill_addr_state].filter(Boolean).join(', ')}
+                {detail.bill_addr_postal ? ` ${detail.bill_addr_postal}` : ''}
+              </div>
+            </div>
+          ) : (
+            <div style={{ fontSize: 12, marginTop: 3, color: 'var(--mt)' }}>— no address —</div>
+          )}
         </div>
         <div>
           <div style={{ fontSize: 9, color: 'var(--mt)', textTransform: 'uppercase', letterSpacing: 1 }}>Contact</div>

--- a/app/src/pages/LoginPage.css
+++ b/app/src/pages/LoginPage.css
@@ -104,7 +104,7 @@
 }
 
 .login-brand-mark {
-  font-size: 76px;
+  font-size: 52px;
   font-weight: 800;
   letter-spacing: 0.5px;
   color: var(--tx);
@@ -279,7 +279,7 @@
 }
 
 @media (max-width: 480px) {
-  .login-brand-mark { font-size: 42px; letter-spacing: 0.5px }
+  .login-brand-mark { font-size: 34px; letter-spacing: 0.5px }
   .login-form { padding: 22px 18px 18px }
   .login-tagline { font-size: 16px }
   .splash-brand { font-size: 46px; letter-spacing: 0.5px }

--- a/app/src/styles/theme.css
+++ b/app/src/styles/theme.css
@@ -227,10 +227,10 @@ td.mn, th.mn {
   height: 1px;
   background: var(--glass-edge-line);
 }
-.brand-mark-svg { flex: none; width: 40px; height: 40px }
+.brand-mark-svg { flex: none; width: 32px; height: 32px }
 .brand-mark {
   font-family: var(--ff-display);
-  font-size: 22px;
+  font-size: 17px;
   font-weight: 800;
   letter-spacing: 0.2px;
   color: var(--tx);


### PR DESCRIPTION
## Summary

- Dial the logo back: sidebar 22 → 17px, login 76 → 52px desktop / 42 → 34px mobile, sidebar mark SVG 40 → 32px. Splash left alone — that screen has the real estate.
- Customer detail "Address" block: single-line comma-joined → multi-line postal style (line1 on top, `City, ST ZIP` below).

## Not in this PR

Sub-customer address fallback (pull parent's address when sub has none). 17 active sub-customers with YTD revenue currently have no `bill_addr_*` populated — their parent does. That requires editing `fn_customer_detail` server-side; doing it as a separate PR.

## Test plan

- [ ] After Netlify rebuild, sidebar wordmark fits comfortably next to nav items at 224px width
- [ ] Login wordmark sized correctly on desktop + ≤480px mobile, no overflow
- [ ] Customer detail Address card shows two lines when populated, muted "— no address —" when not

https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H)_