### PR TITLE
items: drop category prefix in plans/sets; lock QBO sync on local edits

### DIFF
--- a/app/src/pages/plans/PlanBuildDialog.tsx
+++ b/app/src/pages/plans/PlanBuildDialog.tsx
@@ -78,7 +78,7 @@ export function PlanBuildDialog({ planId, planFiscalYear, onClose, onApplied }: 
           const h = byId.get(it.qbo_item_id);
           return {
             qbo_item_id:        it.qbo_item_id,
-            item_name:          it.fully_qualified_name || it.name,
+            item_name:          it.name || it.fully_qualified_name || it.qbo_item_id,
             category_path:      cat,
             ly_annual_qty:      Number(h?.ly_annual_qty ?? 0),
             ly_annual_revenue:  Number(h?.ly_annual_revenue ?? 0),

--- a/app/src/pages/plans/PlanEditor.tsx
+++ b/app/src/pages/plans/PlanEditor.tsx
@@ -94,7 +94,7 @@ export function PlanEditor({ plan, onBack }: Props) {
       plan_id: plan.id,
       line_type: 'item',
       qbo_item_id: it.qbo_item_id,
-      item_name: it.fully_qualified_name || it.name,
+      item_name: it.name || it.fully_qualified_name,
       qbo_account_id: it.income_account_ref_id,
       account_name: it.income_account_name,
       amounts: ZEROS(),
@@ -365,7 +365,7 @@ export function PlanEditor({ plan, onBack }: Props) {
                   .filter((it) => !lines.some((l) => l.qbo_item_id === it.qbo_item_id))
                   .map((it) => (
                     <option key={it.qbo_item_id} value={it.qbo_item_id}>
-                      {(it.fully_qualified_name || it.name) +
+                      {(it.name || it.fully_qualified_name) +
                         (it.income_account_name ? ' → ' + it.income_account_name : '')}
                     </option>
                   ))}

--- a/app/src/pages/settings/ItemSetsEditor.tsx
+++ b/app/src/pages/settings/ItemSetsEditor.tsx
@@ -52,7 +52,7 @@ export function ItemSetsEditor() {
     addItemSetMember({
       set_code: active,
       qbo_item_id: it.qbo_item_id,
-      item_name: it.fully_qualified_name || it.name,
+      item_name: it.name || it.fully_qualified_name || undefined,
     }).then(() => loadMembers(active));
   }
 
@@ -140,7 +140,7 @@ export function ItemSetsEditor() {
               <option value="">+ add an item to this set</option>
               {availableItems.map((it) => (
                 <option key={it.qbo_item_id} value={it.qbo_item_id}>
-                  {it.fully_qualified_name || it.name}
+                  {it.name || it.fully_qualified_name}
                 </option>
               ))}
             </select>

--- a/supabase/functions/sync-qbo-items/index.ts
+++ b/supabase/functions/sync-qbo-items/index.ts
@@ -322,10 +322,27 @@ Deno.serve(async (req: Request) => {
     await getAccessToken(sb);
 
     const items = await fetchAllItems(sb);
-    const rows = items.map(toRow);
-    const withCost = rows.filter((r) => r.purchase_cost != null).length;
-    const activeCount   = rows.filter((r) => r.active === true).length;
-    const inactiveCount = rows.filter((r) => r.active === false).length;
+    const rowsRaw = items.map(toRow);
+    const withCost = rowsRaw.filter((r) => r.purchase_cost != null).length;
+    const activeCount   = rowsRaw.filter((r) => r.active === true).length;
+    const inactiveCount = rowsRaw.filter((r) => r.active === false).length;
+
+    // Skip items that the user has edited locally in the Margin Control
+    // Items master. ops.inventory_settings.is_qbo_locked = true means the
+    // inbound sync must not overwrite that qbo_items row. Sky's normal
+    // workflow is: edit in BRIX → push-qbo-item explicitly when ready,
+    // not the other way around.
+    const { data: lockedRows, error: lockErr } = await sb
+      .schema("ops")
+      .from("inventory_settings")
+      .select("qbo_item_id")
+      .eq("is_qbo_locked", true);
+    if (lockErr) throw lockErr;
+    const lockedIds = new Set(
+      (lockedRows ?? []).map((r: { qbo_item_id: string }) => r.qbo_item_id),
+    );
+    const rows = rowsRaw.filter((r) => !lockedIds.has(r.qbo_item_id));
+    const skipped_locked = rowsRaw.length - rows.length;
 
     let upserted = 0;
     if (rows.length) {
@@ -340,7 +357,9 @@ Deno.serve(async (req: Request) => {
     // Belt-and-suspenders reconciliation: anything in our DB that
     // didn't come back from QBO is either hard-deleted or otherwise
     // unreachable. Mark such rows inactive so they at least disappear
-    // from default UI filters.
+    // from default UI filters. Locked rows are exempted — if Sky has
+    // intentionally curated an item that no longer exists in QBO, we
+    // respect that choice rather than silently deactivating it.
     const fetchedIds = new Set(items.map((i) => i.Id));
     let reconciled_inactive = 0;
     const { data: existing, error: existErr } = await sb
@@ -350,7 +369,7 @@ Deno.serve(async (req: Request) => {
     if (existErr) throw existErr;
     const stale = (existing ?? [])
       .map((r) => r.qbo_item_id)
-      .filter((id: string) => !fetchedIds.has(id));
+      .filter((id: string) => !fetchedIds.has(id) && !lockedIds.has(id));
     if (stale.length > 0) {
       const { error: updErr } = await sb
         .schema("ops")
@@ -371,6 +390,7 @@ Deno.serve(async (req: Request) => {
       with_purchase_cost: withCost,
       without_cost: items.length - withCost,
       upserted,
+      skipped_locked,
       reconciled_inactive,
       duration_ms: Date.now() - startedAt,
     });


### PR DESCRIPTION
## Summary

### A) Category prefix dropped from item displays

Reports based on the materialized view (Margin, Voids, Compare) already use the bare item name — fixed in migration `20260517b`. The remaining `Beverages:3 Gallon BIB:Cola`-style displays were in four spots that read `qbo_items` directly:

- `PlanEditor.tsx` — line write + item picker dropdown
- `PlanBuildDialog.tsx` — line write
- `ItemSetsEditor.tsx` — member write + picker dropdown

Switched display from `(fully_qualified_name || name)` to `(name || fully_qualified_name)`. The long form remains a fallback for items with no bare name (rare), but we always prefer the short one. Search in `ItemsSettingsEditor` / `CustomersSettingsEditor` still matches both fields so the disambiguating context still helps.

### B) Local Items-master edits are now locked from inbound QBO sync

`sync-qbo-items` was upserting every QBO Item row unconditionally, clobbering BRIX edits on the next sync.

**Migration `20260518k`:**
- `ALTER TABLE ops.inventory_settings ADD COLUMN is_qbo_locked BOOLEAN NOT NULL DEFAULT TRUE`
- `fn_set_inventory_settings` now sets `is_qbo_locked = true` on every call — **every UI edit to Items master implicitly locks the item from inbound clobber**
- Existing rows inherit the lock retroactively (every row in `inventory_settings` already represents a deliberate human override)
- New `fn_clear_inventory_lock(qbo_item_id)` explicit unlock for the rare case Sky wants QBO to be authoritative again

**`sync-qbo-items/index.ts`:**
- Pre-queries the locked ID set, filters them out of the upsert payload
- Exempts locked IDs from the "not seen in QBO → mark inactive" reconciliation (Sky may have intentionally curated an item that no longer exists in QBO)
- Returns new `skipped_locked` count in the JSON response

**`push-qbo-item` unaffected** — it uses direct `.update()` on `qbo_items`, not `.upsert()`, so the local lock check doesn't gate the writeback path. Outbound writes continue working as before.

## Test plan

- [ ] Plan editor → Build dialog → item rows show short names (no `Beverages:3 Gallon BIB:` prefix)
- [ ] Edit any item in Items master → row gets locked → trigger sync-qbo-items → response shows `skipped_locked: N` → row's BRIX edits intact
- [ ] Use push-qbo-item on a locked row → still works (outbound writeback unaffected)

https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H)_