### PR TITLE
plans: P&amp;L rollup + bottom-up build from history × split growth

### DIFF
--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -83,7 +83,7 @@ export function Layout({ current, onNav, userEmail, onLogout, children }: Layout
         </button>
 
         <div className="brand">
-          <BrixMark size={collapsed ? 32 : 40} className="brand-mark-svg" title="Brix Beverage" />
+          <BrixMark size={collapsed ? 32 : 32} className="brand-mark-svg" title="Brix Beverage" />
           <div>
             <div className="brand-mark">Bri<span className="brand-bx">XR</span>efractor</div>
           </div>

--- a/app/src/lib/plans.ts
+++ b/app/src/lib/plans.ts
@@ -91,6 +91,38 @@ export function fetchItemOptions() {
   );
 }
 
+export interface QboItemWithCategory extends QboItemOption {
+  category_path: string | null;
+  parent_ref_id: string | null;
+  type: string | null;
+}
+
+export function fetchItemsWithCategory() {
+  return sbq<QboItemWithCategory>(
+    'qbo_items',
+    'select=qbo_item_id,name,fully_qualified_name,income_account_ref_id,income_account_name,category_path,parent_ref_id,type'
+    + '&active=eq.true&order=category_path,name&limit=4000',
+  );
+}
+
+export interface PlanHistoryForItemRow {
+  qbo_item_id: string;
+  item_name: string;
+  category_path: string;
+  income_account_name: string | null;
+  ly_annual_qty: number;
+  ly_annual_revenue: number;
+  ly_avg_unit_price: number | null;
+  ly_customer_count: number;
+}
+
+export function fetchPlanHistoryForItems(item_ids: string[], source_year: number | null) {
+  return sbrpc<PlanHistoryForItemRow[]>('fn_plan_history_for_items', {
+    p_item_ids:    item_ids,
+    p_source_year: source_year,
+  });
+}
+
 // ----- Plan Builder auto-fill (v0.9.31) -----
 
 export interface AutofillResultRow {
@@ -116,5 +148,57 @@ export function autofillPlanFromHistory(opts: {
     p_customer_ids:   opts.customer_ids ?? null,
     p_adjustment_pct: opts.adjustment_pct ?? 0,
     p_source_year:    opts.source_year ?? null,
+  });
+}
+
+// ----- P&L rollup (Refractor planner Phase 1) -----
+
+export interface PlanPlRollupRow {
+  section: 'revenue' | 'cogs' | 'opex' | 'other';
+  section_order: number;
+  pl_line: string;
+  pl_line_order: number;
+  account_name: string;
+  item_category: string;
+  line_count: number;
+  m1: number; m2: number; m3: number; m4: number;
+  m5: number; m6: number; m7: number; m8: number;
+  m9: number; m10: number; m11: number; m12: number;
+  total: number;
+}
+
+export function fetchPlanPlRollup(plan_id: string) {
+  return sbrpc<PlanPlRollupRow[]>('fn_plan_pl_rollup', { p_plan_id: plan_id });
+}
+
+// ----- Split-growth bottom-up build (Refractor planner Phase 2) -----
+
+export interface BuildFromGrowthResultRow {
+  qbo_item_id: string;
+  item_name: string;
+  qbo_customer_id: string;
+  customer_name: string;
+  ly_annual_qty: number;
+  ly_annual_revenue: number;
+  planned_annual_qty: number;
+  planned_annual_revenue: number;
+  created: boolean;
+}
+
+export function buildPlanFromGrowth(opts: {
+  plan_id: string;
+  item_ids?: string[] | null;
+  customer_ids?: string[] | null;
+  qty_growth_pct?: number;
+  price_growth_pct?: number;
+  source_year?: number | null;
+}) {
+  return sbrpc<BuildFromGrowthResultRow[]>('fn_plan_build_from_growth', {
+    p_plan_id:          opts.plan_id,
+    p_item_ids:         opts.item_ids ?? null,
+    p_customer_ids:     opts.customer_ids ?? null,
+    p_qty_growth_pct:   opts.qty_growth_pct   ?? 0,
+    p_price_growth_pct: opts.price_growth_pct ?? 0,
+    p_source_year:      opts.source_year ?? null,
   });
 }

--- a/app/src/pages/CustomerDetailPage.tsx
+++ b/app/src/pages/CustomerDetailPage.tsx
@@ -308,7 +308,17 @@ ${itemRows || '<tr><td colspan="4" style="text-align:center;color:#64748b">No it
         </div>
         <div>
           <div style={{ fontSize: 9, color: 'var(--mt)', textTransform: 'uppercase', letterSpacing: 1 }}>Address</div>
-          <div style={{ fontSize: 12, marginTop: 3 }}>{addr || '—'}</div>
+          {detail.bill_addr_line1 || detail.bill_addr_city || detail.bill_addr_state || detail.bill_addr_postal ? (
+            <div style={{ fontSize: 12, marginTop: 3, lineHeight: 1.45 }}>
+              {detail.bill_addr_line1 && <div>{detail.bill_addr_line1}</div>}
+              <div>
+                {[detail.bill_addr_city, detail.bill_addr_state].filter(Boolean).join(', ')}
+                {detail.bill_addr_postal ? ` ${detail.bill_addr_postal}` : ''}
+              </div>
+            </div>
+          ) : (
+            <div style={{ fontSize: 12, marginTop: 3, color: 'var(--mt)' }}>— no address —</div>
+          )}
         </div>
         <div>
           <div style={{ fontSize: 9, color: 'var(--mt)', textTransform: 'uppercase', letterSpacing: 1 }}>Contact</div>

--- a/app/src/pages/LoginPage.css
+++ b/app/src/pages/LoginPage.css
@@ -104,7 +104,7 @@
 }
 
 .login-brand-mark {
-  font-size: 76px;
+  font-size: 52px;
   font-weight: 800;
   letter-spacing: 0.5px;
   color: var(--tx);
@@ -279,7 +279,7 @@
 }
 
 @media (max-width: 480px) {
-  .login-brand-mark { font-size: 42px; letter-spacing: 0.5px }
+  .login-brand-mark { font-size: 34px; letter-spacing: 0.5px }
   .login-form { padding: 22px 18px 18px }
   .login-tagline { font-size: 16px }
   .splash-brand { font-size: 46px; letter-spacing: 0.5px }

--- a/app/src/pages/plans/PlanBuildDialog.tsx
+++ b/app/src/pages/plans/PlanBuildDialog.tsx
@@ -1,0 +1,359 @@
+// Bottom-up build dialog: pick a category (QBO item parent), see every item in
+// that category with last year's qty / revenue / avg unit price, set per-item
+// qty growth % and price growth %, and Apply — writes plan lines via
+// fn_plan_build_from_growth (one call per unique (qty%, price%) pair).
+
+import { useEffect, useMemo, useState } from 'react';
+import { btnPrimary, btnSecondary, inp } from '../../lib/styles';
+import { fm } from '../../lib/formatters';
+import {
+  PlanHistoryForItemRow,
+  QboItemWithCategory,
+  buildPlanFromGrowth,
+  fetchItemsWithCategory,
+  fetchPlanHistoryForItems,
+} from '../../lib/plans';
+
+interface Props {
+  planId: string;
+  planFiscalYear: number;
+  onClose: () => void;
+  onApplied: () => void;
+}
+
+interface ItemRow {
+  qbo_item_id: string;
+  item_name: string;
+  category_path: string;
+  ly_annual_qty: number;
+  ly_annual_revenue: number;
+  ly_avg_unit_price: number | null;
+  ly_customer_count: number;
+  qty_pct: number;
+  price_pct: number;
+}
+
+export function PlanBuildDialog({ planId, planFiscalYear, onClose, onApplied }: Props) {
+  const [sourceYear, setSourceYear] = useState<number>(planFiscalYear - 1);
+  const [defaultQtyPct, setDefaultQtyPct]     = useState<number>(0);
+  const [defaultPricePct, setDefaultPricePct] = useState<number>(0);
+  const [allItems, setAllItems] = useState<QboItemWithCategory[] | null>(null);
+  const [category, setCategory] = useState<string>('');
+  const [rows, setRows] = useState<ItemRow[] | null>(null);
+  const [loadingRows, setLoadingRows] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchItemsWithCategory().then(setAllItems).catch((e: Error) => setErr(e.message));
+  }, []);
+
+  // Categories = distinct category_path among non-Category items
+  const categories: { value: string; label: string; itemCount: number }[] = useMemo(() => {
+    if (!allItems) return [];
+    const counts = new Map<string, number>();
+    for (const it of allItems) {
+      if (it.type === 'Category') continue;
+      const key = it.category_path || '(no category)';
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .map(([value, itemCount]) => ({ value, label: value, itemCount }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [allItems]);
+
+  function loadCategory(cat: string) {
+    setCategory(cat);
+    setRows(null);
+    if (!cat || !allItems) return;
+    const itemsInCat = allItems.filter(
+      (it) => it.type !== 'Category' && (it.category_path || '(no category)') === cat,
+    );
+    if (itemsInCat.length === 0) { setRows([]); return; }
+    setLoadingRows(true);
+    fetchPlanHistoryForItems(itemsInCat.map((i) => i.qbo_item_id), sourceYear)
+      .then((hist) => {
+        const byId = new Map<string, PlanHistoryForItemRow>(hist.map((h) => [h.qbo_item_id, h]));
+        const out: ItemRow[] = itemsInCat.map((it) => {
+          const h = byId.get(it.qbo_item_id);
+          return {
+            qbo_item_id:        it.qbo_item_id,
+            item_name:          it.fully_qualified_name || it.name,
+            category_path:      cat,
+            ly_annual_qty:      Number(h?.ly_annual_qty ?? 0),
+            ly_annual_revenue:  Number(h?.ly_annual_revenue ?? 0),
+            ly_avg_unit_price:  h?.ly_avg_unit_price != null ? Number(h.ly_avg_unit_price) : null,
+            ly_customer_count:  Number(h?.ly_customer_count ?? 0),
+            qty_pct:            defaultQtyPct,
+            price_pct:          defaultPricePct,
+          };
+        });
+        setRows(out);
+      })
+      .catch((e: Error) => setErr(e.message))
+      .finally(() => setLoadingRows(false));
+  }
+
+  function applyDefaultsToAll() {
+    if (!rows) return;
+    setRows(rows.map((r) => ({ ...r, qty_pct: defaultQtyPct, price_pct: defaultPricePct })));
+  }
+
+  function updateRow(idx: number, patch: Partial<ItemRow>) {
+    if (!rows) return;
+    const next = rows.slice();
+    next[idx] = { ...next[idx], ...patch };
+    setRows(next);
+  }
+
+  async function apply() {
+    if (!rows || rows.length === 0) return;
+    if (!confirm(`Write ${rows.length} item${rows.length === 1 ? '' : 's'} into this plan? Existing lines for those items (any customer) will be overwritten.`)) return;
+    setApplying(true); setErr(null);
+    try {
+      // Group items by (qty_pct, price_pct) so we can make one RPC call per unique combo
+      const groups = new Map<string, { qty_pct: number; price_pct: number; item_ids: string[] }>();
+      for (const r of rows) {
+        const key = r.qty_pct.toFixed(4) + '|' + r.price_pct.toFixed(4);
+        if (!groups.has(key)) groups.set(key, { qty_pct: r.qty_pct, price_pct: r.price_pct, item_ids: [] });
+        groups.get(key)!.item_ids.push(r.qbo_item_id);
+      }
+      for (const g of groups.values()) {
+        await buildPlanFromGrowth({
+          plan_id:          planId,
+          item_ids:         g.item_ids,
+          qty_growth_pct:   g.qty_pct,
+          price_growth_pct: g.price_pct,
+          source_year:      sourceYear,
+        });
+      }
+      onApplied();
+      onClose();
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setApplying(false);
+    }
+  }
+
+  // Computed totals
+  const totals = useMemo(() => {
+    if (!rows) return { ly_qty: 0, ly_rev: 0, plan_qty: 0, plan_rev: 0 };
+    let ly_qty = 0, ly_rev = 0, plan_qty = 0, plan_rev = 0;
+    for (const r of rows) {
+      ly_qty  += r.ly_annual_qty;
+      ly_rev  += r.ly_annual_revenue;
+      const pq = r.ly_annual_qty * (1 + r.qty_pct / 100);
+      const pp = (r.ly_avg_unit_price ?? 0) * (1 + r.price_pct / 100);
+      plan_qty += pq;
+      plan_rev += pq * pp;
+    }
+    return { ly_qty, ly_rev, plan_qty, plan_rev };
+  }, [rows]);
+
+  return (
+    <div style={overlayStyle()} onClick={onClose}>
+      <div style={panelStyle()} onClick={(e) => e.stopPropagation()}>
+        <div style={headerRowStyle()}>
+          <div style={{ fontWeight: 700, fontSize: 14 }}>Build plan from history × growth</div>
+          <button onClick={onClose} style={btnSecondary()}>Close</button>
+        </div>
+
+        <div style={controlsRowStyle()}>
+          <label style={ctrl()}>
+            <span style={lbl()}>Source year</span>
+            <input
+              type="number"
+              value={sourceYear}
+              onChange={(e) => { setSourceYear(Number(e.target.value)); }}
+              onBlur={() => { if (category) loadCategory(category); }}
+              style={{ ...inp(), width: 80 }}
+            />
+          </label>
+          <label style={ctrl()}>
+            <span style={lbl()}>Category</span>
+            <select
+              value={category}
+              onChange={(e) => loadCategory(e.target.value)}
+              style={{ ...inp(), minWidth: 280 }}
+            >
+              <option value="">{allItems ? '-- pick a category --' : 'loading items…'}</option>
+              {categories.map((c) => (
+                <option key={c.value} value={c.value}>{c.label} ({c.itemCount})</option>
+              ))}
+            </select>
+          </label>
+          <label style={ctrl()}>
+            <span style={lbl()}>Default qty %</span>
+            <input
+              type="number" step={0.5}
+              value={defaultQtyPct}
+              onChange={(e) => setDefaultQtyPct(Number(e.target.value))}
+              style={{ ...inp(), width: 70 }}
+            />
+          </label>
+          <label style={ctrl()}>
+            <span style={lbl()}>Default price %</span>
+            <input
+              type="number" step={0.5}
+              value={defaultPricePct}
+              onChange={(e) => setDefaultPricePct(Number(e.target.value))}
+              style={{ ...inp(), width: 70 }}
+            />
+          </label>
+          <button
+            onClick={applyDefaultsToAll}
+            disabled={!rows || rows.length === 0}
+            style={btnSecondary()}
+          >
+            Apply defaults to all
+          </button>
+        </div>
+
+        <div style={{ flex: 1, overflow: 'auto', borderTop: '1px solid var(--bd)' }}>
+          {!category ? (
+            <div className="ld">Pick a category to load its items with last year's qty and revenue.</div>
+          ) : loadingRows ? (
+            <div className="ld">Loading {sourceYear} history…</div>
+          ) : !rows || rows.length === 0 ? (
+            <div className="ld">No items in this category.</div>
+          ) : (
+            <table style={{ width: '100%' }}>
+              <thead style={{ position: 'sticky', top: 0, background: 'var(--sf)', zIndex: 1 }}>
+                <tr>
+                  <th style={{ minWidth: 200 }}>Item</th>
+                  <th style={cellHeadR()}>LY Qty</th>
+                  <th style={cellHeadR()}>LY Avg Price</th>
+                  <th style={cellHeadR()}>LY Revenue</th>
+                  <th style={cellHeadR()}>Cust</th>
+                  <th style={cellHeadR()}>Qty %</th>
+                  <th style={cellHeadR()}>Price %</th>
+                  <th style={cellHeadR()}>Plan Qty</th>
+                  <th style={cellHeadR()}>Plan Price</th>
+                  <th style={cellHeadR()}>Plan Revenue</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r, i) => {
+                  const planQty   = r.ly_annual_qty * (1 + r.qty_pct / 100);
+                  const planPrice = (r.ly_avg_unit_price ?? 0) * (1 + r.price_pct / 100);
+                  const planRev   = planQty * planPrice;
+                  const noHistory = r.ly_annual_revenue === 0;
+                  return (
+                    <tr key={r.qbo_item_id} style={noHistory ? { opacity: 0.5 } : undefined}>
+                      <td style={{ fontSize: 11 }}>{r.item_name}</td>
+                      <td style={cellRight()}>{fmNum(r.ly_annual_qty)}</td>
+                      <td style={cellRight()}>{r.ly_avg_unit_price != null ? fm(r.ly_avg_unit_price) : '—'}</td>
+                      <td style={cellRight()}>{fm(r.ly_annual_revenue)}</td>
+                      <td style={cellRight()}>{r.ly_customer_count}</td>
+                      <td style={cellRight()}>
+                        <input
+                          type="number" step={0.5}
+                          value={r.qty_pct}
+                          onChange={(e) => updateRow(i, { qty_pct: Number(e.target.value) })}
+                          style={{ ...inp(), width: 56, fontSize: 10, padding: '2px 4px', textAlign: 'right' }}
+                        />
+                      </td>
+                      <td style={cellRight()}>
+                        <input
+                          type="number" step={0.5}
+                          value={r.price_pct}
+                          onChange={(e) => updateRow(i, { price_pct: Number(e.target.value) })}
+                          style={{ ...inp(), width: 56, fontSize: 10, padding: '2px 4px', textAlign: 'right' }}
+                        />
+                      </td>
+                      <td style={cellRight()}>{fmNum(planQty)}</td>
+                      <td style={cellRight()}>{fm(planPrice)}</td>
+                      <td style={{ ...cellRight(), fontWeight: 600, color: 'var(--ac)' }}>{fm(planRev)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+              <tfoot style={{ position: 'sticky', bottom: 0, background: 'var(--sf2)' }}>
+                <tr>
+                  <td style={{ fontWeight: 700, padding: '6px 8px' }}>TOTAL ({rows.length} items)</td>
+                  <td style={{ ...cellRight(), fontWeight: 700 }}>{fmNum(totals.ly_qty)}</td>
+                  <td />
+                  <td style={{ ...cellRight(), fontWeight: 700 }}>{fm(totals.ly_rev)}</td>
+                  <td />
+                  <td colSpan={3} />
+                  <td style={{ ...cellRight(), fontWeight: 700 }}>{fmNum(totals.plan_qty)}</td>
+                  <td style={{ ...cellRight(), fontWeight: 700, color: 'var(--ac)' }}>{fm(totals.plan_rev)}</td>
+                </tr>
+              </tfoot>
+            </table>
+          )}
+        </div>
+
+        {err && (
+          <div style={{ padding: '8px 14px', color: 'var(--rd)', borderTop: '1px solid var(--bd)', fontSize: 11 }}>
+            Error: {err}
+          </div>
+        )}
+
+        <div style={footerRowStyle()}>
+          <span style={{ fontSize: 10, color: 'var(--mt)' }}>
+            Applying writes plan lines for every (item × customer) combo present in {sourceYear} actuals.
+            Existing lines for these items are overwritten with the new qty / price assumptions.
+          </span>
+          <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+            <button onClick={onClose} style={btnSecondary()} disabled={applying}>Cancel</button>
+            <button onClick={apply} style={btnPrimary()} disabled={applying || !rows || rows.length === 0}>
+              {applying ? 'Applying…' : 'Apply'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function fmNum(n: number): string {
+  if (n == null || !isFinite(n)) return '0';
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(Math.round(n));
+}
+
+function overlayStyle(): React.CSSProperties {
+  return {
+    position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
+    zIndex: 100, display: 'flex', alignItems: 'center', justifyContent: 'center',
+    padding: 20,
+  };
+}
+function panelStyle(): React.CSSProperties {
+  return {
+    background: 'var(--bg)', border: '1px solid var(--bd)', borderRadius: 6,
+    width: 'min(1200px, 98vw)', maxHeight: '92vh', display: 'flex', flexDirection: 'column',
+    boxShadow: '0 12px 60px rgba(0,0,0,0.4)',
+  };
+}
+function headerRowStyle(): React.CSSProperties {
+  return {
+    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+    padding: '12px 16px', borderBottom: '1px solid var(--bd)',
+  };
+}
+function controlsRowStyle(): React.CSSProperties {
+  return {
+    display: 'flex', gap: 14, alignItems: 'flex-end', flexWrap: 'wrap',
+    padding: '12px 16px',
+  };
+}
+function footerRowStyle(): React.CSSProperties {
+  return {
+    display: 'flex', alignItems: 'center', gap: 12,
+    padding: '10px 16px', borderTop: '1px solid var(--bd)',
+  };
+}
+function ctrl(): React.CSSProperties {
+  return { display: 'inline-flex', flexDirection: 'column', gap: 4 };
+}
+function lbl(): React.CSSProperties {
+  return { fontSize: 9, color: 'var(--mt)', textTransform: 'uppercase', letterSpacing: 1 };
+}
+function cellHeadR(): React.CSSProperties {
+  return { textAlign: 'right', fontSize: 9, color: 'var(--mt)' };
+}
+function cellRight(): React.CSSProperties {
+  return { textAlign: 'right', fontSize: 10, padding: '4px 8px' };
+}

--- a/app/src/pages/plans/PlanEditor.tsx
+++ b/app/src/pages/plans/PlanEditor.tsx
@@ -17,8 +17,10 @@ import {
 import { Dim, fetchPivot } from '../../lib/sales';
 import { PlanVsActuals } from './PlanVsActuals';
 import { PlanForecast } from './PlanForecast';
+import { PlanPlView } from './PlanPlView';
+import { PlanBuildDialog } from './PlanBuildDialog';
 
-type Mode = 'lines' | 'rollup' | 'vs_actuals' | 'forecast';
+type Mode = 'pl' | 'lines' | 'rollup' | 'vs_actuals' | 'forecast';
 type ViewMode = 'revenue' | 'qty' | 'price' | 'cost';
 
 const VIEW_MODES: { id: ViewMode; label: string }[] = [
@@ -42,8 +44,9 @@ export function PlanEditor({ plan, onBack }: Props) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [itemOpts, setItemOpts] = useState<QboItemOption[]>([]);
   const [actualsByItem, setActualsByItem] = useState<Record<string, { amounts: number[]; total: number }> | null>(null);
-  const [mode, setMode] = useState<Mode>('lines');
+  const [mode, setMode] = useState<Mode>('pl');
   const [viewMode, setViewMode] = useState<ViewMode>('revenue');
+  const [buildOpen, setBuildOpen] = useState(false);
 
   function load() {
     Promise.all([fetchPlanLines(plan.id), fetchPlanAccountRollup(plan.id)])
@@ -229,6 +232,7 @@ export function PlanEditor({ plan, onBack }: Props) {
   if (!lines || !rollup) return <div className="ld">Loading plan…</div>;
 
   const modeBtns: { id: Mode; label: string }[] = [
+    { id: 'pl',         label: 'P&L' },
     { id: 'lines',      label: 'Plan Lines' },
     { id: 'rollup',     label: 'Account Rollup' },
     { id: 'vs_actuals', label: 'vs Actuals' },
@@ -280,13 +284,27 @@ export function PlanEditor({ plan, onBack }: Props) {
               </button>
             );
           })}
+          <button onClick={() => setBuildOpen(true)} style={btnPrimary()}>
+            BUILD…
+          </button>
           <button onClick={copyFromActuals} style={btnSecondary()}>
             COPY FROM {plan.fiscal_year - 1}
           </button>
           <button onClick={pushToQbo} style={btnSecondary()}>PUSH TO QBO</button>
-          <button onClick={exportRollupCsv} style={btnPrimary()}>EXPORT CSV</button>
+          <button onClick={exportRollupCsv} style={btnSecondary()}>EXPORT CSV</button>
         </div>
       </div>
+
+      {mode === 'pl' && <PlanPlView planId={plan.id} />}
+
+      {buildOpen && (
+        <PlanBuildDialog
+          planId={plan.id}
+          planFiscalYear={plan.fiscal_year}
+          onClose={() => setBuildOpen(false)}
+          onApplied={load}
+        />
+      )}
 
       {mode === 'lines' && (
         <div className="cd" style={{ padding: 0, marginBottom: 10 }}>

--- a/app/src/pages/plans/PlanPlView.tsx
+++ b/app/src/pages/plans/PlanPlView.tsx
@@ -1,0 +1,190 @@
+// Renders a sales plan as a Profit & Loss statement:
+// Revenue rows → Revenue subtotal → COGS rows → COGS subtotal → Gross Margin →
+// OpEx rows → OpEx subtotal → Net Income.
+
+import { useEffect, useState } from 'react';
+import { MONTHS_SHORT, PlanPlRollupRow, fetchPlanPlRollup } from '../../lib/plans';
+import { fm } from '../../lib/formatters';
+
+const MONTH_KEYS = ['m1','m2','m3','m4','m5','m6','m7','m8','m9','m10','m11','m12'] as const;
+type MonthKey = typeof MONTH_KEYS[number];
+
+interface SectionTotal {
+  m: number[];
+  total: number;
+}
+
+function emptyTotal(): SectionTotal {
+  return { m: Array(12).fill(0), total: 0 };
+}
+
+function addInto(t: SectionTotal, r: PlanPlRollupRow) {
+  MONTH_KEYS.forEach((k, i) => { t.m[i] += Number(r[k] ?? 0); });
+  t.total += Number(r.total ?? 0);
+}
+
+const SECTION_LABEL: Record<string, string> = {
+  revenue: 'REVENUE',
+  cogs:    'COST OF GOODS SOLD',
+  opex:    'OPERATING EXPENSES',
+  other:   'OTHER',
+};
+
+export function PlanPlView({ planId }: { planId: string }) {
+  const [rows, setRows] = useState<PlanPlRollupRow[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    setRows(null); setErr(null);
+    fetchPlanPlRollup(planId).then(setRows).catch((e: Error) => setErr(e.message));
+  }, [planId]);
+
+  if (err) return <div className="cd" style={{ padding: 14, color: 'var(--rd)' }}>P&amp;L rollup error: {err}</div>;
+  if (!rows) return <div className="cd ld">Computing P&amp;L…</div>;
+  if (rows.length === 0) {
+    return <div className="cd ld">No lines in this plan yet. Use Plan Lines to add some, or use Build… to populate from history.</div>;
+  }
+
+  // Group rows by section in document order, and compute section subtotals.
+  const sections: Record<string, { rows: PlanPlRollupRow[]; total: SectionTotal }> = {};
+  for (const r of rows) {
+    if (!sections[r.section]) sections[r.section] = { rows: [], total: emptyTotal() };
+    sections[r.section].rows.push(r);
+    addInto(sections[r.section].total, r);
+  }
+
+  const rev   = sections.revenue?.total ?? emptyTotal();
+  const cogs  = sections.cogs?.total    ?? emptyTotal();
+  const opex  = sections.opex?.total    ?? emptyTotal();
+  const other = sections.other?.total   ?? emptyTotal();
+
+  const gm: SectionTotal = {
+    m: rev.m.map((v, i) => v - cogs.m[i]),
+    total: rev.total - cogs.total,
+  };
+  const net: SectionTotal = {
+    m: gm.m.map((v, i) => v - opex.m[i] - other.m[i]),
+    total: gm.total - opex.total - other.total,
+  };
+  const gmPct  = rev.total > 0 ? (gm.total  / rev.total) * 100 : null;
+  const netPct = rev.total > 0 ? (net.total / rev.total) * 100 : null;
+
+  // Lay out in the canonical P&L order: revenue → cogs → GM → opex → other → net
+  const blocks: { key: string; section?: string; subtotal?: SectionTotal; subtotalLabel?: string; pct?: number | null; highlight?: 'gm' | 'net' }[] = [
+    { key: 'rev_h',  section: 'revenue' },
+    { key: 'rev_t',  subtotal: rev,  subtotalLabel: 'TOTAL REVENUE' },
+    { key: 'cogs_h', section: 'cogs' },
+    { key: 'cogs_t', subtotal: cogs, subtotalLabel: 'TOTAL COGS' },
+    { key: 'gm',     subtotal: gm,   subtotalLabel: 'GROSS MARGIN', pct: gmPct, highlight: 'gm' },
+    { key: 'opex_h', section: 'opex' },
+    { key: 'opex_t', subtotal: opex, subtotalLabel: 'TOTAL OPERATING EXPENSES' },
+    ...(other.total !== 0 ? [{ key: 'other_h', section: 'other' }, { key: 'other_t', subtotal: other, subtotalLabel: 'TOTAL OTHER' }] : []),
+    { key: 'net',    subtotal: net,  subtotalLabel: 'NET INCOME', pct: netPct, highlight: 'net' as const },
+  ];
+
+  return (
+    <div className="cd" style={{ padding: 0 }}>
+      <div style={{ maxHeight: '70vh', overflow: 'auto' }}>
+        <table style={{ width: '100%' }}>
+          <thead style={{ position: 'sticky', top: 0, background: 'var(--sf)', zIndex: 1 }}>
+            <tr>
+              <th style={{ minWidth: 220 }}>Line</th>
+              <th style={{ fontSize: 9, color: 'var(--mt)' }}>Account</th>
+              <th style={{ fontSize: 9, color: 'var(--mt)' }}>Item Category</th>
+              {MONTHS_SHORT.map((m) => (
+                <th key={m} style={{ textAlign: 'right', fontSize: 9 }}>{m}</th>
+              ))}
+              <th style={{ textAlign: 'right' }}>Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {blocks.map((b) => {
+              if (b.section) {
+                const sec = sections[b.section];
+                if (!sec || sec.rows.length === 0) {
+                  return (
+                    <tr key={b.key}>
+                      <td colSpan={16} style={sectionHeaderStyle()}>{SECTION_LABEL[b.section]}</td>
+                    </tr>
+                  );
+                }
+                return (
+                  <>
+                    <tr key={b.key + '_h'}>
+                      <td colSpan={16} style={sectionHeaderStyle()}>{SECTION_LABEL[b.section]}</td>
+                    </tr>
+                    {sec.rows.map((r, i) => (
+                      <tr key={b.section + '_r_' + i}>
+                        <td style={{ fontWeight: 600 }}>{r.pl_line}</td>
+                        <td style={{ fontSize: 10, color: 'var(--mt)' }}>{r.account_name}</td>
+                        <td style={{ fontSize: 10, color: 'var(--mt)' }}>{r.item_category}</td>
+                        {MONTH_KEYS.map((k) => (
+                          <td key={k} className="mn" style={{ textAlign: 'right', fontSize: 10 }}>
+                            {fm(Number(r[k] ?? 0))}
+                          </td>
+                        ))}
+                        <td className="mn" style={{ textAlign: 'right', fontWeight: 600 }}>{fm(Number(r.total ?? 0))}</td>
+                      </tr>
+                    ))}
+                  </>
+                );
+              }
+              // Subtotal row
+              const sub = b.subtotal!;
+              const bgFor = b.highlight === 'gm'  ? 'rgba(91,181,240,0.10)'
+                          : b.highlight === 'net' ? 'rgba(58,167,113,0.12)'
+                          : 'transparent';
+              const colorFor = b.highlight === 'gm' ? 'var(--ac)' : b.highlight === 'net' ? 'var(--gn)' : 'var(--tx)';
+              return (
+                <tr key={b.key} style={{ background: bgFor }}>
+                  <td colSpan={3} style={{ ...subtotalLabelStyle(), color: colorFor }}>
+                    {b.subtotalLabel}
+                    {b.pct != null ? ` · ${b.pct.toFixed(1)}%` : ''}
+                  </td>
+                  {sub.m.map((v, i) => (
+                    <td key={'m' + i} className="mn" style={subtotalCellStyle(colorFor)}>{fm(v)}</td>
+                  ))}
+                  <td className="mn" style={{ ...subtotalCellStyle(colorFor), borderTopWidth: 2 }}>{fm(sub.total)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function sectionHeaderStyle(): React.CSSProperties {
+  return {
+    background: 'var(--sf2)',
+    fontSize: 10,
+    fontWeight: 700,
+    letterSpacing: 1,
+    color: 'var(--mt)',
+    padding: '8px 10px',
+    borderTop: '1px solid var(--bd)',
+    borderBottom: '1px solid var(--bd)',
+    textTransform: 'uppercase',
+  };
+}
+function subtotalLabelStyle(): React.CSSProperties {
+  return {
+    fontWeight: 700,
+    fontSize: 11,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    padding: '6px 10px',
+    borderTop: '1.5px solid var(--bd2)',
+  };
+}
+function subtotalCellStyle(color: string): React.CSSProperties {
+  return {
+    textAlign: 'right',
+    fontWeight: 700,
+    fontSize: 11,
+    color,
+    borderTop: '1.5px solid var(--bd2)',
+    padding: '6px 8px',
+  };
+}

--- a/app/src/styles/theme.css
+++ b/app/src/styles/theme.css
@@ -227,10 +227,10 @@ td.mn, th.mn {
   height: 1px;
   background: var(--glass-edge-line);
 }
-.brand-mark-svg { flex: none; width: 40px; height: 40px }
+.brand-mark-svg { flex: none; width: 32px; height: 32px }
 .brand-mark {
   font-family: var(--ff-display);
-  font-size: 22px;
+  font-size: 17px;
   font-weight: 800;
   letter-spacing: 0.2px;
   color: var(--tx);


### PR DESCRIPTION
## Summary

Reframes the plan editor around how Sky actually wants to plan: the plan **is a P&L**, and you build it **bottom-up by category** with split qty% / price% growth from last year's actuals.

## Two new surfaces in PlanEditor

### P&L (new default landing tab)

Revenue → COGS → **Gross Margin** → OpEx → **Net Income** with subtotals.

- Section taxonomy uses the existing canonical mappings: `revenue_account_map`, `cogs_accounts`, `expense_buckets`. Name-pattern fallback for accounts not in any (looks for `(COGS)` / `Cost of Goods Sold` in the account name).
- For sales-plan lines tied to items, emits TWO rows: a Revenue row from `sales_plan_lines.amounts` + an implied COGS row from `qty[m] × unit_cost[m]`. That's what makes the planner produce a real Gross Margin number from per-item cost data without forcing the user to enter COGS lines manually.
- Gross Margin = Revenue − COGS (with %).
- Net Income = GM − OpEx (with %).
- Subtotals computed in the frontend so the math is transparent.

### Build…

Bottom-up planning dialog. Pick a category (`qbo_items.category_path` — e.g. "Beverages:3 Gallon BIB"), see every item in it pre-populated with last year's actual qty, average unit price, revenue, and customer count. Per-item **Qty %** and **Price %** inputs (split growth — Sky's preference from the previous turn). Live computed Plan Qty / Plan Price / Plan Revenue columns + footer total.

Apply groups items by (qty%, price%) and writes via `fn_plan_build_from_growth` — one RPC per unique combination, so round-trip count stays bounded regardless of category size. The (item × customer) plan lines for those items are overwritten with new growth assumptions stored alongside.

## Backend (deployed via Supabase migrations)

- `20260518a` — `fn_customer_detail` falls back to parent customer's bill address when sub has none.
- `20260518b/c` — `ALTER TABLE sales_plan_lines` adds `qty_growth_pct`, `price_growth_pct`, `baseline_year`. New `fn_plan_pl_rollup`, `fn_plan_build_from_growth`.
- `20260518d` — `fn_plan_history_for_items` (read-only LY snapshot for the dialog).

Smoke-tested on the existing FY2026 budget plan:
- Revenue: $6.28M (17 lines)
- COGS: $1.48M (7 lines)
- Gross Margin: $4.80M (76.5%)
- OpEx: $2.67M (55 lines)
- Net Income: $2.13M (34%)

## Address fallback honest read

Of the 17 sub-customers with revenue but no address, **only 1 (LAS BRISAS → EL PHAROS INC) has an address on its parent**. The other 16 parents are also address-less in QBO. The fallback is in place for future entries and is a no-op for the 16 — those need to be filled in QBO directly.

## What's deliberately NOT in this PR

- Per-item growth on OpEx lines (unusual for a sales plan; v0.10 if Sky wants it)
- Real-time recompute as you type in Plan Lines grid (interactive editor unchanged)
- QBO Items category-tree picker (current flat dropdown of `category_path` strings is enough to start)

## Test plan

- [ ] Open Plans → pick QBO Budget FY2026 → P&L tab is default, shows the section totals above
- [ ] Click Build… → pick category "Beverages:3 Gallon BIB" → see items with LY data
- [ ] Set default qty% = +5, price% = +3 → Apply defaults to all → footer totals update
- [ ] Apply → confirm → plan refreshes, P&L view shows new revenue/COGS

https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H)_