### PR TITLE
qbo cleanup: bail out of the unparent loop after 2 stalled batches

### DIFF
--- a/app/src/pages/settings/QboCategoryCleanupModal.tsx
+++ b/app/src/pages/settings/QboCategoryCleanupModal.tsx
@@ -77,6 +77,8 @@ export function QboCategoryCleanupModal({ open, onClose }: Props) {
     setErrorMsg(null);
     try {
       // Phase A — unparent in batches until remaining hits 0.
+      let lastRemaining: number | null = null;
+      let stalledRuns = 0;
       while (true) {
         const r = await runQboUnparentBatch(true, PHASE_LIMIT);
         const updated = (r.summary?.updated ?? 0) + (r.summary?.already_clean ?? 0);
@@ -92,10 +94,29 @@ export function QboCategoryCleanupModal({ open, onClose }: Props) {
           // No forward progress and no errors — bail to avoid infinite loop.
           throw new Error('Unparent phase stalled with no progress and no errors. Check the QBO sync log.');
         }
+        // Bail if `remaining` count refuses to decrease for two batches in a
+        // row — happens when QBO rejects the same items on every retry and
+        // we'd otherwise loop forever accumulating dupe errors.
+        const remaining = r.remaining ?? 0;
+        if (lastRemaining !== null && remaining >= lastRemaining) {
+          stalledRuns++;
+          if (stalledRuns >= 2) {
+            throw new Error(
+              `Unparent phase stalled — ${remaining} item(s) keep erroring on every retry. ` +
+              `Check ops.qbo_writeback_log for the per-item QBO error and resolve those items manually in QBO. ` +
+              `The other ${(progress.unparented + updated).toLocaleString()} item(s) were unparented successfully.`,
+            );
+          }
+        } else {
+          stalledRuns = 0;
+        }
+        lastRemaining = remaining;
       }
 
       // Phase B — inactivate categories in batches until remaining hits 0.
       setStep('inactivating');
+      lastRemaining = null;
+      stalledRuns = 0;
       while (true) {
         const r = await runQboInactivateBatch(true, PHASE_LIMIT);
         const updated = (r.summary?.updated ?? 0) + (r.summary?.already_inactive ?? 0);
@@ -110,6 +131,19 @@ export function QboCategoryCleanupModal({ open, onClose }: Props) {
         if (updated === 0 && (r.summary?.errors?.length ?? 0) === 0) {
           throw new Error('Inactivate phase stalled with no progress and no errors. Check the QBO sync log.');
         }
+        const remaining = r.remaining ?? 0;
+        if (lastRemaining !== null && remaining >= lastRemaining) {
+          stalledRuns++;
+          if (stalledRuns >= 2) {
+            throw new Error(
+              `Inactivate phase stalled — ${remaining} categor(ies) keep erroring on every retry. ` +
+              `Check ops.qbo_writeback_log for the per-item QBO error and resolve those categories manually in QBO.`,
+            );
+          }
+        } else {
+          stalledRuns = 0;
+        }
+        lastRemaining = remaining;
       }
       setStep('done');
     } catch (e) {


### PR DESCRIPTION
## Summary

The QBO cleanup modal looped forever when a few items refused to unparent — the UI's only exit conditions were `remaining=0` or `(updated=0 AND errors=0)`. With 7 NonInventory/Service items stuck erroring on every retry, the loop hammered them and accumulated ~700 duplicate error notifications.

New behavior:
- Track `lastRemaining` across iterations
- Increment `stalledRuns` when `remaining` doesn't decrease
- After **2 consecutive stalled batches**, throw with a useful message: "X item(s) keep erroring on every retry, check `ops.qbo_writeback_log`; the other Y were unparented successfully."
- Applied to both Phase A (unparent) and Phase B (inactivate)

## Status of the actual cleanup that ran

- **538 of 545** items unparented successfully in QBO. Local mirror reflects that.
- **7 stragglers** still parented (verified via `SELECT … WHERE parent_ref_id IS NOT NULL`):
  - 4 NonInventory items (Equipment Sales children)
  - 2 Service items (PM / Sublet Rental children)
  - 1 nested Category (PICK UP CO2 EMPTIES)
- **55 active QBO Categories** untouched — Phase B never started because Phase A never hit `remaining=0`.

## Not in this PR

The server-side fix to make those 7 actually go through (strip stale computed fields like `FullyQualifiedName` / `Level`, add a sparse-update fallback, log per-item errors to `ops.qbo_writeback_log`). Separate PR once we see the exact QBO error from a server-side log.

## Test plan

- [ ] Re-open the Cleanup modal → run preview → counts now show 7 items + 55 categories
- [ ] (Once server-side fix lands) Begin Cleanup → loop completes cleanly, doesn't hang
- [ ] In the current state, if you click Begin Cleanup the loop will stop after 2 stalled batches with a clear error rather than running forever

https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H)_