### PR TITLE
plans + production: P&amp;L-grouped Plan Lines, scaled BOM rows, dialogs open lower

### DIFF
--- a/app/src/lib/plans.ts
+++ b/app/src/lib/plans.ts
@@ -171,6 +171,17 @@ export function fetchPlanPlRollup(plan_id: string) {
   return sbrpc<PlanPlRollupRow[]>('fn_plan_pl_rollup', { p_plan_id: plan_id });
 }
 
+export interface PlanLineSection {
+  line_id: string;
+  section: 'revenue' | 'cogs' | 'opex' | 'other';
+  section_order: number;
+  pl_line: string;
+}
+
+export function fetchPlanLineSections(plan_id: string) {
+  return sbrpc<PlanLineSection[]>('fn_plan_lines_with_section', { p_plan_id: plan_id });
+}
+
 // ----- Split-growth bottom-up build (Refractor planner Phase 2) -----
 
 export interface BuildFromGrowthResultRow {

--- a/app/src/pages/plans/PlanBuildDialog.tsx
+++ b/app/src/pages/plans/PlanBuildDialog.tsx
@@ -316,14 +316,15 @@ function fmNum(n: number): string {
 function overlayStyle(): React.CSSProperties {
   return {
     position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
-    zIndex: 100, display: 'flex', alignItems: 'center', justifyContent: 'center',
-    padding: 20,
+    zIndex: 100, display: 'flex', alignItems: 'flex-start', justifyContent: 'center',
+    padding: '90px 20px 20px',
+    overflowY: 'auto',
   };
 }
 function panelStyle(): React.CSSProperties {
   return {
     background: 'var(--bg)', border: '1px solid var(--bd)', borderRadius: 6,
-    width: 'min(1200px, 98vw)', maxHeight: '92vh', display: 'flex', flexDirection: 'column',
+    width: 'min(1200px, 98vw)', maxHeight: 'calc(100vh - 110px)', display: 'flex', flexDirection: 'column',
     boxShadow: '0 12px 60px rgba(0,0,0,0.4)',
   };
 }

--- a/app/src/pages/plans/PlanEditor.tsx
+++ b/app/src/pages/plans/PlanEditor.tsx
@@ -7,11 +7,13 @@ import { fm } from '../../lib/formatters';
 import {
   MONTHS_SHORT,
   PlanAccountRollupRow,
+  PlanLineSection,
   QboItemOption,
   SalesPlan,
   SalesPlanLine,
   fetchItemOptions,
   fetchPlanAccountRollup,
+  fetchPlanLineSections,
   fetchPlanLines,
 } from '../../lib/plans';
 import { Dim, fetchPivot } from '../../lib/sales';
@@ -19,6 +21,7 @@ import { PlanVsActuals } from './PlanVsActuals';
 import { PlanForecast } from './PlanForecast';
 import { PlanPlView } from './PlanPlView';
 import { PlanBuildDialog } from './PlanBuildDialog';
+import { PlanLinesGrouped } from './PlanLinesGrouped';
 
 type Mode = 'pl' | 'lines' | 'rollup' | 'vs_actuals' | 'forecast';
 type ViewMode = 'revenue' | 'qty' | 'price' | 'cost';
@@ -40,6 +43,7 @@ interface Props {
 
 export function PlanEditor({ plan, onBack }: Props) {
   const [lines, setLines] = useState<SalesPlanLine[] | null>(null);
+  const [linesSections, setLinesSections] = useState<PlanLineSection[] | null>(null);
   const [rollup, setRollup] = useState<PlanAccountRollupRow[] | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [itemOpts, setItemOpts] = useState<QboItemOption[]>([]);
@@ -49,9 +53,13 @@ export function PlanEditor({ plan, onBack }: Props) {
   const [buildOpen, setBuildOpen] = useState(false);
 
   function load() {
-    Promise.all([fetchPlanLines(plan.id), fetchPlanAccountRollup(plan.id)])
-      .then(([ls, ru]) => { setLines(ls); setRollup(ru); })
-      .catch(() => { setLines([]); setRollup([]); });
+    Promise.all([
+      fetchPlanLines(plan.id),
+      fetchPlanAccountRollup(plan.id),
+      fetchPlanLineSections(plan.id),
+    ])
+      .then(([ls, ru, ss]) => { setLines(ls); setRollup(ru); setLinesSections(ss); })
+      .catch(() => { setLines([]); setRollup([]); setLinesSections([]); });
   }
   useEffect(load, [plan.id]);
 
@@ -359,93 +367,15 @@ export function PlanEditor({ plan, onBack }: Props) {
               </select>
             </div>
           )}
-          <div style={{ maxHeight: '52vh', overflow: 'auto' }}>
-            {lines.length === 0 ? (
-              <div className="ld">No lines yet. Click + ADD ITEM.</div>
-            ) : (
-              <table>
-                <thead style={{ position: 'sticky', top: 0, background: 'var(--sf)', zIndex: 1 }}>
-                  <tr>
-                    <th>Item</th>
-                    <th style={{ fontSize: 9, color: 'var(--mt)' }}>Account</th>
-                    {MONTHS_SHORT.map((m) => (
-                      <th key={m} style={{ textAlign: 'right', fontSize: 9 }}>{m}</th>
-                    ))}
-                    <th style={{ textAlign: 'right' }} title={
-                      viewMode === 'revenue' ? 'Annual revenue (sum of months)'
-                      : viewMode === 'qty'     ? 'Annual units (sum of months)'
-                      : viewMode === 'price'   ? 'Blended avg price = annual revenue ÷ annual units'
-                      :                          'Extended annual cost = Σ qty[i] × cost[i]'
-                    }>
-                      {viewMode === 'revenue' ? 'Annual Rev'
-                       : viewMode === 'qty'    ? 'Annual Qty'
-                       : viewMode === 'price'  ? 'Avg Price'
-                       :                          'Annual Cost'}
-                    </th>
-                    <th></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {lines.map((l) => {
-                    const arr = arrayFor(l, viewMode);
-                    const total = totalFor(l, viewMode);
-                    const isMoney = viewMode !== 'qty';
-                    return (
-                      <tr key={l.id}>
-                        <td
-                          style={{
-                            maxWidth: 200,
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                            fontSize: 11,
-                          }}
-                          title={l.item_name ?? ''}
-                        >
-                          {l.item_name ?? '—'}
-                        </td>
-                        <td style={{ fontSize: 10, color: 'var(--mt)' }}>{l.account_name ?? '—'}</td>
-                        {arr.map((v, idx) => (
-                          <td key={idx} style={{ textAlign: 'right', padding: '2px 4px' }}>
-                            <input
-                              type="number"
-                              step={viewMode === 'qty' ? 1 : 0.01}
-                              defaultValue={v ?? 0}
-                              onBlur={(e) => {
-                                if (Number(e.target.value) !== Number(v)) setCell(l, idx, e.target.value);
-                              }}
-                              style={{ ...inp(), width: 72, textAlign: 'right', fontSize: 10, padding: '3px 4px' }}
-                            />
-                          </td>
-                        ))}
-                        <td className="mn" style={{ textAlign: 'right', fontWeight: 600 }}>
-                          {isMoney ? fm(total) : Math.round(total).toLocaleString()}
-                        </td>
-                        <td style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
-                          <button
-                            onClick={() => {
-                              const annualRev = (l.amounts ?? []).reduce((s, v) => s + Number(v || 0), 0);
-                              const v = prompt('Annual revenue total to spread across 12 months:', String(Math.round(annualRev)));
-                              if (v != null) fillFlat(l, v);
-                            }}
-                            style={{ ...btnSecondary(), fontSize: 9, padding: '2px 6px' }}
-                            title="Spread an annual revenue total flat across 12 months"
-                          >
-                            ÷12
-                          </button>
-                          <button
-                            onClick={() => deleteLine(l.id)}
-                            style={{ ...btnDanger(), marginLeft: 4 }}
-                          >
-                            ×
-                          </button>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            )}
+          <div style={{ maxHeight: '78vh', overflow: 'auto' }}>
+            <PlanLinesGrouped
+              lines={lines}
+              linesSections={linesSections}
+              viewMode={viewMode}
+              onSetCell={(line, monthIdx, value) => setCell(line, monthIdx, value)}
+              onFillFlat={(line, total) => fillFlat(line, total)}
+              onDelete={(id) => deleteLine(id)}
+            />
           </div>
         </div>
       )}

--- a/app/src/pages/plans/PlanLinesGrouped.tsx
+++ b/app/src/pages/plans/PlanLinesGrouped.tsx
@@ -1,0 +1,292 @@
+// Plan Lines view, grouped by P&L section + revenue/COGS line, with subtotals
+// and a Gross Margin row. Each cell is still editable in place; the grouping
+// only changes how rows are laid out so you can see Revenue and COGS together
+// while you adjust them.
+
+import { Fragment, useMemo } from 'react';
+import { MONTHS_SHORT, PlanLineSection, SalesPlanLine } from '../../lib/plans';
+import { fm } from '../../lib/formatters';
+import { btnDanger, btnSecondary, inp } from '../../lib/styles';
+
+export type ViewMode = 'revenue' | 'qty' | 'price' | 'cost';
+
+const ZEROS = (): number[] => [0,0,0,0,0,0,0,0,0,0,0,0];
+
+const SECTION_LABEL: Record<string, string> = {
+  revenue: 'REVENUE',
+  cogs:    'COST OF GOODS SOLD',
+  opex:    'OPERATING EXPENSES',
+  other:   'OTHER',
+};
+const SECTION_ORDER: Record<string, number> = { revenue: 1, cogs: 2, opex: 3, other: 4 };
+
+interface Props {
+  lines: SalesPlanLine[];
+  linesSections: PlanLineSection[] | null;
+  viewMode: ViewMode;
+  onSetCell: (line: SalesPlanLine, monthIdx: number, value: string) => void;
+  onFillFlat: (line: SalesPlanLine, total: string) => void;
+  onDelete: (id: string) => void;
+}
+
+export function PlanLinesGrouped({
+  lines, linesSections, viewMode, onSetCell, onFillFlat, onDelete,
+}: Props) {
+  const isMoney = viewMode !== 'qty';
+
+  // Build section→pl_line→[lines] grouping. When the section RPC hasn't
+  // returned yet, fall back to "other" so the editor never blanks out.
+  const grouped = useMemo(() => {
+    const byLine = new Map<string, PlanLineSection>();
+    if (linesSections) for (const s of linesSections) byLine.set(s.line_id, s);
+    const sections = new Map<string, { order: number; plGroups: Map<string, SalesPlanLine[]> }>();
+    for (const line of lines) {
+      const cls = byLine.get(line.id);
+      const section = cls?.section ?? 'other';
+      const order   = cls?.section_order ?? SECTION_ORDER[section] ?? 4;
+      const plLine  = cls?.pl_line ?? line.account_name ?? '(unmapped)';
+      if (!sections.has(section)) sections.set(section, { order, plGroups: new Map() });
+      const sec = sections.get(section)!;
+      if (!sec.plGroups.has(plLine)) sec.plGroups.set(plLine, []);
+      sec.plGroups.get(plLine)!.push(line);
+    }
+    return Array.from(sections.entries())
+      .sort((a, b) => a[1].order - b[1].order)
+      .map(([name, data]) => ({
+        name,
+        order: data.order,
+        plGroups: Array.from(data.plGroups.entries())
+          .sort((a, b) => a[0].localeCompare(b[0]))
+          .map(([plLine, ls]) => ({ plLine, lines: ls.sort((a, b) => (a.item_name ?? '').localeCompare(b.item_name ?? '')) })),
+      }));
+  }, [lines, linesSections]);
+
+  function arrayFor(line: SalesPlanLine): number[] {
+    switch (viewMode) {
+      case 'revenue': return line.amounts    ?? ZEROS();
+      case 'qty':     return line.qty        ?? ZEROS();
+      case 'price':   return line.unit_price ?? ZEROS();
+      case 'cost':    return line.unit_cost  ?? ZEROS();
+    }
+  }
+
+  function totalFor(line: SalesPlanLine): number {
+    if (viewMode === 'revenue') return (line.amounts ?? []).reduce((s, v) => s + Number(v || 0), 0);
+    if (viewMode === 'qty')     return (line.qty     ?? []).reduce((s, v) => s + Number(v || 0), 0);
+    if (viewMode === 'price') {
+      const qSum = (line.qty     ?? []).reduce((s, v) => s + Number(v || 0), 0);
+      const aSum = (line.amounts ?? []).reduce((s, v) => s + Number(v || 0), 0);
+      return qSum > 0 ? aSum / qSum : 0;
+    }
+    const q = line.qty       ?? ZEROS();
+    const c = line.unit_cost ?? ZEROS();
+    let t = 0;
+    for (let i = 0; i < 12; i++) t += Number(q[i] || 0) * Number(c[i] || 0);
+    return t;
+  }
+
+  // Monthly subtotal for a group of lines (sum of arrayFor per month).
+  function groupMonthly(group: SalesPlanLine[]): { m: number[]; total: number } {
+    const m = Array(12).fill(0) as number[];
+    for (const line of group) {
+      const arr = arrayFor(line);
+      for (let i = 0; i < 12; i++) m[i] += Number(arr[i] || 0);
+    }
+    let total = 0;
+    if (viewMode === 'revenue' || viewMode === 'qty') {
+      total = m.reduce((s, v) => s + v, 0);
+    } else if (viewMode === 'cost') {
+      for (const line of group) total += totalFor(line);
+    } else {
+      // price: blended avg
+      let qSum = 0, aSum = 0;
+      for (const line of group) {
+        qSum += (line.qty     ?? []).reduce((s, v) => s + Number(v || 0), 0);
+        aSum += (line.amounts ?? []).reduce((s, v) => s + Number(v || 0), 0);
+      }
+      total = qSum > 0 ? aSum / qSum : 0;
+    }
+    return { m, total };
+  }
+
+  // Section subtotals for GM/Net math (only meaningful in revenue view).
+  const sectionTotals: Record<string, { m: number[]; total: number }> = {};
+  for (const sec of grouped) {
+    const flat = sec.plGroups.flatMap((g) => g.lines);
+    sectionTotals[sec.name] = groupMonthly(flat);
+  }
+  const showGmNet = viewMode === 'revenue';
+  const rev   = sectionTotals.revenue ?? { m: Array(12).fill(0), total: 0 };
+  const cogs  = sectionTotals.cogs    ?? { m: Array(12).fill(0), total: 0 };
+  const opex  = sectionTotals.opex    ?? { m: Array(12).fill(0), total: 0 };
+  const gm    = { m: rev.m.map((v, i) => v - cogs.m[i]), total: rev.total - cogs.total };
+  const net   = { m: gm.m.map((v, i) => v - opex.m[i]),   total: gm.total - opex.total };
+
+  function fmt(v: number): string {
+    if (!isMoney) return Math.round(v).toLocaleString();
+    return fm(v);
+  }
+
+  if (lines.length === 0) {
+    return <div className="ld">No lines yet. Click + ADD ITEM or use BUILD…</div>;
+  }
+
+  return (
+    <table style={{ width: '100%' }}>
+      <thead style={{ position: 'sticky', top: 0, background: 'var(--sf)', zIndex: 1 }}>
+        <tr>
+          <th style={{ minWidth: 220 }}>Item / Line</th>
+          <th style={{ fontSize: 9, color: 'var(--mt)' }}>Account</th>
+          {MONTHS_SHORT.map((m) => (
+            <th key={m} style={{ textAlign: 'right', fontSize: 9 }}>{m}</th>
+          ))}
+          <th style={{ textAlign: 'right' }}>
+            {viewMode === 'revenue' ? 'Annual Rev'
+             : viewMode === 'qty'    ? 'Annual Qty'
+             : viewMode === 'price'  ? 'Avg Price'
+             :                          'Annual Cost'}
+          </th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        {grouped.map((sec, secIdx) => (
+          <Fragment key={sec.name}>
+            <tr>
+              <td colSpan={15} style={sectionHeaderStyle()}>{SECTION_LABEL[sec.name] ?? sec.name.toUpperCase()}</td>
+            </tr>
+            {sec.plGroups.map((g) => {
+              const groupSum = groupMonthly(g.lines);
+              return (
+                <Fragment key={sec.name + '|' + g.plLine}>
+                  <tr>
+                    <td colSpan={15} style={plLineHeaderStyle()}>{g.plLine} <span style={{ color: 'var(--mt)', fontSize: 9 }}>· {g.lines.length} line{g.lines.length === 1 ? '' : 's'}</span></td>
+                  </tr>
+                  {g.lines.map((l) => {
+                    const arr = arrayFor(l);
+                    const total = totalFor(l);
+                    return (
+                      <tr key={l.id}>
+                        <td style={itemCellStyle()} title={l.item_name ?? ''}>
+                          {l.item_name ?? '—'}
+                        </td>
+                        <td style={{ fontSize: 10, color: 'var(--mt)' }}>{l.account_name ?? '—'}</td>
+                        {arr.map((v, idx) => (
+                          <td key={idx} style={{ textAlign: 'right', padding: '2px 4px' }}>
+                            <input
+                              type="number"
+                              step={viewMode === 'qty' ? 1 : 0.01}
+                              defaultValue={v ?? 0}
+                              onBlur={(e) => {
+                                if (Number(e.target.value) !== Number(v)) onSetCell(l, idx, e.target.value);
+                              }}
+                              style={{ ...inp(), width: 76, textAlign: 'right', fontSize: 11, padding: '4px 5px' }}
+                            />
+                          </td>
+                        ))}
+                        <td className="mn" style={{ textAlign: 'right', fontWeight: 600 }}>{fmt(total)}</td>
+                        <td style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
+                          <button
+                            onClick={() => {
+                              const annualRev = (l.amounts ?? []).reduce((s, v) => s + Number(v || 0), 0);
+                              const v = prompt('Annual revenue total to spread across 12 months:', String(Math.round(annualRev)));
+                              if (v != null) onFillFlat(l, v);
+                            }}
+                            style={{ ...btnSecondary(), fontSize: 9, padding: '2px 6px' }}
+                            title="Spread an annual revenue total flat across 12 months"
+                          >÷12</button>
+                          <button
+                            onClick={() => onDelete(l.id)}
+                            style={{ ...btnDanger(), marginLeft: 4 }}
+                          >×</button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  <tr style={{ background: 'rgba(255,255,255,0.02)' }}>
+                    <td colSpan={2} style={subtotalLabelStyle()}>Subtotal · {g.plLine}</td>
+                    {groupSum.m.map((v, i) => (
+                      <td key={i} className="mn" style={subtotalCellStyle('var(--tx)')}>{fmt(v)}</td>
+                    ))}
+                    <td className="mn" style={{ ...subtotalCellStyle('var(--tx)'), fontWeight: 700 }}>{fmt(groupSum.total)}</td>
+                    <td />
+                  </tr>
+                </Fragment>
+              );
+            })}
+            <tr style={{ background: 'rgba(91,181,240,0.06)' }}>
+              <td colSpan={2} style={{ ...subtotalLabelStyle(), fontSize: 12, color: 'var(--ac)' }}>
+                TOTAL {SECTION_LABEL[sec.name] ?? sec.name.toUpperCase()}
+              </td>
+              {sectionTotals[sec.name].m.map((v, i) => (
+                <td key={i} className="mn" style={subtotalCellStyle('var(--ac)')}>{fmt(v)}</td>
+              ))}
+              <td className="mn" style={{ ...subtotalCellStyle('var(--ac)'), fontWeight: 800 }}>{fmt(sectionTotals[sec.name].total)}</td>
+              <td />
+            </tr>
+            {showGmNet && sec.name === 'cogs' && (
+              <tr style={{ background: 'rgba(58,167,113,0.10)' }}>
+                <td colSpan={2} style={{ ...subtotalLabelStyle(), color: 'var(--gn)', fontSize: 12 }}>
+                  GROSS MARGIN {rev.total > 0 ? `· ${((gm.total / rev.total) * 100).toFixed(1)}%` : ''}
+                </td>
+                {gm.m.map((v, i) => (
+                  <td key={i} className="mn" style={subtotalCellStyle('var(--gn)')}>{fmt(v)}</td>
+                ))}
+                <td className="mn" style={{ ...subtotalCellStyle('var(--gn)'), fontWeight: 800 }}>{fmt(gm.total)}</td>
+                <td />
+              </tr>
+            )}
+            {showGmNet && sec.name === 'opex' && secIdx === grouped.length - 1 && (
+              <tr style={{ background: 'rgba(58,167,113,0.16)' }}>
+                <td colSpan={2} style={{ ...subtotalLabelStyle(), color: 'var(--gn)', fontSize: 13 }}>
+                  NET INCOME {rev.total > 0 ? `· ${((net.total / rev.total) * 100).toFixed(1)}%` : ''}
+                </td>
+                {net.m.map((v, i) => (
+                  <td key={i} className="mn" style={subtotalCellStyle('var(--gn)')}>{fmt(v)}</td>
+                ))}
+                <td className="mn" style={{ ...subtotalCellStyle('var(--gn)'), fontWeight: 800 }}>{fmt(net.total)}</td>
+                <td />
+              </tr>
+            )}
+          </Fragment>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function sectionHeaderStyle(): React.CSSProperties {
+  return {
+    background: 'var(--sf2)', fontSize: 10, fontWeight: 700, letterSpacing: 1,
+    color: 'var(--mt)', padding: '10px 12px',
+    borderTop: '1px solid var(--bd)', borderBottom: '1px solid var(--bd)',
+    textTransform: 'uppercase',
+  };
+}
+function plLineHeaderStyle(): React.CSSProperties {
+  return {
+    background: 'rgba(255,255,255,0.02)', fontSize: 10, fontWeight: 600,
+    color: 'var(--tx2)', padding: '6px 12px 4px',
+    borderTop: '1px solid rgba(255,255,255,0.04)',
+    textTransform: 'uppercase', letterSpacing: 0.5,
+  };
+}
+function itemCellStyle(): React.CSSProperties {
+  return {
+    maxWidth: 240, overflow: 'hidden', textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap', fontSize: 12, padding: '4px 8px',
+  };
+}
+function subtotalLabelStyle(): React.CSSProperties {
+  return {
+    fontWeight: 700, fontSize: 11, letterSpacing: 0.5,
+    textTransform: 'uppercase', padding: '6px 10px',
+    borderTop: '1.5px solid var(--bd2)',
+  };
+}
+function subtotalCellStyle(color: string): React.CSSProperties {
+  return {
+    textAlign: 'right', fontWeight: 700, fontSize: 11, color,
+    borderTop: '1.5px solid var(--bd2)', padding: '6px 8px',
+  };
+}

--- a/app/src/pages/production/BomsTab.tsx
+++ b/app/src/pages/production/BomsTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Plus, Trash2, X as XIcon } from 'lucide-react';
 import {
   BomLineInput, ProductBom, ProductBomLine,
@@ -259,8 +259,8 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
   const [active, setActive] = useState(bom.is_active);
   const [name, setName] = useState<string>(bom.name ?? '');
   // Local-edit copy of the gal-per-yield bridge. Persists via updateBom on
-  // blur so the ScaleBomPanel can scale by gallons immediately without
-  // needing the user to save+reopen.
+  // blur so the BOM scaler can convert "make N gal" → runs without a
+  // save + reopen.
   const [finishedGal, setFinishedGal] = useState<string>(
     bom.finished_vol_per_yield_gal == null ? '' : String(bom.finished_vol_per_yield_gal),
   );
@@ -274,7 +274,37 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
     return () => { alive = false; };
   }, [bomId]);
 
+  // Target volume for scaling — drives the "Required for batch" column in
+  // BomLinesEditor. Held here so a single input at the top controls the rows.
+  const [targetQty, setTargetQty] = useState<string>('');
+  const [targetUom, setTargetUom] = useState<string>(bom.yield_uom || 'each');
+
   const it = itemLookup.byId.get(bom.finished_qbo_item_id);
+
+  const bridgeGal = useMemo(() => {
+    const live = finishedGal.trim();
+    if (live !== '') return Number(live);
+    return bom.finished_vol_per_yield_gal == null ? undefined : Number(bom.finished_vol_per_yield_gal);
+  }, [finishedGal, bom.finished_vol_per_yield_gal]);
+
+  const scaling = useMemo(() => {
+    const tQty = Number(targetQty) || 0;
+    if (!lines || tQty <= 0) return { scaled: null, incompat: false, scaledByIdx: new Map<number, { qty: number; uom: string }>() };
+    const yieldDef = { qty: Number(bom.yield_qty), uom: bom.yield_uom || 'each', finishedVolPerYieldGal: bridgeGal };
+    const out = scaleBom(
+      { qty: tQty, uom: targetUom },
+      yieldDef,
+      lines.map((l, idx) => ({
+        qty_per: Number(l.qty_per),
+        qty_uom: l.qty_uom || 'each',
+        scrap_pct: Number(l.scrap_pct ?? 0),
+        ref: { idx },
+      })),
+    );
+    const map = new Map<number, { qty: number; uom: string }>();
+    if (out) for (const s of out.scaledLines) map.set(s.ref.idx, { qty: s.qty, uom: s.uom });
+    return { scaled: out, incompat: out === null, scaledByIdx: map };
+  }, [lines, bom.yield_qty, bom.yield_uom, bridgeGal, targetQty, targetUom]);
 
   async function saveLines() {
     if (!lines || !lines.every(validLine)) return;
@@ -329,11 +359,12 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
   return (
     <div onClick={onClose} style={{
       position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.55)', zIndex: 1000,
-      display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20,
+      display: 'flex', alignItems: 'flex-start', justifyContent: 'center',
+      padding: '90px 20px 20px', overflowY: 'auto',
     }}>
       <div onClick={(e) => e.stopPropagation()} style={{
         background: 'var(--sf)', border: '1px solid var(--bd)', borderRadius: 6,
-        maxWidth: 880, width: '100%', maxHeight: '90vh', overflowY: 'auto', padding: 20,
+        maxWidth: 1080, width: '100%', maxHeight: 'calc(100vh - 110px)', overflowY: 'auto', padding: 20,
       }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 14 }}>
           <div>
@@ -380,7 +411,7 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
 
         {uomGroup(bom.yield_uom || 'each') === 'count' && (
           <div style={{
-            marginBottom: 14, padding: '8px 10px',
+            marginBottom: 10, padding: '8px 10px',
             border: '1px solid var(--bd)', borderRadius: 4, fontSize: 11,
             display: 'flex', alignItems: 'center', gap: 10,
           }}>
@@ -398,22 +429,58 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
           </div>
         )}
 
+        {/* Scale-to-batch input — drives the Required column in the BOM lines editor below. */}
+        <div style={{
+          marginBottom: 14, padding: '10px 12px',
+          border: '1px solid var(--bd)', borderRadius: 4, fontSize: 12,
+          background: 'rgba(91,181,240,0.04)',
+          display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap',
+        }}>
+          <span style={{ color: 'var(--mt)', fontSize: 10, letterSpacing: 0.5, textTransform: 'uppercase' }}>
+            Scale to make
+          </span>
+          <input type="number" min={0} step="any" style={{ ...inp(), width: 110, textAlign: 'right' }}
+            value={targetQty}
+            onChange={(e) => setTargetQty(e.target.value)}
+            placeholder="qty" />
+          <select value={targetUom} onChange={(e) => setTargetUom(e.target.value)} style={{ ...inp(), width: 110 }}>
+            {UOM_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+          </select>
+          {scaling.scaled ? (
+            <span style={{ color: 'var(--mt)' }}>
+              → <strong style={{ color: 'var(--ac)', fontFamily: 'var(--ff-mono)' }}>
+                {scaling.scaled.runs.toLocaleString(undefined, { maximumFractionDigits: 4 })}
+              </strong> {scaling.scaled.runs === 1 ? 'run' : 'runs'} · BOM lines below show required quantities for this batch
+            </span>
+          ) : scaling.incompat ? (
+            <span style={{ color: 'var(--am)', fontSize: 11 }}>
+              Can't convert {targetUom} → {bom.yield_uom || 'each'}.
+              {uomGroup(targetUom) === 'volume' && uomGroup(bom.yield_uom || 'each') === 'count' && bridgeGal == null
+                ? <> Set "1 {bom.yield_uom || 'each'} produces ___ gal" above.</>
+                : <> Enter the target in {bom.yield_uom || 'each'}.</>}
+            </span>
+          ) : (
+            <span style={{ color: 'var(--mt)', fontSize: 11 }}>
+              Enter a target qty to see Required columns auto-populate.
+            </span>
+          )}
+        </div>
+
         {lines === null
           ? <div style={{ padding: 18, color: 'var(--mt)' }}>Loading lines…</div>
           : <>
-              <BomLinesEditor lines={lines} setLines={setLines} itemLookup={itemLookup} />
+              <BomLinesEditor
+                lines={lines}
+                setLines={setLines}
+                itemLookup={itemLookup}
+                scaledByIdx={scaling.scaledByIdx}
+              />
               <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 14 }}>
                 <button onClick={onClose} style={btnSecondary()}>Close</button>
                 <button onClick={saveLines} disabled={saving || !lines.every(validLine)} style={btnPrimary()}>
                   {saving ? 'Saving…' : 'Save lines'}
                 </button>
               </div>
-              <ScaleBomPanel
-                bom={bom}
-                lines={lines}
-                itemLookup={itemLookup}
-                finishedVolPerYieldGal={finishedGal.trim() === '' ? null : Number(finishedGal)}
-              />
             </>}
       </div>
     </div>
@@ -422,11 +489,16 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
 
 // ── BOM lines sub-editor (shared by create form + detail modal) ─────────
 
-function BomLinesEditor({ lines, setLines, itemLookup }: {
+function BomLinesEditor({ lines, setLines, itemLookup, scaledByIdx }: {
   lines: BomLineInput[];
   setLines: (next: BomLineInput[]) => void;
   itemLookup: ProductionItemLookup;
+  /** Per-row scaled qty + uom keyed by line index. Empty Map = no scaling
+   *  active; the Required column renders "—". */
+  scaledByIdx?: Map<number, { qty: number; uom: string }>;
 }) {
+  const showRequired = (scaledByIdx?.size ?? 0) > 0;
+
   function addComponent() { setLines([...lines, emptyComponentLine()]); }
   function addService()   { setLines([...lines, emptyServiceLine()]); }
   function rm(i: number)  { setLines(lines.filter((_, idx) => idx !== i)); }
@@ -437,7 +509,7 @@ function BomLinesEditor({ lines, setLines, itemLookup }: {
   return (
     <>
       <div style={{ marginTop: 14, fontSize: 10, color: 'var(--mt)', letterSpacing: 0.5, textTransform: 'uppercase', marginBottom: 6 }}>
-        Lines (per yield qty)
+        Lines (per yield qty){showRequired ? ' · Required column shows scaled batch quantities' : ''}
       </div>
       <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
         <thead>
@@ -446,6 +518,9 @@ function BomLinesEditor({ lines, setLines, itemLookup }: {
             <th style={cellTh}>Component / Service</th>
             <th style={{ ...cellTh, width: 80, textAlign: 'right' }}>Qty / yield</th>
             <th style={{ ...cellTh, width: 80 }}>UoM</th>
+            {showRequired && (
+              <th style={{ ...cellTh, width: 110, textAlign: 'right', color: 'var(--ac)' }}>Required</th>
+            )}
             <th style={{ ...cellTh, width: 80, textAlign: 'right' }}>Scrap %</th>
             <th style={{ ...cellTh, width: 100, textAlign: 'right' }}>Unit Cost</th>
             <th style={{ ...cellTh, width: 150 }}>Notes</th>
@@ -489,6 +564,13 @@ function BomLinesEditor({ lines, setLines, itemLookup }: {
                   {UOM_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
                 </select>
               </td>
+              {showRequired && (
+                <td style={{ ...cellTd, textAlign: 'right', fontFamily: 'var(--ff-mono)', fontWeight: 600, color: 'var(--ac)' }}>
+                  {scaledByIdx?.has(i)
+                    ? fmtQty(scaledByIdx.get(i)!.qty, scaledByIdx.get(i)!.uom)
+                    : <span style={{ color: 'var(--mt)' }}>—</span>}
+                </td>
+              )}
               <td style={{ ...cellTd, textAlign: 'right' }}>
                 <input type="number" min={0} max={99} step="any" style={{ ...inp(), width: '100%', textAlign: 'right' }}
                   value={(l.scrap_pct ?? 0) * 100}
@@ -571,108 +653,3 @@ const cellTh: React.CSSProperties = { textAlign: 'left', padding: '7px 10px', fo
   letterSpacing: 0.5, textTransform: 'uppercase', color: 'var(--mt)' };
 const cellTd: React.CSSProperties = { padding: '6px 10px', verticalAlign: 'middle' };
 
-// ── Scale this BOM calculator ───────────────────────────────────────────
-//
-// Live scratchpad inside the BOM detail modal. Operator types a target
-// quantity + UoM ("make 1000 gal") and we multiply every line by the
-// implied runs. Read-only — doesn't save anything, just shows the math
-// so the operator can sanity-check a future work order.
-function ScaleBomPanel({ bom, lines, itemLookup, finishedVolPerYieldGal }: {
-  bom: ProductBom;
-  lines: BomLineInput[];
-  itemLookup: ProductionItemLookup;
-  /** Live value from the modal's editable bridge field. Falls back to the
-   *  persisted bom.finished_vol_per_yield_gal so existing BOMs still scale
-   *  without a re-save. */
-  finishedVolPerYieldGal?: number | null;
-}) {
-  const [targetQty, setTargetQty] = useState<string>(String(bom.yield_qty));
-  const [targetUom, setTargetUom] = useState<string>(bom.yield_uom || 'each');
-
-  const target = { qty: Number(targetQty) || 0, uom: targetUom };
-  const bridgeGal = finishedVolPerYieldGal
-    ?? (bom.finished_vol_per_yield_gal == null ? undefined : Number(bom.finished_vol_per_yield_gal))
-    ?? undefined;
-  const yield_ = {
-    qty: Number(bom.yield_qty),
-    uom: bom.yield_uom || 'each',
-    finishedVolPerYieldGal: bridgeGal,
-  };
-  const scaled = target.qty > 0
-    ? scaleBom(target, yield_, lines.map((l, idx) => ({
-        qty_per: Number(l.qty_per),
-        qty_uom: l.qty_uom || 'each',
-        scrap_pct: Number(l.scrap_pct ?? 0),
-        ref: { line: l, idx },
-      })))
-    : null;
-  const incompat = target.qty > 0 && scaled === null;
-  const sameCountFamily =
-    uomGroup(targetUom) === 'count' && uomGroup(yield_.uom) === 'count';
-  const missingBridge =
-    uomGroup(targetUom) === 'volume' && uomGroup(yield_.uom) === 'count' && bridgeGal == null;
-
-  return (
-    <div style={{
-      marginTop: 20, padding: 14, border: '1px solid var(--bd)', borderRadius: 6,
-      background: 'rgba(91,181,240,0.04)',
-    }}>
-      <div style={{ fontSize: 10, color: 'var(--mt)', letterSpacing: 0.6, textTransform: 'uppercase', marginBottom: 10 }}>
-        Scale this BOM
-      </div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
-        <span style={{ fontSize: 12 }}>Make</span>
-        <input type="number" min={0} step="any" style={{ ...inp(), width: 120, textAlign: 'right' }}
-          value={targetQty} onChange={(e) => setTargetQty(e.target.value)} />
-        <select value={targetUom} onChange={(e) => setTargetUom(e.target.value)} style={{ ...inp(), width: 100 }}>
-          {UOM_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
-        </select>
-        {scaled
-          ? <span style={{ fontSize: 12, color: 'var(--mt)' }}>
-              → <strong style={{ color: 'var(--tx)', fontFamily: 'var(--ff-mono)' }}>{scaled.runs.toLocaleString(undefined, { maximumFractionDigits: 4 })}</strong> {scaled.runs === 1 ? 'run' : 'runs'} of this BOM
-            </span>
-          : incompat
-            ? <span style={{ fontSize: 11, color: 'var(--am)' }}>
-                Can't convert {targetUom} → {yield_.uom}.{' '}
-                {missingBridge
-                  ? <>Set "1 {yield_.uom} produces ___ gal" above to scale by volume, or type the target in {yield_.uom}.</>
-                  : sameCountFamily
-                    ? <>Type the target in {yield_.uom} — there's no fixed conversion between each and case.</>
-                    : <>Type the target in {yield_.uom}.</>}
-              </span>
-            : null}
-      </div>
-
-      {scaled && scaled.scaledLines.length > 0 && (
-        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12, marginTop: 12 }}>
-          <thead>
-            <tr style={{ borderBottom: '1px solid var(--bd)' }}>
-              <th style={cellTh}>Component / Service</th>
-              <th style={{ ...cellTh, textAlign: 'right' }}>Per yield</th>
-              <th style={{ ...cellTh, textAlign: 'right' }}>Required</th>
-            </tr>
-          </thead>
-          <tbody>
-            {scaled.scaledLines.map(({ qty, uom, ref }) => {
-              const l = ref.line;
-              const label = l.line_type === 'component'
-                ? (l.component_qbo_item_id ? itemLookup.byId.get(l.component_qbo_item_id)?.item_name : null) ?? '(no component)'
-                : (l.service_label || '(no label)');
-              return (
-                <tr key={ref.idx} style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
-                  <td style={cellTd}>{label}</td>
-                  <td style={{ ...cellTd, textAlign: 'right', color: 'var(--mt)', fontFamily: 'var(--ff-mono)' }}>
-                    {fmtQty(Number(l.qty_per), l.qty_uom || 'each')}
-                  </td>
-                  <td style={{ ...cellTd, textAlign: 'right', fontFamily: 'var(--ff-mono)', fontWeight: 600 }}>
-                    {fmtQty(qty, uom)}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      )}
-    </div>
-  );
-}

--- a/app/src/pages/production/WorkOrdersTab.tsx
+++ b/app/src/pages/production/WorkOrdersTab.tsx
@@ -427,11 +427,12 @@ function WorkOrderDetailModal({
   return (
     <div onClick={onClose} style={{
       position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.55)', zIndex: 1000,
-      display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20,
+      display: 'flex', alignItems: 'flex-start', justifyContent: 'center',
+      padding: '90px 20px 20px', overflowY: 'auto',
     }}>
       <div onClick={(e) => e.stopPropagation()} style={{
         background: 'var(--sf)', border: '1px solid var(--bd)', borderRadius: 6,
-        maxWidth: 940, width: '100%', maxHeight: '90vh', overflowY: 'auto', padding: 20,
+        maxWidth: 940, width: '100%', maxHeight: 'calc(100vh - 110px)', overflowY: 'auto', padding: 20,
       }}>
         <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 14 }}>
           <div>


### PR DESCRIPTION
## Four issues from Sky's planner feedback

### 1. Plan Lines grouped by P&L section (this is the big one)

The point of the planner is to edit Revenue and COGS side by side. The old flat alphabetical list buried that connection. New `PlanLinesGrouped` component:

- Revenue lines grouped by their P&L revenue line (e.g., "BIB - 3 Gallon")
- COGS lines grouped by their pl_line_label
- Gross Margin row immediately after COGS section (with %)
- OpEx → Net Income row at the bottom (with %)
- Subtotals at both the pl_line level and the section level
- Each cell still editable in place

Backed by a new RPC `fn_plan_lines_with_section` (migration `20260518e`) that mirrors the same classification logic as `fn_plan_pl_rollup`.

### 2. Plan Lines grid taller

`maxHeight: 52vh → 78vh`.

### 3. BOM rows auto-scale by target volume

The old BOM modal had a Scale-this-BOM calculator at the bottom that showed scaling in a separate read-only table. Now:

- Target qty + UoM input sits at the top of the modal (right under the gal-per-yield bridge)
- Every BOM row gets a **Required** column (when target > 0) showing the scaled quantity in the right UoM
- Drops the redundant ScaleBomPanel (~105 lines)
- "Make N gal" still works via the count→volume bridge

So: enter "Make 1000 gal" → every BOM row shows what you'd need to consume for that batch, inline.

### 4. Modals open lower

Three modals (PlanBuildDialog, BomDetailModal, WorkOrderDetailModal) were center-flexed against the viewport — when tall, the top would clip. Now:

```
alignItems: flex-start
padding: 90px 20px 20px
overflowY: auto (on overlay)
maxHeight: calc(100vh - 110px) (on panel)
```

Guaranteed 90px of breathing room at the top, no matter the screen size.

## Test plan

- [ ] FY2026 plan → Plan Lines tab → see Revenue/COGS sections with subtotals and Gross Margin
- [ ] Plan Lines grid uses ~78vh of vertical space
- [ ] Click Build… → dialog opens 90px from top, no clipping
- [ ] Production → click a BOM → enter "1000" in Make field, pick "gal" → Required column populates on every row
- [ ] Production → Work Orders → click a WO → modal opens 90px from top

https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H)_