### PR TITLE
qbo invoice sync: mirror QBO hosted-payment URL for brix-order

### DIFF
--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -8,7 +8,7 @@
     {
       "name": "sync-qbo",
       "kind": "supabase-edge-function",
-      "source_repo": "unknown",
+      "source_repo": "skypace/apbg-billing",
       "schedule": "nightly 09:00 UTC + every 3 min backfill",
       "writes": [
         "ops.qbo_invoices",
@@ -18,8 +18,8 @@
       ],
       "multi_writer": true,
       "external_inputs": ["QuickBooks Online API"],
-      "notes": "Legacy QBO sync. Writes qbo_token_cache via lease RPC ops.qbo_token_claim_refresh().",
-      "last_verified": "2026-05-05"
+      "notes": "Source at supabase/functions/sync-qbo/. Writes qbo_token_cache via lease RPC ops.qbo_token_claim_refresh(). v40 (2026-05-28) populates qbo_invoices.invoice_payment_url with Invoice.InvoiceLink via per-invoice read with ?include=invoiceLink&minorversion=70; surfaces to brix-order /invoices/:id 'Pay now' CTA.",
+      "last_verified": "2026-05-28"
     },
     {
       "name": "sync-qbo-items",

--- a/supabase/functions/sync-qbo/index.ts
+++ b/supabase/functions/sync-qbo/index.ts
@@ -1,0 +1,536 @@
+// sync-qbo edge function — APBG-BILLING Supabase project
+// version 40 (2026-05-28): populate ops.qbo_invoices.invoice_payment_url with
+//   Invoice.InvoiceLink (QBO-hosted "Pay now" URL) on every per-invoice read.
+//   Read path now passes ?include=invoiceLink&minorversion=70 for Invoice-type
+//   txns; for SalesReceipt / CreditMemo / RefundReceipt the field is N/A and
+//   left NULL. We no longer short-circuit the per-invoice read when lines are
+//   already present *and* the URL is missing — that gate now requires both
+//   conditions to be satisfied before skipping, so back-pressure refills the
+//   URL on the next scheduled run without forcing a full refetch_lines pass.
+//   Surfaces to brix-order via orders.v_invoices_all.
+// version 39 (2026-05-17): UPSERT line writes + mode=refresh-lines for chunked
+//   historical refetch without an empty-cache window.
+//   v38's delete-then-insert had two problems: (1) brief window where cache
+//   showed $0 revenue for an invoice, (2) if 150s idle timeout killed the
+//   function mid-loop, some invoices lost their lines entirely.
+//   v39: schema migration 20260518b added UNIQUE(invoice_id, line_num); now we
+//   UPSERT lines on that key. No empty window, no risk of orphaning lines.
+//   New mode `refresh-lines` iterates a date+id-range window and refetches each
+//   invoice's lines, designed for parallel slicing.
+// version 38: smarter line-fetch skip + ?types= filter
+// version 37: polymorphic sales-txn sync (Invoice, SalesReceipt, CreditMemo,
+//   RefundReceipt). Sign-flip credits/refunds. Parse Discount line type.
+// version 36: createClient { db: { schema: 'ops' } } so client targets ops.*
+
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient, SupabaseClient } from "jsr:@supabase/supabase-js@2";
+
+const QBO_BASE = "https://quickbooks.api.intuit.com/v3/company";
+const QBO_TOKEN_URL = "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer";
+const QBO_MINOR_VERSION_INVOICE_LINK = "70";
+const PAGE_SIZE = 1000;
+const ACCESS_TOKEN_TTL_SECONDS = 3600;
+const REFRESH_TOKEN_TTL_SECONDS = 100 * 24 * 3600;
+const REFRESH_MIN_REMAINING_SECONDS = 300;
+const LEASE_SECONDS = 20;
+const LEASE_POLL_INTERVAL_MS = 750;
+const LEASE_POLL_MAX_ATTEMPTS = 20;
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "*",
+};
+
+interface TxnConfig { qboEntity: string; sign: 1 | -1; readPath: string; hasInvoiceLink: boolean; }
+const TXN_CONFIGS: Record<string, TxnConfig> = {
+  Invoice:       { qboEntity: "Invoice",       sign:  1, readPath: "invoice",       hasInvoiceLink: true  },
+  SalesReceipt:  { qboEntity: "SalesReceipt",  sign:  1, readPath: "salesreceipt",  hasInvoiceLink: false },
+  CreditMemo:    { qboEntity: "CreditMemo",    sign: -1, readPath: "creditmemo",    hasInvoiceLink: false },
+  RefundReceipt: { qboEntity: "RefundReceipt", sign: -1, readPath: "refundreceipt", hasInvoiceLink: false },
+};
+const ALL_TXN_TYPES = Object.keys(TXN_CONFIGS);
+
+const REVENUE_LINE_MAP_FALLBACK: Record<string, string> = {
+  "120": "BIB - 3 Gallon", "121": "BIB - 5 Gallon", "273": "BIB - Delivery Fees",
+  "123": "Gas - CO2",      "124": "Gas - Mixed/Nitro", "272": "Gas - Hazmat Fees",
+  "32": "Equipment Sales", "33": "Equipment Rental",   "278": "Packaged Beverage",
+  "35": "Service - General","253": "Service - Reman",  "255": "Service - Freshpet",
+  "303": "Service - PM Contract", "306": "Shopify Sales", "312": "Shopify Shipping",
+  "230": "Shipping Income","229": "Markup",            "10": "Shipping and Delivery",
+};
+
+function getRealm(): string { return Deno.env.get("QBO_REALM_ID") || "9130352144155116"; }
+function getSB(): SupabaseClient {
+  return createClient(Deno.env.get("SUPABASE_URL") || "", Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "", { db: { schema: "ops" } });
+}
+function jsonRes(d: unknown, s = 200) {
+  return new Response(JSON.stringify(d, null, 2), { status: s, headers: { "Content-Type": "application/json", ...CORS } });
+}
+function sleep(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
+
+async function refreshSalesLines(sb: SupabaseClient) {
+  try { const { error } = await sb.rpc("refresh_sales_lines"); return { ok: !error, error: error?.message }; }
+  catch (e) { return { ok: false, error: (e as Error).message }; }
+}
+async function loadRevenueMap(sb: SupabaseClient): Promise<Record<string, string>> {
+  try {
+    const { data } = await sb.from("revenue_account_map").select("qbo_income_account_id, revenue_line");
+    if (!data || data.length === 0) return REVENUE_LINE_MAP_FALLBACK;
+    const m: Record<string, string> = {};
+    for (const r of data as any[]) m[r.qbo_income_account_id] = r.revenue_line;
+    return m;
+  } catch (_e) { return REVENUE_LINE_MAP_FALLBACK; }
+}
+
+// ── Token rotation (unchanged) ──
+interface ClaimResult { cached_access_token: string | null; cached_refresh_token: string | null; must_refresh: boolean; lease_acquired: boolean; reason: string; }
+async function claimRefresh(sb: SupabaseClient): Promise<ClaimResult> {
+  const { data, error } = await sb.rpc("qbo_token_claim_refresh",
+    { p_realm_id: getRealm(), p_min_ttl_seconds: REFRESH_MIN_REMAINING_SECONDS, p_lease_seconds: LEASE_SECONDS });
+  if (error) throw new Error("claim_refresh: " + error.message);
+  return (Array.isArray(data) ? data[0] : data) as ClaimResult;
+}
+async function persistTokens(sb: SupabaseClient, a: string, r: string, e: number, x: number | null) {
+  const aE = new Date(Date.now() + e * 1000).toISOString();
+  const rE = x ? new Date(Date.now() + x * 1000).toISOString() : new Date(Date.now() + REFRESH_TOKEN_TTL_SECONDS * 1000).toISOString();
+  const { error } = await sb.rpc("qbo_token_persist",
+    { p_realm_id: getRealm(), p_access_token: a, p_access_expires: aE, p_refresh_token: r, p_refresh_expires: rE, p_refreshed_by: "sync-qbo@v40" });
+  if (error) throw new Error("persist: " + error.message);
+}
+async function releaseFailedLease(sb: SupabaseClient, m: string) {
+  await sb.rpc("qbo_token_release_failed", { p_realm_id: getRealm(), p_error: m.slice(0, 500) });
+}
+async function intuitRefresh(rt: string) {
+  const cid = Deno.env.get("QBO_CLIENT_ID") || ""; const csec = Deno.env.get("QBO_CLIENT_SECRET") || "";
+  if (!cid || !csec) throw new Error("missing QBO creds");
+  const res = await fetch(QBO_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json", Authorization: "Basic " + btoa(cid + ":" + csec) },
+    body: new URLSearchParams({ grant_type: "refresh_token", refresh_token: rt }),
+  });
+  const data = await res.json();
+  if (!res.ok || !data.access_token) throw new Error("intuit: " + JSON.stringify(data));
+  return data;
+}
+async function getAccessToken(sb: SupabaseClient): Promise<string> {
+  for (let i = 0; i < LEASE_POLL_MAX_ATTEMPTS; i++) {
+    const c = await claimRefresh(sb);
+    if (!c.must_refresh && c.cached_access_token) return c.cached_access_token;
+    if (c.lease_acquired) {
+      const seed = c.cached_refresh_token || Deno.env.get("QBO_REFRESH_TOKEN") || "";
+      if (!seed) { await releaseFailedLease(sb, "no refresh token"); throw new Error("no refresh token"); }
+      try {
+        const fresh = await intuitRefresh(seed);
+        await persistTokens(sb, fresh.access_token, fresh.refresh_token,
+          fresh.expires_in || ACCESS_TOKEN_TTL_SECONDS, fresh.x_refresh_token_expires_in ?? null);
+        return fresh.access_token;
+      } catch (err) { await releaseFailedLease(sb, (err as Error).message); throw err; }
+    }
+    await sleep(LEASE_POLL_INTERVAL_MS);
+  }
+  throw new Error("timed out on QBO refresh lease");
+}
+
+async function qboQ(sb: SupabaseClient, q: string): Promise<any> {
+  const realm = getRealm();
+  let token = await getAccessToken(sb);
+  const url = QBO_BASE + "/" + realm + "/query?query=" + encodeURIComponent(q);
+  let res = await fetch(url, { headers: { Authorization: "Bearer " + token, Accept: "application/json" } });
+  if (res.status === 401) {
+    await sb.rpc("qbo_token_release_failed", { p_realm_id: realm, p_error: "401 query" });
+    token = await getAccessToken(sb);
+    res = await fetch(url, { headers: { Authorization: "Bearer " + token, Accept: "application/json" } });
+  }
+  return res.json();
+}
+async function qboRead(sb: SupabaseClient, p: string, id: string, opts: { include?: string; minorVersion?: string } = {}): Promise<any> {
+  const realm = getRealm();
+  let token = await getAccessToken(sb);
+  const params = new URLSearchParams();
+  if (opts.include) params.set("include", opts.include);
+  if (opts.minorVersion) params.set("minorversion", opts.minorVersion);
+  const qs = params.toString();
+  const url = QBO_BASE + "/" + realm + "/" + p + "/" + id + (qs ? "?" + qs : "");
+  let res = await fetch(url, { headers: { Authorization: "Bearer " + token, Accept: "application/json" } });
+  if (res.status === 401) {
+    await sb.rpc("qbo_token_release_failed", { p_realm_id: realm, p_error: "401 read " + p });
+    token = await getAccessToken(sb);
+    res = await fetch(url, { headers: { Authorization: "Bearer " + token, Accept: "application/json" } });
+  }
+  return res.json();
+}
+async function qboReport(sb: SupabaseClient, n: string, p: Record<string, string>) {
+  const realm = getRealm();
+  let token = await getAccessToken(sb);
+  const url = QBO_BASE + "/" + realm + "/reports/" + n + "?" + new URLSearchParams(p).toString();
+  let res = await fetch(url, { headers: { Authorization: "Bearer " + token, Accept: "application/json" } });
+  if (res.status === 401) {
+    await sb.rpc("qbo_token_release_failed", { p_realm_id: realm, p_error: "401 report " + n });
+    token = await getAccessToken(sb);
+    res = await fetch(url, { headers: { Authorization: "Bearer " + token, Accept: "application/json" } });
+  }
+  return res.json();
+}
+
+// readSalesTxn — wraps qboRead with the right include/minorversion combo per
+// txn type. Invoice gets ?include=invoiceLink so the response carries the
+// hosted payment URL; other txn types use the plain read path.
+async function readSalesTxn(sb: SupabaseClient, cfg: TxnConfig, id: string): Promise<any> {
+  if (cfg.hasInvoiceLink) {
+    return qboRead(sb, cfg.readPath, id, { include: "invoiceLink", minorVersion: QBO_MINOR_VERSION_INVOICE_LINK });
+  }
+  return qboRead(sb, cfg.readPath, id);
+}
+
+function headerRow(txn: any, txnType: string, sign: 1 | -1) {
+  return {
+    qbo_invoice_id: txn.Id, txn_type: txnType,
+    doc_number: txn.DocNumber || null,
+    txn_date: txn.TxnDate, due_date: txn.DueDate || null,
+    customer_ref_id: txn.CustomerRef?.value || null,
+    customer_name:   txn.CustomerRef?.name  || null,
+    total_amount: (parseFloat(txn.TotalAmt) || 0) * sign,
+    balance:      (parseFloat(txn.Balance) || 0) * sign,
+    status: parseFloat(txn.Balance) === 0 ? "paid" : "open",
+    department: txn.DepartmentRef?.name || null,
+    memo: txn.PrivateNote || null,
+    synced_at: new Date().toISOString(),
+    qbo_updated_at: txn.MetaData?.LastUpdatedTime || null,
+    // InvoiceLink only comes back when the read includes ?include=invoiceLink;
+    // the bulk SELECT * query never returns it, so on the initial header upsert
+    // this is left undefined (i.e. column not touched) and gets filled in by
+    // the per-invoice read below.
+  };
+}
+function lineRowsFromTxn(txn: any, invRowId: number, sign: 1 | -1, revMap: Record<string, string>): any[] {
+  const out: any[] = [];
+  let idx = 0;
+  for (const l of (txn.Line || [])) {
+    const dt = l.DetailType;
+    let acctId = "", acctName: string | null = null;
+    let itemRefId: string | null = null, itemName: string | null = null;
+    let qty: number | null = null, unitPrice: number | null = null;
+    let lineSign: 1 | -1 = sign;
+
+    if (dt === "SalesItemLineDetail") {
+      const d = l.SalesItemLineDetail || {};
+      acctId = d.ItemAccountRef?.value || "";
+      acctName = d.ItemAccountRef?.name || null;
+      itemRefId = d.ItemRef?.value || null;
+      itemName  = d.ItemRef?.name  || null;
+      qty = d.Qty ?? null; unitPrice = d.UnitPrice ?? null;
+    } else if (dt === "DiscountLineDetail") {
+      const d = l.DiscountLineDetail || {};
+      acctId = d.DiscountAccountRef?.value || "";
+      acctName = d.DiscountAccountRef?.name || "Discounts";
+      lineSign = (sign * -1) as 1 | -1;
+    } else if (dt === "GroupLineDetail") {
+      // Group/bundle item — expand its child lines. Each child has its own
+      // SalesItemLineDetail. The parent line's Amount is the sum and gets
+      // skipped; the children get individually emitted.
+      const group = l.GroupLineDetail || {};
+      for (const child of (group.Line || [])) {
+        const cd = child.DetailType;
+        if (cd !== "SalesItemLineDetail") continue;
+        const cdd = child.SalesItemLineDetail || {};
+        idx++;
+        out.push({
+          invoice_id: invRowId, line_num: idx,
+          description: child.Description || null,
+          quantity: cdd.Qty ?? null,
+          unit_price: cdd.UnitPrice ?? null,
+          amount: (parseFloat(child.Amount) || 0) * sign,
+          item_ref_id: cdd.ItemRef?.value || null,
+          item_name:   cdd.ItemRef?.name  || null,
+          account_ref_id: cdd.ItemAccountRef?.value || "",
+          account_name:   cdd.ItemAccountRef?.name  || null,
+          revenue_line: cdd.ItemAccountRef?.value ? (revMap[cdd.ItemAccountRef.value] || null) : null,
+          department: txn.DepartmentRef?.name || null,
+        });
+      }
+      continue;
+    } else { continue; }
+
+    idx++;
+    const raw = parseFloat(l.Amount) || 0;
+    out.push({
+      invoice_id: invRowId, line_num: idx,
+      description: l.Description || null,
+      quantity: qty, unit_price: unitPrice,
+      amount: raw * lineSign,
+      item_ref_id: itemRefId, item_name: itemName,
+      account_ref_id: acctId, account_name: acctName,
+      revenue_line: acctId ? (revMap[acctId] || null) : null,
+      department: txn.DepartmentRef?.name || null,
+    });
+  }
+  return out;
+}
+
+async function writeLines(sb: SupabaseClient, invRowId: number, lines: any[]) {
+  if (lines.length === 0) return 0;
+  // UPSERT on (invoice_id, line_num). Removes the empty-window risk; safe if
+  // killed mid-flight.
+  const { error } = await sb.from("qbo_invoice_lines")
+    .upsert(lines, { onConflict: "invoice_id,line_num" });
+  if (error) throw new Error("upsert lines: " + error.message);
+  // Remove any orphan lines with line_num greater than what we wrote (in case
+  // QBO removed a line since the previous sync).
+  const maxLineNum = Math.max(...lines.map((l) => l.line_num));
+  await sb.from("qbo_invoice_lines").delete().eq("invoice_id", invRowId).gt("line_num", maxLineNum);
+  return lines.length;
+}
+
+// updateInvoicePaymentUrl — writes Invoice.InvoiceLink back to the header row.
+// Only meaningful for txn_type=Invoice; the column stays NULL for everything
+// else. We always write (even when InvoiceLink is null) so QBO toggling
+// e-invoicing off retracts the URL on the next sync.
+async function updateInvoicePaymentUrl(sb: SupabaseClient, invRowId: number, url: string | null) {
+  const { error } = await sb.from("qbo_invoices")
+    .update({ invoice_payment_url: url }).eq("id", invRowId);
+  if (error) console.error(`update invoice_payment_url id=${invRowId}: ${error.message}`);
+}
+
+async function syncOneType(
+  sb: SupabaseClient, txnType: string, startDate: string, endDate: string,
+  skipLines: boolean, refetchExistingLines: boolean, revMap: Record<string, string>,
+) {
+  const cfg = TXN_CONFIGS[txnType];
+  let headers = 0, lines = 0, errors = 0;
+  let startPos = 1;
+  while (true) {
+    const q = `SELECT * FROM ${cfg.qboEntity} WHERE TxnDate >= '${startDate}' AND TxnDate <= '${endDate}' STARTPOSITION ${startPos} MAXRESULTS ${PAGE_SIZE}`;
+    const result = await qboQ(sb, q);
+    const list = result?.QueryResponse?.[cfg.qboEntity] || [];
+    if (list.length === 0) break;
+    const headerRows = list.map((txn: any) => headerRow(txn, txnType, cfg.sign));
+    await sb.from("qbo_invoices").upsert(headerRows, { onConflict: "qbo_invoice_id,txn_type" });
+    if (!skipLines) {
+      const qboIds = list.map((t: any) => t.Id);
+      const { data: invRows } = await sb.from("qbo_invoices")
+        .select("id, qbo_invoice_id, invoice_payment_url").in("qbo_invoice_id", qboIds).eq("txn_type", txnType);
+      const invByQboId = new Map<string, { id: number; invoice_payment_url: string | null }>();
+      for (const r of (invRows as any[]) || []) invByQboId.set(r.qbo_invoice_id, { id: r.id, invoice_payment_url: r.invoice_payment_url });
+      for (const txn of list) {
+        try {
+          const row = invByQboId.get(txn.Id);
+          if (!row) continue;
+          const invDbId = row.id;
+          const needsUrl = cfg.hasInvoiceLink && !row.invoice_payment_url;
+          if (!refetchExistingLines && !needsUrl) {
+            const { count } = await sb.from("qbo_invoice_lines").select("id", { count: "exact", head: true }).eq("invoice_id", invDbId);
+            if ((count || 0) > 0) continue;
+          }
+          const full = await readSalesTxn(sb, cfg, txn.Id);
+          const body = full?.[cfg.qboEntity] || txn;
+          const lineRows = lineRowsFromTxn(body, invDbId, cfg.sign, revMap);
+          lines += await writeLines(sb, invDbId, lineRows);
+          if (cfg.hasInvoiceLink) {
+            await updateInvoicePaymentUrl(sb, invDbId, body.InvoiceLink || null);
+          }
+          await sleep(80);
+        } catch (e: any) {
+          errors++;
+          console.error(`${txnType} ${txn.Id}: ${e.message}`);
+        }
+      }
+    }
+    headers += list.length;
+    if (list.length < PAGE_SIZE) break;
+    startPos += PAGE_SIZE;
+  }
+  return { headers, lines, errors };
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") return new Response(null, { status: 204, headers: CORS });
+  const url = new URL(req.url);
+  const mode = url.searchParams.get("mode") || "incremental";
+  const sb = getSB();
+
+  if (mode === "refresh-mv") {
+    const r = await refreshSalesLines(sb);
+    return jsonRes({ status: r.ok ? "success" : "error", refresh: r });
+  }
+  if (mode === "whoami") return jsonRes({ version: 40, txn_types_supported: ALL_TXN_TYPES });
+
+  // === refresh-lines mode ===
+  // Reads a slice of qbo_invoices by date+offset and refetches their lines via
+  // upsert. Designed for parallel use: fire N calls with offsets 0, batch, 2*batch...
+  // Each call is bounded; safe under the 150s timeout. v40 also refreshes
+  // invoice_payment_url for Invoice-type rows.
+  if (mode === "refresh-lines") {
+    const start = url.searchParams.get("start") || "2026-01-01";
+    const end = url.searchParams.get("end") || new Date().toISOString().split("T")[0];
+    const offset = parseInt(url.searchParams.get("offset") || "0");
+    const batch = parseInt(url.searchParams.get("batch") || "100");
+    const revMap = await loadRevenueMap(sb);
+    const { data: rows } = await sb.from("qbo_invoices")
+      .select("id, qbo_invoice_id, txn_type")
+      .gte("txn_date", start).lte("txn_date", end)
+      .order("id")
+      .range(offset, offset + batch - 1);
+    let processed = 0, linesWritten = 0, urlsWritten = 0, errors = 0;
+    for (const r of (rows || []) as any[]) {
+      const cfg = TXN_CONFIGS[r.txn_type] || TXN_CONFIGS.Invoice;
+      try {
+        const full = await readSalesTxn(sb, cfg, r.qbo_invoice_id);
+        const body = full?.[cfg.qboEntity];
+        if (!body) continue;
+        const lineRows = lineRowsFromTxn(body, r.id, cfg.sign, revMap);
+        linesWritten += await writeLines(sb, r.id, lineRows);
+        if (cfg.hasInvoiceLink) {
+          await updateInvoicePaymentUrl(sb, r.id, body.InvoiceLink || null);
+          if (body.InvoiceLink) urlsWritten++;
+        }
+        processed++;
+        await sleep(80);
+      } catch (e: any) {
+        errors++;
+        console.error(`refresh-lines ${r.qbo_invoice_id} (${r.txn_type}): ${e.message}`);
+      }
+    }
+    const mvResult = await refreshSalesLines(sb);
+    return jsonRes({
+      status: "success", mode: "refresh-lines",
+      start, end, offset, batch,
+      rows_returned: rows?.length || 0, processed, lines_written: linesWritten, urls_written: urlsWritten, errors,
+      next_offset: offset + batch, mv_refresh: mvResult,
+    });
+  }
+
+  if (mode === "lines") {
+    const batchSize = parseInt(url.searchParams.get("batch") || "50");
+    const offset = parseInt(url.searchParams.get("offset") || "0");
+    const revMap = await loadRevenueMap(sb);
+    const { data: allInvs } = await sb.from("qbo_invoices")
+      .select("id, qbo_invoice_id, txn_type, invoice_payment_url")
+      .range(offset, offset + batchSize - 1);
+    let processed = 0, linesAdded = 0;
+    for (const inv of (allInvs || []) as any[]) {
+      const cfg = TXN_CONFIGS[inv.txn_type] || TXN_CONFIGS.Invoice;
+      const needsUrl = cfg.hasInvoiceLink && !inv.invoice_payment_url;
+      const { count } = await sb.from("qbo_invoice_lines")
+        .select("id", { count: "exact", head: true }).eq("invoice_id", inv.id);
+      if ((count || 0) > 0 && !needsUrl) continue;
+      try {
+        const full = await readSalesTxn(sb, cfg, inv.qbo_invoice_id);
+        const body = full?.[cfg.qboEntity];
+        if (!body) continue;
+        const rows = lineRowsFromTxn(body, inv.id, cfg.sign, revMap);
+        linesAdded += await writeLines(sb, inv.id, rows);
+        if (cfg.hasInvoiceLink) {
+          await updateInvoicePaymentUrl(sb, inv.id, body.InvoiceLink || null);
+        }
+        processed++;
+        await sleep(80);
+      } catch (e: any) {
+        console.error(`Line read ${inv.qbo_invoice_id} (${inv.txn_type}): ${e.message}`);
+      }
+    }
+    const mvResult = await refreshSalesLines(sb);
+    await sb.from("sync_log").insert({
+      source: "qbo", sync_type: "lines_backfill", status: "success",
+      records_synced: linesAdded, completed_at: new Date().toISOString(),
+      metadata: { offset, batch: batchSize, processed, mv_refresh: mvResult },
+    });
+    return jsonRes({
+      status: "success", mode: "lines",
+      invoices_checked: allInvs?.length || 0, invoices_processed: processed,
+      lines_added: linesAdded, next_offset: offset + batchSize, mv_refresh: mvResult,
+    });
+  }
+
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  let startDate = url.searchParams.get("start") || (now.getFullYear() + "-" + pad(now.getMonth() + 1) + "-01");
+  let endDate = url.searchParams.get("end") || now.toISOString().split("T")[0];
+  if (mode === "full") startDate = "2025-01-01";
+  const skipLines = url.searchParams.get("skip_lines") === "true" || mode === "fast";
+  const refetchExistingLines = url.searchParams.get("refetch_lines") === "true";
+  const requestedTypes = (url.searchParams.get("types") || ALL_TXN_TYPES.join(","))
+    .split(",").map(s => s.trim()).filter(s => ALL_TXN_TYPES.includes(s));
+  const types = requestedTypes.length > 0 ? requestedTypes : ALL_TXN_TYPES;
+
+  try {
+    await getAccessToken(sb);
+    const revMap = await loadRevenueMap(sb);
+    const perTypeResults: Record<string, any> = {};
+    let totalHeaders = 0;
+    for (const t of types) {
+      const r = await syncOneType(sb, t, startDate, endDate, skipLines, refetchExistingLines, revMap);
+      perTypeResults[t] = r;
+      totalHeaders += r.headers;
+    }
+    await sb.from("sync_log").insert({
+      source: "qbo", sync_type: skipLines ? "headers_only" : "invoices",
+      status: "success", records_synced: totalHeaders,
+      completed_at: new Date().toISOString(),
+      metadata: { start_date: startDate, end_date: endDate, mode, skip_lines: skipLines, types, per_type: perTypeResults },
+    });
+
+    let plCount = 0;
+    if (requestedTypes.length === 0 || requestedTypes.length === ALL_TXN_TYPES.length) {
+      const startD = new Date(startDate);
+      const endD = new Date(endDate);
+      const cur = new Date(startD.getFullYear(), startD.getMonth(), 1);
+      while (cur <= endD) {
+        const ms = cur.toISOString().split("T")[0];
+        const me = new Date(cur.getFullYear(), cur.getMonth() + 1, 0).toISOString().split("T")[0];
+        const report = await qboReport(sb, "ProfitAndLoss", { start_date: ms, end_date: me, accounting_method: "Accrual" });
+        const plRows: any[] = [];
+        function extract(section: any, accountType: string) {
+          if (!section?.Row) return;
+          for (const row of section.Row) {
+            if (row.type === "Data" && row.ColData) {
+              const name = row.ColData[0]?.value;
+              const id = row.ColData[0]?.id;
+              const amt = parseFloat(row.ColData[1]?.value) || 0;
+              if (name && id) plRows.push({
+                period: ms, account_id: id, account_name: name,
+                account_type: accountType, amount: amt,
+                entity: "combined", snapshot_at: new Date().toISOString(),
+              });
+            }
+            if (row.Rows) extract(row.Rows, accountType);
+          }
+        }
+        for (const section of (report?.Rows?.Row || [])) {
+          const h = section.Header?.ColData?.[0]?.value || "";
+          let t = "Other";
+          if (h === "Income") t = "Income";
+          else if (h === "Cost of Goods Sold") t = "Cost of Goods Sold";
+          else if (h === "Expenses") t = "Expense";
+          if (section.Rows) extract(section.Rows, t);
+        }
+        if (plRows.length > 0) {
+          await sb.from("pl_snapshots").delete().eq("period", ms).eq("entity", "combined");
+          await sb.from("pl_snapshots").insert(plRows);
+        }
+        plCount += plRows.length;
+        cur.setMonth(cur.getMonth() + 1);
+      }
+      await sb.from("sync_log").insert({
+        source: "qbo", sync_type: "pl_snapshots", status: "success",
+        records_synced: plCount, completed_at: new Date().toISOString(),
+      });
+    }
+    const mvResult = await refreshSalesLines(sb);
+    return jsonRes({
+      status: "success", mode, types, skip_lines: skipLines,
+      total_headers: totalHeaders, per_type: perTypeResults,
+      pl_rows: plCount, mv_refresh: mvResult,
+    });
+  } catch (err: any) {
+    console.error("FATAL:", err);
+    try {
+      await sb.from("sync_log").insert({
+        source: "qbo", sync_type: "fatal", status: "error",
+        records_synced: 0, error_message: err.message,
+        completed_at: new Date().toISOString(),
+      });
+    } catch (_e) { /* */ }
+    return jsonRes({ status: "error", message: err.message }, 500);
+  }
+});

--- a/supabase/migrations/20260528a_qbo_invoices_payment_url.sql
+++ b/supabase/migrations/20260528a_qbo_invoices_payment_url.sql
@@ -1,0 +1,19 @@
+-- Add hosted-payment URL to the invoice mirror.
+--
+-- QBO exposes Invoice.InvoiceLink (a hosted "Pay now" page) when QuickBooks
+-- e-invoicing is enabled on the company. brix-order's /invoices/:id surface
+-- renders a "Pay now" CTA pointing at this URL so customers can settle their
+-- balance by ACH or card; the resulting payment lands in QBO and flows back
+-- through sync-qbo into ops.qbo_invoices.balance / .status.
+--
+-- Populated by sync-qbo v40+: when fetching per-invoice detail (the read used
+-- to mirror line items), the function passes ?include=invoiceLink&minorversion=70
+-- and writes the returned InvoiceLink on the header row. NULL for txn_types
+-- that don't have a hosted invoice (SalesReceipt / CreditMemo / RefundReceipt)
+-- and for Invoice rows where QBO e-invoicing was off at sync time.
+
+ALTER TABLE ops.qbo_invoices
+  ADD COLUMN IF NOT EXISTS invoice_payment_url text;
+
+COMMENT ON COLUMN ops.qbo_invoices.invoice_payment_url IS
+  'QBO-hosted payment-page URL (Invoice.InvoiceLink). Populated by sync-qbo on each per-invoice read. Used by brix-order /invoices/:id "Pay now" CTA. NULL for non-Invoice txn_types or invoices without e-invoicing enabled.';


### PR DESCRIPTION
## Summary

Lights up the "Pay now" CTA on brix-order's `/invoices/:id` page (the [follow-up hand-off](https://github.com/activespacescience/brix-order) from PR #1 there). brix-order already renders the button disabled with a placeholder; this PR fills in the QBO-hosted payment URL it's waiting on.

- **New column** `ops.qbo_invoices.invoice_payment_url text` (migration `20260528a_qbo_invoices_payment_url.sql`). NULL for non-Invoice txn_types and Invoice rows without an e-invoicing link.
- **sync-qbo v40**: per-invoice read now uses `?include=invoiceLink&minorversion=70` for `txn_type=Invoice` and writes `Invoice.InvoiceLink` to the new column. Other txn types unchanged.
- **Skip-gate**: the existing "skip the per-invoice read if lines already exist" optimisation now also requires `invoice_payment_url` to be populated before skipping, so each subsequent incremental run back-pressure-fills the URL on the existing dataset without needing a full `refetch_lines` pass.
- **`refresh-lines` mode** also writes the URL and reports `urls_written` in the response payload.
- **sync-qbo source** is now tracked at `supabase/functions/sync-qbo/index.ts` (was deployed-only, manifest had `source_repo: unknown`). The manifest entry is flipped to `skypace/apbg-billing`.

Lines mirror (`ops.qbo_invoice_lines`) is unchanged — it was already populated end-to-end by v39 with a slightly different shape than the hand-off doc described (`invoice_id bigint` → `qbo_invoices.id`, no `taxable` / `synced_at` columns). brix-order's planned `orders.v_invoice_lines` view will need to join on that surrogate `id` rather than on `qbo_invoice_id text`; calling that out so the brix-order side picks up the right shape.

## Deploy state

- ✅ Migration applied to `gfsdpwiqzshhexkofiif`
- ✅ sync-qbo v40 deployed (was v39)
- ✅ Smoke test (`mode=refresh-lines`, 5 May-2026 invoices): processed=5, errors=0. **`urls_written=0`** — every invoice came back from QBO with no `InvoiceLink`. Most likely the realm doesn't have QBO Online Invoicing / QBO Payments turned on, or the sampled invoices weren't issued through the e-invoicing flow. Plumbing is correct; column populates as soon as QBO returns the field.

## Test plan

- [ ] Confirm QBO Online Invoicing / Payments is enabled on realm `9130352144155116` (Intuit account settings) — without this the column stays NULL no matter how often we sync.
- [ ] After enabling, trigger one of:
  - `curl 'https://gfsdpwiqzshhexkofiif.supabase.co/functions/v1/sync-qbo?mode=refresh-lines&start=2026-05-01&end=2026-05-28&offset=0&batch=100'`
  - or wait for the next nightly run
- [ ] `select count(*) from ops.qbo_invoices where invoice_payment_url is not null;` → > 0
- [ ] Sign into brix-order, open `/invoices/<id>` for an invoice that now has a URL → "Pay now" button enabled, opens the QBO hosted page in a new tab.
- [ ] Pay one in test mode → on next sync cadence the balance/status flips through to brix-order.

## Rollback

Redeploy v39 source from this PR's commit parent. The column stays — it's additive and only ever written via direct UPDATE, so leaving it around is harmless.

---

Hand-off context: `activespacescience/brix-order` PR #1 ships a branded invoice list/detail today; the spec from that session is reproduced in the chat that originated this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZCreCRGZ7LryDmBqnoNq)_