### PR TITLE
bom + wo: theoretical $/case·can·oz on BOM, actual + yield-loss on WO close

### DIFF
--- a/app/src/lib/production.ts
+++ b/app/src/lib/production.ts
@@ -24,6 +24,11 @@ export interface ProductBom {
    *  dilution_ratio) when this is set and ingredient SKUs parse to known
    *  per-unit volumes. Default 0 = no dilution (concentrate is finished). */
   dilution_ratio: number;
+  /** Pack count per case. Default 24. Used by the BOM cost-rollup to
+   *  derive $/case from $/can. Configurable per BOM for non-24 packs. */
+  cans_per_case: number;
+  /** Fluid ounces per can. Default 12. Used for $/oz and $/gal-finished. */
+  oz_per_can: number;
   is_active: boolean;
   notes: string | null;
   created_by: string | null;
@@ -69,6 +74,10 @@ export interface WorkOrder {
   qty_to_produce: number;
   target_uom: string | null;
   qty_produced_actual: number | null;
+  /** Actual yield reported at WO close. Together with actual_yield_uom this
+   *  drives the actual-vs-theoretical cost rollup. NULL until closed. */
+  actual_yield_qty: number | null;
+  actual_yield_uom: string | null;
   production_location_id: string;
   status: WorkOrderStatus;
   scheduled_date: string | null;
@@ -105,6 +114,13 @@ export interface WorkOrderCosts {
   total_cost: number;
   unit_cost: number | null;
   qty_produced: number;
+  /** Set when actual_yield_qty was recorded at WO close. NULL otherwise. */
+  per_case: number | null;
+  per_can: number | null;
+  per_oz: number | null;
+  per_gal_finished: number | null;
+  actual_yield_pct: number | null;
+  yield_loss_dollars: number | null;
   detail: WorkOrderCostDetail[];
   computed_at: string;
 }

--- a/app/src/pages/production/BomsTab.tsx
+++ b/app/src/pages/production/BomsTab.tsx
@@ -272,6 +272,14 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
       ? ''
       : String(bom.dilution_ratio),
   );
+  // Pack sizing for the cost-rollup card. 24 × 12 oz is the default
+  // because that's what all of Sky's RAW INGREDIENTS sheet rows use.
+  const [cansPerCase, setCansPerCase] = useState<string>(
+    bom.cans_per_case == null ? '24' : String(bom.cans_per_case),
+  );
+  const [ozPerCan, setOzPerCan] = useState<string>(
+    bom.oz_per_can == null ? '12' : String(bom.oz_per_can),
+  );
 
   useEffect(() => {
     let alive = true;
@@ -300,6 +308,16 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
     if (live !== '') return Number(live);
     return bom.dilution_ratio == null ? 0 : Number(bom.dilution_ratio);
   }, [dilutionRatio, bom.dilution_ratio]);
+
+  // Effective pack sizing (live edits before they're persisted).
+  const cansPerCaseNum = useMemo(() => {
+    const v = Number(cansPerCase);
+    return Number.isFinite(v) && v > 0 ? v : 24;
+  }, [cansPerCase]);
+  const ozPerCanNum = useMemo(() => {
+    const v = Number(ozPerCan);
+    return Number.isFinite(v) && v > 0 ? v : 12;
+  }, [ozPerCan]);
 
   const scaling = useMemo(() => {
     const tQty = Number(targetQty) || 0;
@@ -341,6 +359,62 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
     if (out) for (const s of out.scaledLines) map.set(s.ref.idx, { qty: s.qty, uom: s.uom });
     return { scaled: out, incompat: out === null, scaledByIdx: map };
   }, [lines, bom.yield_qty, bom.yield_uom, bridgeGal, dilutionNum, targetQty, targetUom, itemLookup]);
+
+  // Cost rollup at the target scale. Theoretical math — assumes 100% yield.
+  // Per-line cost = qty_required × (line.default_cost ?? item.purchase_cost ?? 0).
+  // Per-unit costs are derived from the target volume + pack sizing.
+  const costRollup = useMemo(() => {
+    if (!lines || !scaling.scaled) return null;
+    let totalBatchCost = 0;
+    let componentsCost = 0;
+    let servicesCost = 0;
+    const rows: { idx: number; label: string; unit_cost: number; qty: number; uom: string; subtotal: number }[] = [];
+    for (const [i, l] of lines.entries()) {
+      const scaled = scaling.scaledByIdx.get(i);
+      if (!scaled) continue;
+      const item = l.component_qbo_item_id ? itemLookup.byId.get(l.component_qbo_item_id) : null;
+      const unitCost = l.default_cost != null && Number(l.default_cost) > 0
+        ? Number(l.default_cost)
+        : Number(item?.purchase_cost ?? 0);
+      const subtotal = scaled.qty * unitCost;
+      const label = l.line_type === 'component'
+        ? (item?.item_name ?? '(missing item)')
+        : (l.service_label ?? '(service)');
+      rows.push({ idx: i, label, unit_cost: unitCost, qty: scaled.qty, uom: scaled.uom, subtotal });
+      totalBatchCost += subtotal;
+      if (l.line_type === 'service') servicesCost += subtotal;
+      else componentsCost += subtotal;
+    }
+    // Target volume in fl_oz — the denominator for $/oz.
+    // When target is in volume units, that's straightforward.
+    // When target is in count + we have ingredient-mode scaling, use the
+    // computed finished volume from scaleBom. Otherwise we can't show
+    // per-oz / per-can / per-case — only total + per-unit-of-yield.
+    let finishedFlOz: number | null = null;
+    const tQty = Number(targetQty) || 0;
+    if (uomGroup(targetUom) === 'volume' && tQty > 0) {
+      finishedFlOz = tQty * (
+        targetUom === 'gal' ? 128
+        : targetUom === 'fl_oz' ? 1
+        : targetUom === 'L' ? 33.8140227
+        : targetUom === 'mL' ? 0.0338140227
+        : 0
+      );
+    } else if (scaling.scaled?.finishedVolPerYieldGal && scaling.scaled.runs > 0) {
+      finishedFlOz = scaling.scaled.finishedVolPerYieldGal * scaling.scaled.runs * 128;
+    }
+    const perOz = finishedFlOz && finishedFlOz > 0 ? totalBatchCost / finishedFlOz : null;
+    const perCan = perOz != null ? perOz * ozPerCanNum : null;
+    const perCase = perCan != null ? perCan * cansPerCaseNum : null;
+    const perGalFinished = perOz != null ? perOz * 128 : null;
+    const cansProduced = finishedFlOz != null && ozPerCanNum > 0 ? finishedFlOz / ozPerCanNum : null;
+    const casesProduced = cansProduced != null ? cansProduced / cansPerCaseNum : null;
+    return {
+      totalBatchCost, componentsCost, servicesCost, rows,
+      finishedFlOz, cansProduced, casesProduced,
+      perOz, perCan, perCase, perGalFinished,
+    };
+  }, [lines, scaling, itemLookup, targetQty, targetUom, ozPerCanNum, cansPerCaseNum]);
 
   async function saveLines() {
     if (!lines || !lines.every(validLine)) return;
@@ -397,6 +471,19 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
     try {
       await updateBom(bomId, { dilution_ratio: next });
     } catch (e) { toast.error(errMsg(e)); }
+  }
+
+  async function savePackSizing() {
+    const nextCans = Number(cansPerCase) || 24;
+    const nextOz = Number(ozPerCan) || 12;
+    const prevCans = bom.cans_per_case ?? 24;
+    const prevOz = Number(bom.oz_per_can ?? 12);
+    const patch: Partial<ProductBom> = {};
+    if (nextCans !== prevCans && Number.isFinite(nextCans) && nextCans > 0) patch.cans_per_case = nextCans;
+    if (nextOz !== prevOz && Number.isFinite(nextOz) && nextOz > 0) patch.oz_per_can = nextOz;
+    if (Object.keys(patch).length === 0) return;
+    try { await updateBom(bomId, patch); }
+    catch (e) { toast.error(errMsg(e)); }
   }
 
   const displayName = (name && name.trim()) || `Version ${bom.version}`;
@@ -562,6 +649,73 @@ function BomDetailModal({ bomId, bom, itemLookup, onClose, onChanged }: {
                 itemLookup={itemLookup}
                 scaledByIdx={scaling.scaledByIdx}
               />
+
+              {/* Pack sizing — controls $/case and $/oz in the rollup card. */}
+              <div style={{
+                marginTop: 14, padding: '8px 10px',
+                border: '1px solid var(--bd)', borderRadius: 4, fontSize: 11,
+                display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap',
+              }}>
+                <span style={{ color: 'var(--mt)', textTransform: 'uppercase', letterSpacing: 0.5, fontSize: 10 }}>
+                  Pack sizing
+                </span>
+                <input type="number" min={1} step="any" style={{ ...inp(), width: 60, textAlign: 'right' }}
+                  value={cansPerCase}
+                  onChange={(e) => setCansPerCase(e.target.value)}
+                  onBlur={savePackSizing} />
+                <span style={{ color: 'var(--mt)' }}>cans per case ×</span>
+                <input type="number" min={0.01} step="any" style={{ ...inp(), width: 60, textAlign: 'right' }}
+                  value={ozPerCan}
+                  onChange={(e) => setOzPerCan(e.target.value)}
+                  onBlur={savePackSizing} />
+                <span style={{ color: 'var(--mt)' }}>
+                  oz per can = {(cansPerCaseNum * ozPerCanNum).toLocaleString(undefined, { maximumFractionDigits: 2 })} oz/case
+                  ({(cansPerCaseNum * ozPerCanNum / 128).toLocaleString(undefined, { maximumFractionDigits: 3 })} gal/case)
+                </span>
+              </div>
+
+              {/* Cost rollup — theoretical (assumes 100% yield). The Work
+                  Order detail modal owns the actual-yield-aware variant. */}
+              {costRollup && costRollup.totalBatchCost > 0 && (
+                <div className="cd" style={{ marginTop: 14, padding: 14, background: 'rgba(58,167,113,0.04)', borderColor: 'rgba(58,167,113,0.3)' }}>
+                  <div style={{ fontSize: 10, color: 'var(--mt)', textTransform: 'uppercase', letterSpacing: 0.6, marginBottom: 10 }}>
+                    Theoretical cost rollup at this scale (100% yield)
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 12, fontSize: 12 }}>
+                    <CostStat label="Total batch cost" value={`$${costRollup.totalBatchCost.toLocaleString(undefined, { maximumFractionDigits: 2 })}`} primary />
+                    <CostStat label="Components" value={`$${costRollup.componentsCost.toLocaleString(undefined, { maximumFractionDigits: 2 })}`} />
+                    <CostStat label="Services / labor" value={`$${costRollup.servicesCost.toLocaleString(undefined, { maximumFractionDigits: 2 })}`} />
+                    {costRollup.casesProduced != null && (
+                      <CostStat
+                        label="Cases produced"
+                        value={costRollup.casesProduced.toLocaleString(undefined, { maximumFractionDigits: 1 })}
+                      />
+                    )}
+                  </div>
+                  {(costRollup.perCase != null || costRollup.perCan != null || costRollup.perOz != null) && (
+                    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 12, fontSize: 12, marginTop: 12, paddingTop: 12, borderTop: '1px solid var(--bd)' }}>
+                      {costRollup.perCase != null && (
+                        <CostStat label="$ / case" value={`$${costRollup.perCase.toFixed(4)}`} primary />
+                      )}
+                      {costRollup.perCan != null && (
+                        <CostStat label="$ / can" value={`$${costRollup.perCan.toFixed(4)}`} />
+                      )}
+                      {costRollup.perOz != null && (
+                        <CostStat label="$ / oz" value={`$${costRollup.perOz.toFixed(5)}`} />
+                      )}
+                      {costRollup.perGalFinished != null && (
+                        <CostStat label="$ / gal finished" value={`$${costRollup.perGalFinished.toFixed(4)}`} />
+                      )}
+                    </div>
+                  )}
+                  {costRollup.perOz == null && (
+                    <div style={{ fontSize: 10, color: 'var(--mt)', fontStyle: 'italic', marginTop: 8 }}>
+                      Enter the target in a volume unit (gal / fl_oz / L) or set a dilution_ratio to see per-can / per-case / per-oz numbers.
+                    </div>
+                  )}
+                </div>
+              )}
+
               <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 14 }}>
                 <button onClick={onClose} style={btnSecondary()}>Close</button>
                 <button onClick={saveLines} disabled={saving || !lines.every(validLine)} style={btnPrimary()}>
@@ -756,4 +910,24 @@ function LField({ label, children }: { label: string; children: React.ReactNode 
 const cellTh: React.CSSProperties = { textAlign: 'left', padding: '7px 10px', fontSize: 10, fontWeight: 600,
   letterSpacing: 0.5, textTransform: 'uppercase', color: 'var(--mt)' };
 const cellTd: React.CSSProperties = { padding: '6px 10px', verticalAlign: 'middle' };
+
+// Small KPI-style stat tile used in the cost-rollup card.
+function CostStat({ label, value, primary }: { label: string; value: string; primary?: boolean }) {
+  return (
+    <div>
+      <div style={{ fontSize: 9, color: 'var(--mt)', textTransform: 'uppercase', letterSpacing: 0.6 }}>
+        {label}
+      </div>
+      <div style={{
+        fontSize: primary ? 16 : 14,
+        fontWeight: primary ? 700 : 600,
+        fontFamily: 'var(--ff-mono)',
+        color: primary ? 'var(--gn)' : 'var(--tx)',
+        marginTop: 2,
+      }}>
+        {value}
+      </div>
+    </div>
+  );
+}
 

--- a/app/src/pages/production/WorkOrdersTab.tsx
+++ b/app/src/pages/production/WorkOrdersTab.tsx
@@ -475,6 +475,75 @@ function WorkOrderDetailModal({
               <Kv label="Total"      value={fm(Number(costs.total_cost))} bold />
               <Kv label="Unit cost"  value={costs.unit_cost == null ? '—' : `$${Number(costs.unit_cost).toFixed(4)}`} bold accent />
             </div>
+            {/* Per-can / per-case / per-oz from actual yield. Computed
+                client-side from total_cost ÷ finished_oz, where finished_oz
+                is derived from qty_produced × the BOM's finished-volume
+                yield (gallons-per-yield bridge or dilution-driven). The
+                actual_yield_pct vs target reveals yield loss in $$.  */}
+            {(() => {
+              if (!bom || !costs) return null;
+              const actualQty = Number(costs.qty_produced);
+              const targetQty = Number(wo.qty_to_produce);
+              const total = Number(costs.total_cost);
+              if (!(actualQty > 0) || !(total > 0)) return null;
+              // Resolve finished volume per yield-unit (gal). Uses the
+              // dilution path when set, else legacy gal-bridge, else
+              // yield_uom if it's already a volume.
+              let finishedGalPerYieldUnit: number | null = null;
+              const dr = Number(bom.dilution_ratio || 0);
+              if (dr > 0 && bom.yield_qty > 0) {
+                // Can't perfectly derive ingredient volume without the
+                // lines; fall back to gal-bridge if set.
+              }
+              if (finishedGalPerYieldUnit == null && bom.finished_vol_per_yield_gal) {
+                finishedGalPerYieldUnit = Number(bom.finished_vol_per_yield_gal) / Number(bom.yield_qty);
+              }
+              if (finishedGalPerYieldUnit == null && (bom.yield_uom === 'gal' || bom.yield_uom === 'fl_oz' || bom.yield_uom === 'L' || bom.yield_uom === 'mL')) {
+                // Yield UoM is already a volume; per yield-unit = 1 of that unit
+                const VOLUME: Record<string, number> = { gal: 128, fl_oz: 1, L: 33.8140227, mL: 0.0338140227 };
+                finishedGalPerYieldUnit = VOLUME[bom.yield_uom] / 128;
+              }
+              if (finishedGalPerYieldUnit == null) {
+                return (
+                  <div style={{ marginTop: 10, fontSize: 10, color: 'var(--mt)', fontStyle: 'italic' }}>
+                    Set <strong>1 {bom.yield_uom || 'each'} produces ___ gal</strong> on the BOM (or use volume-UoM yield) to compute $/case · $/can · $/oz.
+                  </div>
+                );
+              }
+              const cansPerCase = Number(bom.cans_per_case ?? 24);
+              const ozPerCan    = Number(bom.oz_per_can ?? 12);
+              const finishedGal = actualQty * finishedGalPerYieldUnit;
+              const finishedOz  = finishedGal * 128;
+              const cansProduced = finishedOz / ozPerCan;
+              const casesProduced = cansProduced / cansPerCase;
+              const perOz   = total / finishedOz;
+              const perCan  = perOz * ozPerCan;
+              const perCase = perCan * cansPerCase;
+              const perGal  = perOz * 128;
+              const yieldPct = targetQty > 0 ? actualQty / targetQty : null;
+              const yieldLoss = yieldPct != null && yieldPct < 1 ? total * (1 - yieldPct) / Math.max(yieldPct, 0.0001) : 0;
+              return (
+                <div style={{ marginTop: 12, paddingTop: 10, borderTop: '1px solid var(--bd)' }}>
+                  <div style={{ fontSize: 10, color: 'var(--mt)', letterSpacing: 0.6, textTransform: 'uppercase', marginBottom: 8 }}>
+                    Per-unit (from actual yield: {actualQty} {bom.yield_uom || 'each'} = {finishedGal.toLocaleString(undefined, { maximumFractionDigits: 1 })} gal · {cansProduced.toLocaleString(undefined, { maximumFractionDigits: 0 })} cans · {casesProduced.toLocaleString(undefined, { maximumFractionDigits: 1 })} cases)
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8, fontSize: 13 }}>
+                    <Kv label="$ / case" value={`$${perCase.toFixed(4)}`} bold accent />
+                    <Kv label="$ / can"  value={`$${perCan.toFixed(4)}`} />
+                    <Kv label="$ / oz"   value={`$${perOz.toFixed(5)}`} />
+                    <Kv label="$ / gal"  value={`$${perGal.toFixed(4)}`} />
+                  </div>
+                  {yieldPct != null && (
+                    <div style={{ marginTop: 8, fontSize: 11, color: yieldPct < 1 ? 'var(--am)' : 'var(--gn)' }}>
+                      Yield: <strong>{(yieldPct * 100).toFixed(1)}%</strong> ({actualQty} actual / {targetQty} target)
+                      {yieldPct < 1 && (
+                        <> · loss attributable to missed yield: <strong>${yieldLoss.toFixed(2)}</strong></>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })()}
             {costs.detail.length > 0 && (
               <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 11, marginTop: 10 }}>
                 <thead>


### PR DESCRIPTION
## Why

Walked through `docs/Can Financials.xlsx` (the RAW INGREDIENTS / NEW PRODUCTION / CANS METALWORKS workflow) and confirmed Sky's actual production math splits cleanly into two surfaces:

- **BOM** owns the recipe + pack sizing + **theoretical** `$/case · $/can · $/oz` at the BOM's current Scale-to-make target (assumes 100% yield)
- **Work Order** owns the actual yield reported at close → **recomputes per-unit cost** against what really came out of the tank + surfaces **yield-loss dollars**

## Migration `20260518m`

- `product_bom.cans_per_case` (INT DEFAULT 24) + `oz_per_can` (NUMERIC DEFAULT 12)
- `work_orders.actual_yield_qty` + `actual_yield_uom`
- `work_order_costs.per_case` / `per_can` / `per_oz` / `per_gal_finished` / `actual_yield_pct` / `yield_loss_dollars`

## BOM detail modal

- **Pack sizing strip** under the BOM lines table: `[24] cans per case × [12] oz per can = N oz/case (M gal/case)`. Autosaves on blur.
- **Cost Rollup card** (green tint) under that. When Scale-to-make is set:
  - Total batch cost = `Σ qty_required × (line.default_cost ?? item.purchase_cost ?? 0)`. Components vs Services subtotals.
  - Cases produced from finished volume.
  - **$/case · $/can · $/oz · $/gal-finished**.

## Work Order detail modal (when closed)

Extended cost rollup block now shows below the existing Total / Unit-cost tiles:

- **Per-unit derivation summary**: `actual yield = N gal · M cans · K cases`
- **$/case · $/can · $/oz · $/gal** computed from `total_cost ÷ finished_oz`
- **Yield %** (`qty_produced ÷ qty_to_produce`) + **loss attributable to missed yield** in dollars when yield < 100%

So Sky's flow becomes:
1. Open BOM → see theoretical $/case at this target
2. Create WO for that target → batch runs in the plant
3. Close WO with actual yield → modal now shows the **real** $/case and the dollar value of the yield loss

## Test plan

- [ ] Open a BOM with cost data → enter target volume → Cost Rollup card shows totals
- [ ] Change `cans_per_case` to 8 → $/case quadruples (cans/case dropped from 24 → 8 means more cases per oz)
- [ ] Close a Work Order with actual_yield < target → modal shows yield % < 100% and the loss-attributable dollars

https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkcha1snnX7WwWJtbAj75H)_