### PR TITLE
plans: drop Account Rollup tab; collapse arrows on Plan Lines

### DIFF
--- a/app/src/pages/plans/PlanEditor.tsx
+++ b/app/src/pages/plans/PlanEditor.tsx
@@ -6,13 +6,11 @@ import { downloadCsv, toCsv } from '../../lib/csv';
 import { fm } from '../../lib/formatters';
 import {
   MONTHS_SHORT,
-  PlanAccountRollupRow,
   PlanLineSection,
   QboItemOption,
   SalesPlan,
   SalesPlanLine,
   fetchItemOptions,
-  fetchPlanAccountRollup,
   fetchPlanLineSections,
   fetchPlanLines,
 } from '../../lib/plans';
@@ -23,7 +21,7 @@ import { PlanPlView } from './PlanPlView';
 import { PlanBuildDialog } from './PlanBuildDialog';
 import { PlanLinesGrouped } from './PlanLinesGrouped';
 
-type Mode = 'pl' | 'lines' | 'rollup' | 'vs_actuals' | 'forecast';
+type Mode = 'pl' | 'lines' | 'vs_actuals' | 'forecast';
 type ViewMode = 'revenue' | 'qty' | 'price' | 'cost';
 
 const VIEW_MODES: { id: ViewMode; label: string }[] = [
@@ -44,7 +42,6 @@ interface Props {
 export function PlanEditor({ plan, onBack }: Props) {
   const [lines, setLines] = useState<SalesPlanLine[] | null>(null);
   const [linesSections, setLinesSections] = useState<PlanLineSection[] | null>(null);
-  const [rollup, setRollup] = useState<PlanAccountRollupRow[] | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [itemOpts, setItemOpts] = useState<QboItemOption[]>([]);
   const [actualsByItem, setActualsByItem] = useState<Record<string, { amounts: number[]; total: number }> | null>(null);
@@ -55,11 +52,10 @@ export function PlanEditor({ plan, onBack }: Props) {
   function load() {
     Promise.all([
       fetchPlanLines(plan.id),
-      fetchPlanAccountRollup(plan.id),
       fetchPlanLineSections(plan.id),
     ])
-      .then(([ls, ru, ss]) => { setLines(ls); setRollup(ru); setLinesSections(ss); })
-      .catch(() => { setLines([]); setRollup([]); setLinesSections([]); });
+      .then(([ls, ss]) => { setLines(ls); setLinesSections(ss); })
+      .catch(() => { setLines([]); setLinesSections([]); });
   }
   useEffect(load, [plan.id]);
 
@@ -219,30 +215,39 @@ export function PlanEditor({ plan, onBack }: Props) {
   }
 
   function exportRollupCsv() {
-    if (!rollup || rollup.length === 0) { alert('Nothing to export yet.'); return; }
+    if (!lines || lines.length === 0) { alert('Nothing to export yet.'); return; }
+    // Aggregate plan lines by account, client-side. Each line's amounts[]
+    // is summed by month for its account.
+    const byAcc = new Map<string, { qbo_account_id: string | null; m: number[]; total: number }>();
+    for (const l of lines) {
+      const key = l.account_name ?? '(unmapped)';
+      if (!byAcc.has(key)) byAcc.set(key, { qbo_account_id: l.qbo_account_id, m: Array(12).fill(0), total: 0 });
+      const e = byAcc.get(key)!;
+      const amt = l.amounts ?? [];
+      for (let i = 0; i < 12; i++) e.m[i] += Number(amt[i] ?? 0);
+      e.total += amt.reduce((s, v) => s + Number(v || 0), 0);
+    }
+    const sorted = Array.from(byAcc.entries()).sort((a, b) => b[1].total - a[1].total);
     const head = ['Account', 'QBO Account ID', ...MONTHS_SHORT, 'Total'];
-    const rows = rollup.map((r) => [
-      r.account_name,
-      r.qbo_account_id ?? '',
-      ...['m1','m2','m3','m4','m5','m6','m7','m8','m9','m10','m11','m12'].map((k) =>
-        Number((r as unknown as Record<string, number>)[k] ?? 0).toFixed(2),
-      ),
-      Number(r.total ?? 0).toFixed(2),
+    const rows = sorted.map(([name, e]) => [
+      name,
+      e.qbo_account_id ?? '',
+      ...e.m.map((v) => v.toFixed(2)),
+      e.total.toFixed(2),
     ]);
     downloadCsv(plan.name.replace(/\s+/g, '_') + `_FY${plan.fiscal_year}_budget.csv`, toCsv([head, ...rows]));
   }
 
   const totalAnnual = useMemo(
-    () => (rollup ?? []).reduce((s, r) => s + Number(r.total ?? 0), 0),
-    [rollup],
+    () => (lines ?? []).reduce((s, l) => s + (l.amounts ?? []).reduce((a, v) => a + Number(v || 0), 0), 0),
+    [lines],
   );
 
-  if (!lines || !rollup) return <div className="ld">Loading plan…</div>;
+  if (!lines) return <div className="ld">Loading plan…</div>;
 
   const modeBtns: { id: Mode; label: string }[] = [
     { id: 'pl',         label: 'P&L' },
     { id: 'lines',      label: 'Plan Lines' },
-    { id: 'rollup',     label: 'Account Rollup' },
     { id: 'vs_actuals', label: 'vs Actuals' },
     { id: 'forecast',   label: 'Forecast' },
   ];
@@ -377,43 +382,6 @@ export function PlanEditor({ plan, onBack }: Props) {
               onDelete={(id) => deleteLine(id)}
             />
           </div>
-        </div>
-      )}
-
-      {mode === 'rollup' && (
-        <div className="cd" style={{ padding: 0 }}>
-          {rollup.length === 0 ? (
-            <div className="ld">No rollup yet — add some lines first.</div>
-          ) : (
-            <div style={{ maxHeight: '60vh', overflow: 'auto' }}>
-              <table>
-                <thead style={{ position: 'sticky', top: 0, background: 'var(--sf)', zIndex: 1 }}>
-                  <tr>
-                    <th>Account</th>
-                    <th style={{ fontSize: 9, color: 'var(--mt)' }}>Lines</th>
-                    {MONTHS_SHORT.map((m) => (
-                      <th key={m} style={{ textAlign: 'right', fontSize: 9 }}>{m}</th>
-                    ))}
-                    <th style={{ textAlign: 'right' }}>Total</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rollup.map((r) => (
-                    <tr key={r.qbo_account_id ?? r.account_name}>
-                      <td style={{ fontWeight: 600 }}>{r.account_name}</td>
-                      <td style={{ fontSize: 10, color: 'var(--mt)' }}>{r.line_count}</td>
-                      {(['m1','m2','m3','m4','m5','m6','m7','m8','m9','m10','m11','m12'] as const).map((k) => (
-                        <td key={k} className="mn" style={{ textAlign: 'right', fontSize: 10 }}>
-                          {fm((r as unknown as Record<string, number>)[k])}
-                        </td>
-                      ))}
-                      <td className="mn" style={{ textAlign: 'right', fontWeight: 600 }}>{fm(r.total)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
         </div>
       )}
 

--- a/app/src/pages/plans/PlanLinesGrouped.tsx
+++ b/app/src/pages/plans/PlanLinesGrouped.tsx
@@ -3,7 +3,7 @@
 // only changes how rows are laid out so you can see Revenue and COGS together
 // while you adjust them.
 
-import { Fragment, useMemo } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 import { MONTHS_SHORT, PlanLineSection, SalesPlanLine } from '../../lib/plans';
 import { fm } from '../../lib/formatters';
 import { btnDanger, btnSecondary, inp } from '../../lib/styles';
@@ -33,6 +33,19 @@ export function PlanLinesGrouped({
   lines, linesSections, viewMode, onSetCell, onFillFlat, onDelete,
 }: Props) {
   const isMoney = viewMode !== 'qty';
+
+  // Collapsed state. Section keys: 'section:revenue', pl_line keys:
+  // 'pl:revenue|BIB - 3 Gallon'. Collapsing a section hides every pl_line
+  // and item row; the section subtotal stays visible.
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  function toggle(key: string) {
+    setCollapsed((s) => {
+      const next = new Set(s);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  }
+  const isCollapsed = (key: string) => collapsed.has(key);
 
   // Build section→pl_line→[lines] grouping. When the section RPC hasn't
   // returned yet, fall back to "other" so the editor never blanks out.
@@ -150,19 +163,34 @@ export function PlanLinesGrouped({
         </tr>
       </thead>
       <tbody>
-        {grouped.map((sec, secIdx) => (
+        {grouped.map((sec, secIdx) => {
+          const sectionKey = 'section:' + sec.name;
+          const sectionCollapsed = isCollapsed(sectionKey);
+          return (
           <Fragment key={sec.name}>
-            <tr>
-              <td colSpan={15} style={sectionHeaderStyle()}>{SECTION_LABEL[sec.name] ?? sec.name.toUpperCase()}</td>
+            <tr onClick={() => toggle(sectionKey)} style={{ cursor: 'pointer' }} title={sectionCollapsed ? 'Click to expand' : 'Click to collapse'}>
+              <td colSpan={15} style={sectionHeaderStyle()}>
+                <span style={{ display: 'inline-block', width: 14, color: 'var(--mt)' }}>
+                  {sectionCollapsed ? '▶' : '▼'}
+                </span>
+                {SECTION_LABEL[sec.name] ?? sec.name.toUpperCase()}
+              </td>
             </tr>
-            {sec.plGroups.map((g) => {
+            {!sectionCollapsed && sec.plGroups.map((g) => {
+              const groupKey = 'pl:' + sec.name + '|' + g.plLine;
+              const groupCollapsed = isCollapsed(groupKey);
               const groupSum = groupMonthly(g.lines);
               return (
                 <Fragment key={sec.name + '|' + g.plLine}>
-                  <tr>
-                    <td colSpan={15} style={plLineHeaderStyle()}>{g.plLine} <span style={{ color: 'var(--mt)', fontSize: 9 }}>· {g.lines.length} line{g.lines.length === 1 ? '' : 's'}</span></td>
+                  <tr onClick={() => toggle(groupKey)} style={{ cursor: 'pointer' }} title={groupCollapsed ? 'Click to expand' : 'Click to collapse'}>
+                    <td colSpan={15} style={plLineHeaderStyle()}>
+                      <span style={{ display: 'inline-block', width: 14, color: 'var(--mt)' }}>
+                        {groupCollapsed ? '▶' : '▼'}
+                      </span>
+                      {g.plLine} <span style={{ color: 'var(--mt)', fontSize: 9 }}>· {g.lines.length} line{g.lines.length === 1 ? '' : 's'}</span>
+                    </td>
                   </tr>
-                  {g.lines.map((l) => {
+                  {!groupCollapsed && g.lines.map((l) => {
                     const arr = arrayFor(l);
                     const total = totalFor(l);
                     return (
@@ -249,7 +277,8 @@ export function PlanLinesGrouped({
               </tr>
             )}
           </Fragment>
-        ))}
+          );
+        })}
       </tbody>
     </table>
   );


### PR DESCRIPTION
## Summary

Sky's call: Account Rollup tab was working but redundant once Plan Lines is P&L-grouped — same data, less context. Pivot: drop the tab, add expand/collapse arrows to Plan Lines.

- ▶/▼ caret on every **section header** (REVENUE / COGS / OpEx) — collapse a section and only its subtotal shows.
- ▶/▼ caret on every **pl_line header** (BIB - 3 Gallon, Equipment Sales, etc.) — collapse a pl_line and only its subtotal shows.
- Gross Margin and Net Income rows always render so you keep the bottom-line context when stuff is collapsed.
- Account Rollup tab removed from the mode toggle and from the render tree.
- `EXPORT CSV` still works — repointed to aggregate plan lines client-side by account (same output as the old RPC).
- Header annual total now sums plan-line amounts directly.

## Test plan

- [ ] Plans → FY2026 → Plan Lines: see Revenue/COGS/OpEx sections with carets
- [ ] Click ▼ next to "OPERATING EXPENSES" → only the OpEx subtotal + Net Income row remain visible
- [ ] Click ▼ next to "BIB - 3 Gallon" → only that pl_line's subtotal remains
- [ ] Mode toggle row no longer shows ACCOUNT ROLLUP
- [ ] EXPORT CSV downloads the per-account aggregated file

https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H)_