### PR TITLE
sync-qbo v41: extract SF job id from QBO memos into ops.qbo_invoices.sf_job_id

### DIFF
--- a/supabase/functions/sync-qbo/index.ts
+++ b/supabase/functions/sync-qbo/index.ts
@@ -1,4 +1,9 @@
 // sync-qbo edge function — APBG-BILLING Supabase project
+// version 41 (2026-05-28): extract Service Fusion job id from QBO PrivateNote /
+//   CustomerMemo via regex (Job #?\d{8,12} | SF[-\s]?\d{8,12}) and persist to
+//   ops.qbo_invoices.sf_job_id on every header upsert. NULL when the memo
+//   carries no job reference. Surfaces to brix-order /invoices/:id so
+//   customers can cross-reference an invoice with its delivery/service job.
 // version 40 (2026-05-28): populate ops.qbo_invoices.invoice_payment_url with
 //   Invoice.InvoiceLink (QBO-hosted "Pay now" URL) on every per-invoice read.
 //   Read path now passes ?include=invoiceLink&minorversion=70 for Invoice-type
@@ -183,6 +188,22 @@ async function readSalesTxn(sb: SupabaseClient, cfg: TxnConfig, id: string): Pro
   return qboRead(sb, cfg.readPath, id);
 }
 
+// extractSfJobId — best-effort regex extraction of a Service Fusion job id
+// from QBO's PrivateNote and CustomerMemo fields. Matches "Job #1089501883",
+// "Job 1089501883", "SF-1089501883", "SF 1089501883" (case-insensitive).
+// Returns the first capture group or null.
+const SF_JOB_ID_RE = /(?:Job\s*#?|SF[-\s]?)(\d{8,12})\b/i;
+function extractSfJobId(txn: any): string | null {
+  const candidates: string[] = [];
+  if (txn.PrivateNote) candidates.push(String(txn.PrivateNote));
+  if (txn.CustomerMemo?.value) candidates.push(String(txn.CustomerMemo.value));
+  for (const c of candidates) {
+    const m = c.match(SF_JOB_ID_RE);
+    if (m && m[1]) return m[1];
+  }
+  return null;
+}
+
 function headerRow(txn: any, txnType: string, sign: 1 | -1) {
   return {
     qbo_invoice_id: txn.Id, txn_type: txnType,
@@ -195,6 +216,7 @@ function headerRow(txn: any, txnType: string, sign: 1 | -1) {
     status: parseFloat(txn.Balance) === 0 ? "paid" : "open",
     department: txn.DepartmentRef?.name || null,
     memo: txn.PrivateNote || null,
+    sf_job_id: extractSfJobId(txn),
     synced_at: new Date().toISOString(),
     qbo_updated_at: txn.MetaData?.LastUpdatedTime || null,
     // InvoiceLink only comes back when the read includes ?include=invoiceLink;
@@ -353,7 +375,7 @@ Deno.serve(async (req: Request) => {
     const r = await refreshSalesLines(sb);
     return jsonRes({ status: r.ok ? "success" : "error", refresh: r });
   }
-  if (mode === "whoami") return jsonRes({ version: 40, txn_types_supported: ALL_TXN_TYPES });
+  if (mode === "whoami") return jsonRes({ version: 41, txn_types_supported: ALL_TXN_TYPES });
 
   // === refresh-lines mode ===
   // Reads a slice of qbo_invoices by date+offset and refetches their lines via

--- a/supabase/migrations/20260528b_qbo_invoices_sf_job_id.sql
+++ b/supabase/migrations/20260528b_qbo_invoices_sf_job_id.sql
@@ -1,0 +1,28 @@
+-- Add Service Fusion job-id link to the invoice mirror.
+--
+-- Brix-order /invoices/:id wants to show "Job #1089501883" so customers
+-- can cross-reference their delivery / service record with the invoice
+-- that bills it. The link doesn't exist natively in QBO — there's no
+-- foreign-key field — so sync-qbo extracts it best-effort from QBO's
+-- PrivateNote / CustomerMemo via a regex (`Job #?\d{8,12}` or
+-- `SF[-\s]?\d{8,12}`).
+--
+-- For invoices that were created by an automation that already includes
+-- the SF job number in the memo, this will populate immediately on the
+-- next sync. For older invoices (or invoices created without the
+-- convention), the column stays NULL and brix-order's UI omits the
+-- "Job #" line. Future work can cross-reference SF directly by
+-- customer+date+amount, but the regex path covers the common case at
+-- zero extra API cost.
+--
+-- Populated by sync-qbo v41+.
+
+ALTER TABLE ops.qbo_invoices
+  ADD COLUMN IF NOT EXISTS sf_job_id text;
+
+CREATE INDEX IF NOT EXISTS qbo_invoices_sf_job_id_idx
+  ON ops.qbo_invoices (sf_job_id)
+  WHERE sf_job_id IS NOT NULL;
+
+COMMENT ON COLUMN ops.qbo_invoices.sf_job_id IS
+  'Service Fusion job id linked to this invoice. Extracted by sync-qbo from the QBO PrivateNote / CustomerMemo via regex. NULL when the memo carries no job reference; brix-order omits the Job# row in that case.';


### PR DESCRIPTION
## Summary

Brix-order `/invoices/:id` wants to cross-reference each invoice with the Service Fusion job that fulfilled it. QBO has no native SF-job-id field, so sync-qbo extracts it from QBO's `PrivateNote` / `CustomerMemo` via regex:

```
/(?:Job\s*#?|SF[-\s]?)(\d{8,12})\b/i
```

Matches `Job #1089501883`, `Job 1089501883`, `SF-1089501883`, `SF 1089501883` (case-insensitive, 8–12 digit ids). Returns the first capture group or `null`. Wired into `headerRow()` so every invoice header upsert persists it.

## Changes

- **Migration `20260528b_qbo_invoices_sf_job_id.sql`** — adds `ops.qbo_invoices.sf_job_id text` + a partial index (`WHERE sf_job_id IS NOT NULL`).
- **`supabase/functions/sync-qbo/index.ts` v41** — new `extractSfJobId(txn)` helper, called from `headerRow`. Token-persist label bumped to `sync-qbo@v41`. `whoami` returns `version: 41`.

## Deployed

- Migration applied to `gfsdpwiqzshhexkofiif` (column live).
- Edge function v41 deployed via Supabase MCP — active now.

## Caveat (forward-looking, not blocking)

Existing invoice memos look like `"GENERATED BY FREEFLOW AUTOMATION"` and `"Store Order MV-0004 — Burbank"` — they don't match the regex pattern, so this column will populate **for zero of the 12,807 existing invoices** on the first sync after deploy.

To start populating: update the FreeFlow automation that creates QBO invoices to include `Job #<id>` (or `SF-<id>`) in the QBO PrivateNote when invoicing from a Service Fusion job. After that, every new invoice populates automatically and a `?mode=refresh-lines` pass backfills any in the date window. Zero extra API cost vs. the current sync.

## Test plan

- [x] `?mode=whoami` returns `version: 41`
- [ ] Manually update a QBO invoice's PrivateNote to include `Job #1234567890`, run `?mode=refresh-lines&start=2026-05-28`, confirm `sf_job_id` populates
- [ ] Brix-order side (separate PR) bubbles through `v_invoices_all` and renders the Job # on the invoice detail page

https://claude.ai/code/session_01NqqhP9MiADma6ZMvjXZRWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqqhP9MiADma6ZMvjXZRWH)_