### PR TITLE
ResQ↔SF sync: Starbird hotfix + v2 plan + Phase 1 (sync_customers identity map)

### DIFF
--- a/architecture/projects/resq-sf-sync-v2/PRD.md
+++ b/architecture/projects/resq-sf-sync-v2/PRD.md
@@ -1,0 +1,101 @@
+# ResQ ↔ Service Fusion Sync v2 — PRD
+
+> Status: **DRAFT for review** · Owner: Sky · Drafted: 2026-06-02
+> Home of record: this doc should be mirrored into
+> `activespacescience/Skilliosis_Mytosis_Architecture/projects/resq-sf-sync-v2/`.
+> It lives in `apbg-billing` for now only because that repo holds the v1 code
+> and was the in-scope repo for the drafting session.
+
+## Problem
+
+The ResQ ↔ Service Fusion sync (`apbg-billing/netlify/functions/resq-sf-sync-background.mjs`,
+driven by a 5-minute cron) keeps the two systems loosely aligned but still
+leans on **manual steps** and a **fragile state model**:
+
+- **Photos are manual.** `transferSfPhotosToResq` is a stub — it detects that
+  an SF job has pictures and tells the operator to upload them to ResQ by hand
+  via `sync.html`. (The stub's comment claims SF exposes no download endpoint;
+  that is no longer true — see Decisions.)
+- **Expense → bill is manual.** `expense-to-bill.mjs` is a dashboard button:
+  the operator opens a job, drops in a receipt, Claude OCRs it, and a QBO bill
+  is created one at a time.
+- **No payment loop.** Once a bill exists in QBO there is no structured
+  approve-and-pay step; Brixpense already solves this for internal expenses
+  but is not wired to SF-sourced bills.
+- **State is a single JSON blob** (`wo-mapping` in Netlify Blobs), read-modified-
+  written per work order under a lock blob. No history, no queryability, and it
+  has already produced cross-file drift bugs (e.g. the Starbird customer-name
+  mismatch — see PR #124).
+- **Customer identity is hand-maintained in two places that disagree.** The
+  ResQ-facility → SF-customer → QBO-customer mapping is duplicated as string
+  literals in `resq-sf-sync-background.mjs` and `expense-to-bill.mjs`, and the
+  literals don't match (`STARBIRD CHICKEN: RESQ` vs `STARBIRD CHICKEN RESQ`).
+
+## Vision
+
+A **fully automated, event-driven, auditable** bridge between ResQ and Service
+Fusion, with QuickBooks and Brixpense closing the financial loop — **no manual
+data entry** in the happy path.
+
+1. When a job changes in **SF**, it pushes to **ResQ** (status, completion,
+   photos, the vendor invoice).
+2. When a work order changes in **ResQ**, it pushes to **SF** (job create,
+   status).
+3. **SF photos** are pulled and pushed into ResQ automatically (attached to the
+   visit on completion).
+4. **SF expenses** are captured automatically into a **QBO vendor bill** with
+   the correct COGS account + customer, mirroring the receipt image.
+5. The **payment** of that bill is approved through **Brixpense** — automation
+   captures the AP liability; a human still says "pay it."
+
+## Goals
+
+- G1. Eliminate manual photo upload. SF pictures land in ResQ automatically.
+- G2. Eliminate manual receipt→bill entry. SF expenses become QBO bills
+  automatically, with the receipt attached.
+- G3. Route SF-sourced bills through Brixpense for payment approval.
+- G4. Make the sync near-real-time in the SF→ResQ direction (webhook), and
+  efficient (cursor-based) in the ResQ→SF direction.
+- G5. Move sync state out of a JSON blob into queryable `ops.*` tables with a
+  full event/audit trail.
+- G6. Establish **one** customer-identity source of truth across ResQ, SF, and
+  QBO, killing the name-drift class of bug permanently.
+
+## Non-goals
+
+- Not replacing the proven ResQ→SF job-create / dedup logic or the 5-mutation
+  SF→ResQ invoice flow — those are preserved and migrated, not rewritten.
+- Not building a new UI framework. `sync.html` stays as the operator console;
+  it just reads from `ops.*` instead of blobs and loses the manual widgets.
+- Not changing ResQ auth from cookie/CSRF to something else (out of our
+  control); we only harden and monitor it.
+- Not introducing customer-facing surfaces — this is internal ops plumbing.
+
+## Users
+
+- **Ops (Dani et al.)** — want jobs, photos, and invoices to "just sync,"
+  and to approve payments in one place (Brixpense).
+- **Finance / Sky** — want every SF cost captured as a QBO bill with the right
+  account/customer, and a clean approve-to-pay trail.
+- **Engineering** — want a queryable, debuggable sync with an audit log instead
+  of a blob and a wall of `console.log`.
+
+## Success metrics
+
+- 0 manual photo uploads per week (currently every completed job with photos).
+- 100% of billable SF expenses auto-captured as QBO bills within one sync cycle.
+- SF→ResQ status latency p95 < 60s (webhook) vs up to 5 min today.
+- Every sync action visible in `ops.sync_log` / an events table — no more
+  blob-archaeology to answer "what happened to WO R12345?".
+- Zero customer-name-drift incidents after the identity map ships.
+
+## Risks (summary — detail in scoping.md)
+
+- **Auto-posting bills** risks duplicate/incorrect AP if OCR or matching is
+  wrong. Mitigation: strict idempotency keys + Brixpense as the human payment
+  gate; bills are captured but money never moves without approval.
+- **ResQ has no webhooks** (cookie-auth GraphQL); ResQ→SF stays polled. The
+  realtime win is one-directional.
+- **SF S3/cookie download** depends on undocumented SF behavior already proven
+  in `brix-order`; if SF changes it, the photo pipeline needs the cookie
+  fallback (also already built in `brix-order`).

--- a/architecture/projects/resq-sf-sync-v2/decisions.md
+++ b/architecture/projects/resq-sf-sync-v2/decisions.md
@@ -1,0 +1,39 @@
+# ResQ ↔ SF Sync v2 — Decisions Log
+
+> One row per decision. "Confirmed" = agreed with Sky; "Proposed" = my
+> recommendation pending sign-off.
+
+| # | Decision | Status | Rationale |
+|---|---|---|---|
+| D1 | **One identity map** (`ops.sync_customers`) is the single source of truth for ResQ-facility ↔ SF-customer ↔ QBO-customer ↔ COGS account ↔ entity. Both `resq-sf-sync-background.mjs` and `expense-to-bill.mjs` read it. | Proposed | Kills the name-drift bug class (Starbird `: RESQ` vs ` RESQ`, PR #124). Prereq for auto-billing. |
+| D2 | **State moves from the `wo-mapping` Netlify Blob to `ops.resq_sf_links` + `ops.sync_events`.** | Proposed | Queryable, auditable, PK lookups instead of full scans; same `ops.*` posture as the rest of the stack; lets `sync.html` + APBG-OPS read sync state directly. |
+| D3 | **SF→ResQ becomes webhook-driven** (`sf-webhook.mjs`); **ResQ→SF stays cursor-polled**; the cron becomes a reconciler/safety-net. | Proposed | SF supports webhooks; ResQ (cookie-auth GraphQL) does not. Get realtime where we can, stay correct where we can't. |
+| D4 | **Photo download uses `brix-order`'s public-S3 path first, cookie-replay proxy as fallback.** | Confirmed | Sky: "we figured a workaround out in brix-order." Proven in `_lib/sf-attachment-sync.ts` (S3) + `get-sf-job-asset.ts` (cookies in `orders.sf_portal_session`). v1's "S3 is private" comment is stale. |
+| D5 | **Fetch SF photos BEFORE ending the ResQ visit, and attach them to `endVisit`.** | Proposed | Fixes the v1 ordering bug — v1 ends the visit with `images:[]` then can't push photos after. |
+| D6 | **SF expenses auto-create a QBO vendor bill; the PAYMENT is approved in Brixpense.** | Confirmed | Sky chose "auto-create, pay via Brixpense." Automation captures the AP liability; a human still authorizes the money. |
+| D7 | **Converge on ONE AP path.** SF-sourced bills flow into Brixpense's existing approval model (`expense-request-*` + `ops.expense_requests`), not a parallel pipeline. | Proposed | `expense-to-bill.mjs` and `expense-request-link-bill.mjs` already both create QBO bills; don't add a third. |
+| D8 | **Hard idempotency on bill creation** keyed on `sf_expense_id` (or `sf_job_id`+line hash), recorded on `ops.resq_sf_links`. | Proposed | Auto-posting bills is the highest-risk change; duplicate AP is the worst failure. Idempotency + Brixpense gate are mandatory mitigations. |
+| D9 | **Preserve the v1 crown jewels**: ResQ→SF create/dedup (`processNewWO`, `pickBestSfJob`, po_number join) and the 5-mutation SF→ResQ invoice flow (`buildAndSubmitInvoice`). Migrate, don't rewrite. | Proposed | They encode hard-won ResQ GraphQL knowledge; rewriting risks regressions for no benefit. |
+| D10 | **Build order: P1 (identity map) first**, independent of the rest. | Confirmed | Smallest change, biggest correctness payoff, and a prerequisite for P5. |
+| D11 | **ResQ auth failures become loud** (write `sync_events` + trigger health-alert) rather than silent. | Proposed | ResQ cookie/CSRF login is the fragile single point of failure; SF is OAuth-rotated. |
+| D12 | **Plan-first**: PRD/scoping/decisions authored before code, per the architecture-handbook convention. | Confirmed | Sky chose "write the plan first." |
+
+## Cross-repo / architecture-handbook impact (mirror to `Skilliosis_Mytosis_Architecture/ARCHITECTURE.md`)
+
+This project introduces architecture-level changes that the handbook tracks:
+
+- **New `ops.*` tables**: `ops.sync_customers`, `ops.resq_sf_links`,
+  `ops.sync_events` — add to `apbg-billing/architecture/sync-manifest.json`
+  (the build lint will otherwise fail) and to ARCHITECTURE.md's data inventory.
+- **New ingress**: `sf-webhook.mjs` (a new external→us webhook from Service
+  Fusion) — new env var category (`SF_WEBHOOK_SECRET` or reuse
+  `INBOUND_EMAIL_SECRET`).
+- **New cross-repo dependency**: `apbg-billing` reuses `brix-order`'s SF
+  attachment mechanism (`sf-job-attachments` bucket, `orders.sf_portal_session`,
+  the public-S3 resolver) — candidate to promote to a shared lib.
+- **New cross-tool dependency**: SF sync now writes into the **Brixpense**
+  approval queue (`ops.expense_requests`).
+
+> ⚠ The architecture repo was **not in this session's GitHub scope**, so
+> ARCHITECTURE.md was not updated automatically. Apply the change log row
+> manually (or via the ASM MCP) when this plan is approved.

--- a/architecture/projects/resq-sf-sync-v2/scoping.md
+++ b/architecture/projects/resq-sf-sync-v2/scoping.md
@@ -1,0 +1,195 @@
+# ResQ ↔ SF Sync v2 — Scoping & Technical Design
+
+> Companion to PRD.md. Status: **DRAFT for review**.
+
+## 1. Current-state teardown (v1)
+
+All in `apbg-billing` unless noted.
+
+| Piece | File | Notes |
+|---|---|---|
+| Cron trigger | `netlify/functions/resq-sf-sync-cron.mjs` | Fires the background worker every 5 min. |
+| Worker | `netlify/functions/resq-sf-sync-background.mjs` (~1,240 lines) | Poll-and-diff both directions. |
+| Diagnostics/lookup | `netlify/functions/resq-sf-sync.mjs` | WO lookup + SF photo-download probing (`handleSfPhotos`). |
+| ResQ auth/GQL | `netlify/functions/resq-helpers.mjs` | Username/password + CSRF cookie scrape. No rotation. |
+| SF auth/REST | `netlify/functions/sf-helpers.mjs` | OAuth2 w/ refresh rotation (good). |
+| Expense→bill | `netlify/functions/expense-to-bill.mjs` | Manual button: Claude OCR → QBO bill. |
+| Operator console | `public/sync.html` | Table + manual photo-upload + manual bill widgets. |
+| State | Netlify Blob `wo-mapping` (store `resq-sf-sync`) | One JSON object; per-WO read-modify-write under `sync-lock`. |
+
+### What works and must be preserved
+
+- **ResQ→SF job create + dedup**: `processNewWO`, `findSfJobsByPoNumber`,
+  `pickBestSfJob`, `isSfProgressed/Unscheduled/Cancelled`, `cancelSfJob`.
+  po_number = ResQ code (`R#####`) is the join key.
+- **SF→ResQ status + visit completion**: `syncBidirectional`,
+  `provideUpdateToResq` (startVisit / endVisit / captureVisitNotes fallbacks).
+- **SF→ResQ invoice**: `buildAndSubmitInvoice` — the 5-mutation flow
+  (createRecordOfWork → saveRecordOfWork → submitRecordOfWork →
+  createOriginalVendorInvoice → createUpdatePayoutOffer). This is the crown
+  jewel; migrate, don't rewrite.
+
+### Concrete defects / debt found while reading
+
+1. **Identity drift across files.** `SF_CUSTOMERS`/`FACILITY_MAP` in the worker
+   vs `RESQ_CUSTOMER_MAP` in `expense-to-bill.mjs` disagree on the Starbird
+   name (`STARBIRD CHICKEN: RESQ` vs `STARBIRD CHICKEN RESQ`). Three namespaces
+   (ResQ facility kw, SF customer name, QBO customer name) maintained by hand.
+2. **Photo transfer is a stub.** `transferSfPhotosToResq` only flags for manual
+   upload. Its comment ("SF API does not expose file download endpoints. S3
+   bucket is private") is **stale** — disproven by `brix-order` (see §4).
+3. **Photo ordering bug.** ResQ attaches images at visit completion
+   (`endVisit`/`captureVisitNotes` take `images: []`). v1 completes the visit
+   with `images: []` and sets `visitCompleted`, then *later* tries to push
+   photos and can't. v2 must fetch photos **before** ending the visit.
+4. **Two AP paths.** `expense-to-bill.mjs` and Brixpense's
+   `expense-request-link-bill.mjs` both create QBO bills with different account
+   logic. v2 converges on one.
+5. **Vendor eligibility short-circuit** (fixed in PR #124): `vendor?.name ||
+   executingVendor?.name` dropped WOs where Brix is the executing (not primary)
+   vendor.
+6. **State scalability**: full 500-WO scan every 5 min; N SF GETs per WO;
+   blob rewrite per WO. Doesn't scale and isn't queryable.
+
+## 2. Target architecture
+
+```
+   SF webhook (job/expense changed)            ResQ poll (cursor: raisedOn/updatedAt high-water)
+            │                                              │
+            ▼                                              ▼
+   sf-webhook.mjs  ──────────┐              resq-sf-sync-background.mjs (reconciler + ResQ→SF)
+            │                │                             │
+            ▼                ▼                             ▼
+   ┌──────────────────────────  ops.* (system of record)  ───────────────────────────┐
+   │  ops.sync_customers   one identity map: resq_facility_kw | sf_customer_name |     │
+   │                       qbo_customer_name | qbo_cogs_account_id | entity            │
+   │  ops.resq_sf_links    resq_wo_id, resq_code, sf_job_id, statuses, flags,          │
+   │                       qbo_bill_id, brixpense_request_id, timestamps               │
+   │  ops.sync_events      append-only audit (actor, action, payload, ts)             │
+   │  ops.sync_log         existing — keep feeding it (APBG-OPS reads it)             │
+   └───────┬───────────────────┬────────────────────────┬──────────────────────────┘
+           ▼                   ▼                         ▼
+   status push (both)    photos: SF→Supabase        expense → QBO bill (auto)
+                         Storage → ResQ visit       → ops.expense_requests row
+                                                    → Brixpense PAYMENT approval
+```
+
+### 2.1 Data model (new `ops.*` tables — must be added to `architecture/sync-manifest.json`)
+
+- **`ops.sync_customers`** — the single identity map.
+  `id, resq_facility_keywords text[], sf_customer_name text, qbo_customer_name
+  text, qbo_customer_id text, qbo_cogs_account_id text, entity text, active bool`.
+  Seeded from today's literals (reconciled to the *real* SF/QBO names).
+  Read by the worker, `expense-to-bill`, and `sync.html`. **Kills defect #1.**
+- **`ops.resq_sf_links`** — replaces the `wo-mapping` blob.
+  `resq_wo_id (uniq), resq_code, sf_job_id, sf_customer_id→sync_customers,
+  resq_status, sf_status, flags (visit_completed, photos_synced,
+  invoice_submitted, sf_deleted), qbo_bill_id, brixpense_request_id,
+  reconciled bool, created_at, last_sync_at`. PK/uniq lookups replace the
+  3-page SF scan and the full-object rewrite.
+- **`ops.sync_events`** — append-only `{link_id, direction, action, ok,
+  message, payload jsonb, created_at}`. Powers the dashboard review queue and
+  debugging (replaces the dedupe-report blob + log blob).
+
+RLS: anon SELECT (dashboard reads), service-role writes — same posture as the
+rest of `ops.*` (see APBG-OPS migration `0009_rls_lockdown.sql`).
+
+### 2.2 Ingress
+
+- **SF → ResQ: webhook.** New `sf-webhook.mjs` receiver. SF fires on job
+  status change / job updated / (if available) expense added. Verify a shared
+  secret (reuse the `INBOUND_EMAIL_SECRET` pattern). Look up the `resq_sf_links`
+  row by `sf_job_id`, run only the handlers that apply (status push, photo
+  sync, expense→bill). Near-real-time; no scan.
+  - *If SF webhook coverage is insufficient* for some event types, the cron
+    reconciler (below) still catches them within 5 min.
+- **ResQ → SF: cursor poll.** Keep the cron, but (a) track a high-water mark
+  (max `raisedOn`/`updatedAt` processed) so we only diff changed WOs, and (b)
+  resolve existing links by PK instead of scanning SF. The cron also becomes
+  the **reconciler/safety-net** for anything the SF webhook missed.
+
+### 2.3 Photo pipeline (replaces the stub)
+
+Reuse the **proven `brix-order` mechanism** (see §4):
+1. `GET /jobs/:id?expand=pictures,signatures`.
+2. For each non-private picture, resolve `file_location` →
+   `servicefusion.s3.amazonaws.com/images/estimates/<file>` (signatures:
+   `images/sign/<file>`); honor full URLs verbatim.
+3. Anonymous GET the bytes (public-read S3). **Fallback**: the cookie-replay
+   proxy (`get-sf-job-asset.ts` pattern, cookies in `orders.sf_portal_session`)
+   for anything that 401s/returns HTML.
+4. Mirror into Supabase Storage (reuse `sf-job-attachments` bucket +
+   `sf_job_attachments` table that `brix-order` already created), for audit +
+   dedup.
+5. **Push into ResQ on visit completion** — fetch photos *first*, then call
+   `endVisit` with `images: [...]` (fixes defect #3). If a post-completion
+   attach mutation exists in ResQ's schema, use it for late-arriving photos.
+
+### 2.4 Expense → QBO bill → Brixpense (auto)
+
+On SF expense (webhook or job completion):
+1. Pull the expense + receipt image from SF.
+2. OCR via the existing Claude flow in `expense-to-bill.mjs` (extract vendor,
+   lines, amounts, category).
+3. Resolve vendor (QBO), customer + COGS account from `ops.sync_customers`.
+4. **Create the QBO bill** with a hard idempotency key
+   (`sf_expense_id` / `sf_job_id`+line hash) to prevent duplicates; attach the
+   receipt; store `qbo_bill_id` on the link.
+5. **Write an `ops.expense_requests`-compatible row** so the bill appears in
+   the **Brixpense** queue as a payment to approve. Reuse Brixpense's existing
+   approval model + `expense-request-link-bill` rather than a second path
+   (converges defect #4). Automation = AP capture; Brixpense = payment gate.
+
+Decision: **auto-create the bill, gate the payment in Brixpense** (per PRD).
+
+### 2.5 Auth hardening
+
+- Wrap `resqLogin` with ret/alerting: on failure, write a `sync_events` row +
+  fire the existing health-alert path (APBG-OPS `health-alert` / billing
+  `health-watchdog`). ResQ is the fragile dependency; make its failure loud.
+
+## 3. Migration plan (incremental, each phase ships independently)
+
+| Phase | Deliverable | Risk |
+|---|---|---|
+| **P1** | `ops.sync_customers` + read it from both files. Reconcile names to the real SF/QBO records. | Low. Pure win; kills name drift. |
+| **P2** | `ops.resq_sf_links` + `ops.sync_events`. Dual-write (blob + tables), then cut reads over, then drop the blob. | Med. Data migration of the existing blob. |
+| **P3** | `sf-webhook.mjs` receiver; cron demoted to reconciler + cursor. | Med. Needs SF webhook config + secret. |
+| **P4** | Real photo pipeline (S3-first + cookie fallback), reorder visit completion. | Med. Depends on `brix-order` mechanism holding. |
+| **P5** | Auto expense→QBO bill→Brixpense payment queue. | High. Money path — idempotency + Brixpense gate are mandatory. |
+| **P6** | Retire manual widgets in `sync.html`; point dashboard at `ops.*`. | Low. Cleanup. |
+
+P1 is the recommended first build regardless — it's the smallest change with
+the biggest correctness payoff and it's a prerequisite for P5.
+
+## 4. Proven prior art (`brix-order`)
+
+- `netlify/functions/_lib/sf-attachment-sync.ts` — `resolveSfAssetUrl` +
+  `fetchSfAssetBytes` + `syncJobAttachments`: the **public-S3 download** that
+  disproves v1's "S3 is private" comment. Already runs on a daily schedule and
+  on-demand. Mirrors to Supabase Storage `sf-job-attachments` + table
+  `orders.sf_job_attachments`, with a paid-invoice purge (`purgePaidAttachments`).
+- `netlify/functions/get-sf-job-asset.ts` + `orders.sf_portal_session` — the
+  **cookie-replay proxy** fallback (host-aware "Bearer *or* Cookie, never both").
+- `_lib/sf.ts` — SF OAuth (Consumer creds). Mirrors `apbg-billing/sf-helpers.mjs`.
+
+Net: the hardest unknown (getting bytes out of SF) is already solved. v2
+should lift this pattern, not reinvent it. Consider promoting it to a shared
+lib if both repos keep using it.
+
+## 5. Open questions
+
+1. **SF webhooks**: which event types does our SF plan expose (job status,
+   job updated, expense added)? Determines how much of P3 is webhook vs
+   reconciler.
+2. **Brixpense intake shape**: do we insert directly into `ops.expense_requests`
+   or call a new `expense-request-from-sf` endpoint? (Prefer an endpoint so RLS
+   + validation + sync-manifest stay centralized.)
+3. **COGS mapping for SF expenses**: use `ops.sync_customers.qbo_cogs_account_id`
+   per customer, or keep the category→account map (equipment/service)? Likely
+   both: category first, customer default as fallback.
+4. **Photo retention**: adopt `brix-order`'s purge-when-paid, or keep SF photos
+   in ResQ only and treat Supabase Storage as a transient staging copy?
+5. **Cross-repo home**: do these `ops.*` tables + the attachment lib live in
+   `apbg-billing`, or get promoted to a shared sync package? (Affects
+   `sync-manifest.json` ownership.)

--- a/architecture/schema-snapshot.json
+++ b/architecture/schema-snapshot.json
@@ -74,6 +74,7 @@
     "sf_token_cache",
     "staff",
     "staff_roles",
+    "sync_customers",
     "sync_log",
     "team_members",
     "third_party_crews"

--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -297,6 +297,18 @@
       ],
       "notes": "Mirrors QBO-direct PurchaseOrders into shadow tables so the inventory On Order column (fn_items_master.on_order CTE) counts POs that were never created through BRIX. Per-PO picker modal in app/src/pages/production/QboPosPickerModal.tsx. Bearer-only auth (any logged-in @brixbev.com employee can preview + import). Upserts headers by qbo_id; lines are replaced wholesale on each import. De-dup with ops.purchase_orders.qbo_purchase_order_id so a BRIX-native PO pushed to QBO isn't counted twice. Migration: 20260516b_qbo_purchase_orders_shadow.sql.",
       "last_verified": "2026-05-16"
+    },
+    {
+      "name": "sync-customers",
+      "kind": "netlify-function",
+      "source_repo": "skypace/apbg-billing",
+      "schedule": "on-demand (operator manages linked customers in the sync.html Settings section)",
+      "writes": [
+        "ops.sync_customers"
+      ],
+      "external_inputs": ["QuickBooks Online API: Customer (discovers RESQ-named candidates)"],
+      "notes": "Phase 1 of resq-sf-sync v2. Single identity map for RESQ-linked customers (ResQ facility <-> SF customer <-> QBO customer). Replaces the drifted string literals in resq-sf-sync-background.mjs (SF_CUSTOMERS/FACILITY_MAP) and expense-to-bill.mjs (RESQ_CUSTOMER_MAP). requireAuth superadmin; writes via service-role. Seeded by migration 20260602a_sync_customers.sql with the two live RESQ customers (THE MELT RESQ 1944, STARBIRD CHICKEN RESQ 1945). Read at runtime by resq-sf-sync-background and expense-to-bill via netlify/functions/lib/sync-customers.mjs.",
+      "last_verified": "2026-06-02"
     }
   ],
 

--- a/netlify/functions/expense-to-bill.mjs
+++ b/netlify/functions/expense-to-bill.mjs
@@ -12,6 +12,7 @@
 import { sfRequest } from './sf-helpers.mjs';
 import { qboRequest, qboQuery, corsHeaders } from './qbo-helpers.mjs';
 import { requireAuth } from './lib/auth.mjs';
+import { loadSyncCustomers, classifySyncCustomer } from './lib/sync-customers.mjs';
 
 const ACCOUNT_MAP = {
   equipment: { id: '42', name: 'Equipment Sales COGS' },
@@ -19,14 +20,11 @@ const ACCOUNT_MAP = {
 };
 const DEFAULT_ACCOUNT = ACCOUNT_MAP.service;
 
-// QBO customer name to attach to bills coming from each ResQ facility.
-// Only facilities listed here trigger the customer attachment; bills for
-// other facilities (e.g. Brix warehouse) are still created but without
-// a CustomerRef, matching pre-feature behavior.
-const RESQ_CUSTOMER_MAP = {
-  starbird: 'STARBIRD CHICKEN RESQ',
-  melt:     'THE MELT RESQ',
-};
+// The ResQ-facility ↔ QBO-customer mapping is no longer hardcoded here — it
+// lives in ops.sync_customers (single source of truth, managed in sync.html →
+// Settings). Bills for facilities that match a linked customer get a
+// CustomerRef (using the row's qbo_customer_id directly — no fuzzy name
+// lookup); bills for anything else are still created without one.
 
 export async function handler(event) {
   if (event.httpMethod === 'OPTIONS') {
@@ -336,13 +334,21 @@ async function findQBOVendor(name) {
 }
 
 // ── Resolve which ResQ customer a bill belongs to ──
-// Strategy: look up the wo-mapping blob first (most reliable — it stores
-// the customer key set by classifyFacility). Fall back to inspecting the
-// SF job's customer_name.
+// Uses the ops.sync_customers identity map (single source of truth). We resolve
+// to a linked customer via, in order:
+//   1. the wo-mapping blob (customerQboId, set by the sync worker) — exact id;
+//   2. the wo-mapping blob's facility / legacy customer keyword — classify;
+//   3. the SF job's customer_name — match against linked names/keywords.
+// Because the map stores qbo_customer_id, we build the CustomerRef directly —
+// no fuzzy QBO name search.
 async function resolveResqCustomer({ sfJobId, resqCode }) {
-  let key = null;
+  const customers = await loadSyncCustomers().catch(() => []);
+  const byId = (id) => customers.find(c => String(c.qbo_customer_id) === String(id));
 
-  // 1. wo-mapping blob keyed by ResQ code
+  let cust = null;
+  let facilityHint = null;
+
+  // 1 + 2. wo-mapping blob keyed by ResQ code
   if (resqCode) {
     try {
       const { getStore } = await import('@netlify/blobs');
@@ -355,57 +361,44 @@ async function resolveResqCustomer({ sfJobId, resqCode }) {
       if (raw) {
         const mapping = JSON.parse(raw);
         for (const v of Object.values(mapping)) {
-          if (v.resqCode === resqCode && v.customer) { key = v.customer; break; }
+          if (v.resqCode !== resqCode) continue;
+          facilityHint = v.facility || null;
+          if (v.customerQboId) cust = byId(v.customerQboId);
+          if (!cust && v.facility) cust = classifySyncCustomer(v.facility, customers);
+          // legacy: v.customer was a facility keyword ('starbird'/'melt')
+          if (!cust && v.customer) cust = classifySyncCustomer(String(v.customer), customers);
+          break;
         }
       }
     } catch (e) { /* fall through */ }
   }
 
-  // 2. Inspect the SF job's customer_name
-  if (!key && sfJobId) {
+  // 3. Inspect the SF job's customer_name + match against linked customers
+  if (!cust && sfJobId) {
     try {
       const sfJob = await sfRequest('GET', `/jobs/${sfJobId}`);
       const sfName = (sfJob.customer_name || '').toLowerCase();
-      if (sfName.includes('starbird') || sfName.includes('star bird')) key = 'starbird';
-      else if (sfName.includes('melt') || sfName.includes('homeroom')) key = 'melt';
-      else if (sfName.includes('brix')) key = 'brix';
+      cust = customers.find(c => {
+        const names = [c.qbo_customer_name, c.sf_customer_name].filter(Boolean).map(n => n.toLowerCase());
+        if (names.some(n => sfName.includes(n) || n.includes(sfName))) return true;
+        return (c.resq_facility_keywords || []).some(k => k && sfName.includes(String(k).toLowerCase()));
+      }) || null;
     } catch (e) { /* fall through */ }
   }
 
-  // Facility not in the auto-attach list (or unknown) — return a "no attachment"
-  // result. The handler will create the bill without a CustomerRef.
-  if (!key || !RESQ_CUSTOMER_MAP[key]) {
-    return { key, qboName: null, qboCustomer: null };
+  if (!cust) {
+    // No linked customer — create the bill without a CustomerRef (as before).
+    return { key: null, qboName: null, qboCustomer: null, facilityHint };
   }
 
-  const qboName = RESQ_CUSTOMER_MAP[key];
-  const qboCustomer = await findQBOCustomer(qboName);
-  return { key, qboName, qboCustomer };
-}
-
-// ── Find QBO customer by exact DisplayName, then fuzzy fallback ──
-async function findQBOCustomer(name) {
-  if (!name) return null;
-  // Exact match first (fast path)
-  try {
-    const exact = await qboQuery(`SELECT * FROM Customer WHERE DisplayName = '${name.replace(/'/g, "\\'")}'`);
-    const customers = exact.QueryResponse?.Customer || [];
-    if (customers.length > 0) return customers[0];
-  } catch (e) {}
-  // Fuzzy: try the most distinctive word (skip "RESQ", "THE", short words)
-  try {
-    const words = name.split(/[\s:]+/).filter(w => w.length > 2 && !/^(resq|the)$/i.test(w));
-    for (const word of words) {
-      const clean = word.replace(/[^a-zA-Z0-9]/g, '');
-      if (!clean) continue;
-      const like = await qboQuery(`SELECT * FROM Customer WHERE DisplayName LIKE '%${clean}%'`);
-      const customers = like.QueryResponse?.Customer || [];
-      // Only return if it's the resq variant (must contain RESQ)
-      const resqMatch = customers.find(c => /resq/i.test(c.DisplayName || ''));
-      if (resqMatch) return resqMatch;
-    }
-  } catch (e) {}
-  return null;
+  // We have the QBO id from the map — build the CustomerRef directly.
+  return {
+    key: cust.qbo_customer_id,
+    qboName: cust.qbo_customer_name,
+    qboCustomer: { Id: String(cust.qbo_customer_id), DisplayName: cust.qbo_customer_name },
+    cogsAccountId: cust.qbo_cogs_account_id || null,
+    facilityHint,
+  };
 }
 
 function round(n) { return Math.round(n * 100) / 100; }

--- a/netlify/functions/lib/sync-customers.mjs
+++ b/netlify/functions/lib/sync-customers.mjs
@@ -1,0 +1,80 @@
+// Shared loader for ops.sync_customers — the single identity map for the
+// RESQ-linked customers (ResQ facility <-> SF customer <-> QBO customer).
+//
+// Read by resq-sf-sync-background.mjs and expense-to-bill.mjs so the
+// ResQ-facility / SF-customer / QBO-customer names live in ONE place instead
+// of drifting across hardcoded literals. Managed via the sync-customers
+// Netlify function + the Settings section in sync.html.
+//
+// Reads use the public anon key (RLS allows SELECT). Writes happen only in
+// the sync-customers endpoint via the service-role key.
+
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from '../supabase-helpers.mjs';
+
+// Defensive fallback used ONLY if the DB read fails or returns nothing, so a
+// transient Supabase blip can't silently halt the whole sync. Mirrors the two
+// live rows seeded by migration 20260602a_sync_customers.sql.
+const FALLBACK = [
+  { qbo_customer_id: '1944', qbo_customer_name: 'THE MELT RESQ', sf_customer_name: 'THE MELT RESQ', resq_facility_keywords: ['melt', 'homeroom'], qbo_cogs_account_id: null, entity: null, linked: true },
+  { qbo_customer_id: '1945', qbo_customer_name: 'STARBIRD CHICKEN RESQ', sf_customer_name: 'STARBIRD CHICKEN RESQ', resq_facility_keywords: ['starbird', 'star bird'], qbo_cogs_account_id: null, entity: null, linked: true },
+];
+
+/**
+ * Load sync-customer rows. By default only linked rows (active in the sync).
+ * Returns the FALLBACK list if the read fails or is empty so the sync degrades
+ * to the known-good two customers rather than syncing nothing.
+ */
+export async function loadSyncCustomers({ includeUnlinked = false } = {}) {
+  const url =
+    `${SUPABASE_URL}/rest/v1/sync_customers?select=*&order=qbo_customer_name.asc` +
+    (includeUnlinked ? '' : '&linked=eq.true');
+  try {
+    const res = await fetch(url, {
+      headers: {
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+        'Accept-Profile': 'ops',
+      },
+    });
+    if (!res.ok) throw new Error(`sync_customers read ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const rows = await res.json();
+    if (Array.isArray(rows) && rows.length) return rows;
+    // Empty table — fall back so the sync keeps working on first deploy.
+    return includeUnlinked ? rows : FALLBACK;
+  } catch (e) {
+    console.warn('[sync-customers] read failed, using fallback:', e.message);
+    return includeUnlinked ? [] : FALLBACK;
+  }
+}
+
+/**
+ * Classify a ResQ facility name to a linked customer row, or null if none
+ * of the linked customers' facility keywords match.
+ */
+export function classifySyncCustomer(facilityName, customers) {
+  const f = (facilityName || '').toLowerCase();
+  if (!f) return null;
+  for (const c of customers) {
+    const kws = c.resq_facility_keywords || [];
+    if (kws.some((k) => k && f.includes(String(k).toLowerCase()))) return c;
+  }
+  return null;
+}
+
+/** Union of every linked customer's facility keywords (for the WO filter). */
+export function allFacilityKeywords(customers) {
+  return customers
+    .flatMap((c) => c.resq_facility_keywords || [])
+    .map((k) => String(k || '').toLowerCase())
+    .filter(Boolean);
+}
+
+/** The SF customer name to seed resolveSfCustomerName() with for a row. */
+export function sfNameFor(customer) {
+  return customer?.sf_customer_name || customer?.qbo_customer_name || null;
+}
+
+/** A short brand stem for fuzzy SF/QBO matching (first facility keyword). */
+export function stemFor(customer) {
+  return (customer?.resq_facility_keywords || [])[0] || null;
+}

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -221,7 +221,7 @@ async function processNewWO(wo, mapping, sfCustomerNames) {
   const result = { steps: [], errors: [], created: 0, report: [] };
   const sfCustomerKey = classifyFacility(wo.facility);
   if (!sfCustomerKey) {
-    result.steps.push(`Skip ${wo.code}: "${wo.facility}" not Starbird/Melt`);
+    result.steps.push(`Skip ${wo.code}: "${wo.facility}" not Starbird/Melt/Brix`);
     return result;
   }
 
@@ -302,7 +302,19 @@ async function processNewWO(wo, mapping, sfCustomerNames) {
 
   // Create new SF job
   try {
-    const sfJob = await createSfJob(wo, customerName);
+    // Resolve the configured SF customer name against a real SF customer record
+    // BEFORE creating. SF's POST /jobs requires customer_name to match exactly;
+    // a punctuation/spacing drift (e.g. "STARBIRD CHICKEN: RESQ" vs the actual
+    // record) makes every create throw and the WO never maps — ResQ then drifts
+    // away from SF. Self-heal small mismatches; otherwise fail loudly so the
+    // operator can correct the SF record / SF_CUSTOMERS entry.
+    const resolvedName = await resolveSfCustomerName(customerName, sfCustomerKey);
+    if (!resolvedName) {
+      result.errors.push(`SF customer not found for ${wo.code}: configured "${customerName}" (${sfCustomerKey}) matched no SF customer. Fix the SF customer record name or SF_CUSTOMERS.`);
+      result.report?.push({ resqCode: wo.code, reason: 'sf_customer_not_found', message: `No SF customer matches "${customerName}" (stem "${sfCustomerKey}").`, facility: wo.facility });
+      return result;
+    }
+    const sfJob = await createSfJob(wo, resolvedName);
 
     // Determine initial SF status based on ResQ status
     const resqStatus = (wo.status || '').toUpperCase();
@@ -513,7 +525,12 @@ async function fetchSyncableWOs(session) {
 
   return (data.data?.workOrders?.edges || [])
     .filter(e => {
-      const v = (e.node.vendor?.name || e.node.executingVendor?.name || '').toLowerCase();
+      // Brix can sit in EITHER the primary vendor slot or the executing-vendor
+      // slot. Starbird WOs are frequently held by a property-management vendor
+      // and dispatched to Brix as executingVendor — the old `||` short-circuit
+      // only checked executingVendor when vendor was absent, so those WOs were
+      // silently dropped and ResQ drifted out of sync with SF. Check both.
+      const v = `${e.node.vendor?.name || ''} ${e.node.executingVendor?.name || ''}`.toLowerCase();
       if (!BRIX_VENDOR_KEYWORDS.some(k => v.includes(k))) return false;
       const f = (e.node.facility?.name || '').toLowerCase();
       return FACILITY_MAP.some(fm => fm.keywords.some(k => f.includes(k)));
@@ -629,6 +646,41 @@ async function cancelSfJob(jobId) {
   } catch (e) {
     return { ok: false, error: (e.message || '').substring(0, 200) };
   }
+}
+
+// Resolve the configured SF customer name to a real SF customer record name.
+// Returns the exact SF `customer_name` to use, or null when no confident match
+// exists (caller then fails loudly instead of creating a job SF will reject).
+//   1. Exact match (case/whitespace-insensitive) on the configured name.
+//   2. Stem search — exactly one RESQ sync customer containing the brand stem
+//      (e.g. "starbird") self-heals punctuation/spacing drift.
+// Conservative on purpose: never guesses between multiple candidates.
+async function resolveSfCustomerName(configuredName, stem) {
+  const want = String(configuredName || '').trim().toLowerCase();
+  if (!want) return null;
+
+  // 1. Exact (case/space-insensitive) match on the configured name.
+  try {
+    const res = await sfRequest('GET', `/customers?filters[customer_name]=${encodeURIComponent(configuredName)}&per-page=25`);
+    const items = res.items || res.data || [];
+    const exact = items.find(c => String(c.customer_name || '').trim().toLowerCase() === want);
+    if (exact) return exact.customer_name;
+  } catch (e) { /* fall through to stem search */ }
+
+  // 2. Stem search — find the single RESQ sync customer for this brand.
+  const s = String(stem || '').trim().toLowerCase();
+  if (s) {
+    try {
+      const res = await sfRequest('GET', `/customers?filters[customer_name]=${encodeURIComponent(stem)}&per-page=50`);
+      const items = res.items || res.data || [];
+      const resq = items.filter(c => {
+        const n = String(c.customer_name || '').toLowerCase();
+        return n.includes(s) && n.includes('resq');
+      });
+      if (resq.length === 1) return resq[0].customer_name;
+    } catch (e) { /* fall through */ }
+  }
+  return null;
 }
 
 // --- SF Helpers ---

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -18,20 +18,13 @@
 import { resqLogin, resqGql } from './resq-helpers.mjs';
 import { sfRequest } from './sf-helpers.mjs';
 import { requireAuth } from './lib/auth.mjs';
+import { loadSyncCustomers, classifySyncCustomer, allFacilityKeywords, sfNameFor, stemFor } from './lib/sync-customers.mjs';
 
 const BRIX_VENDOR_KEYWORDS = ['brix'];
 
-const SF_CUSTOMERS = {
-  starbird: { name: 'STARBIRD CHICKEN: RESQ' },
-  melt: { name: 'THE MELT RESQ' },
-  brix: { name: 'BRIX BEVERAGE: RESQ' },
-};
-
-const FACILITY_MAP = [
-  { keywords: ['starbird', 'star bird'], sfCustomer: 'starbird' },
-  { keywords: ['melt', 'homeroom'], sfCustomer: 'melt' },
-  { keywords: ['brix', 'equipment storage'], sfCustomer: 'brix' },
-];
+// Customer identity (ResQ facility <-> SF customer <-> QBO customer) now lives
+// in ops.sync_customers, loaded once per run and threaded through the worker.
+// See netlify/functions/lib/sync-customers.mjs + migration 20260602a.
 
 // ResQ statuses that mean "done" — don't create new SF jobs for these
 const RESQ_DONE_STATUSES = ['AWAITING_PAYMENT', 'CLOSED', 'CANCELLED'];
@@ -90,17 +83,18 @@ export async function handler(event) {
       throw new Error('SF not connected: ' + e.message);
     }
 
-    // 3. Load mapping + fetch WOs
+    // 3. Load mapping + the linked-customer identity map + fetch WOs
     const mapping = await loadMapping();
     log.steps.push(`Loaded ${Object.keys(mapping).length} mappings`);
 
+    const syncCustomers = await loadSyncCustomers();
+    log.steps.push(`Loaded ${syncCustomers.length} linked customers: ${syncCustomers.map(c => c.qbo_customer_name).join(', ') || '(none)'}`);
+
     log.steps.push('Fetching ResQ WOs...');
     await saveProgress();
-    const resqWOs = await fetchSyncableWOs(session);
+    const resqWOs = await fetchSyncableWOs(session, syncCustomers);
     log.steps.push(`Found ${resqWOs.length} syncable WOs`);
     await saveProgress();
-
-    const sfCustomerNames = { melt: SF_CUSTOMERS.melt.name, starbird: SF_CUSTOMERS.starbird.name, brix: SF_CUSTOMERS.brix.name };
 
     // 4. Process each WO
     log.steps.push('Processing WOs...');
@@ -130,7 +124,7 @@ export async function handler(event) {
             continue;
           }
 
-          const r = await withTimeout(processNewWO(wo, mapping, sfCustomerNames), 15000, `process ${wo.code}`);
+          const r = await withTimeout(processNewWO(wo, mapping, syncCustomers), 15000, `process ${wo.code}`);
           if (r.steps.length) log.steps.push(...r.steps);
           if (r.errors.length) log.errors.push(...r.errors);
           if (r.report?.length) dedupeReport.push(...r.report);
@@ -217,17 +211,19 @@ function withTimeout(promise, ms, label) {
 }
 
 // --- Process new unmapped WO ---
-async function processNewWO(wo, mapping, sfCustomerNames) {
+async function processNewWO(wo, mapping, syncCustomers) {
   const result = { steps: [], errors: [], created: 0, report: [] };
-  const sfCustomerKey = classifyFacility(wo.facility);
-  if (!sfCustomerKey) {
-    result.steps.push(`Skip ${wo.code}: "${wo.facility}" not Starbird/Melt/Brix`);
+  const cust = classifySyncCustomer(wo.facility, syncCustomers);
+  if (!cust) {
+    const names = syncCustomers.map(c => c.qbo_customer_name).join(' / ') || 'no linked customers';
+    result.steps.push(`Skip ${wo.code}: "${wo.facility}" matches no linked customer (${names})`);
     return result;
   }
 
-  const customerName = sfCustomerNames[sfCustomerKey];
+  const sfCustomerKey = stemFor(cust) || cust.qbo_customer_id;
+  const customerName = sfNameFor(cust);
   if (!customerName) {
-    result.errors.push(`No SF customer name for "${sfCustomerKey}".`);
+    result.errors.push(`No SF/QBO customer name on linked customer ${cust.qbo_customer_id}.`);
     return result;
   }
 
@@ -261,7 +257,7 @@ async function processNewWO(wo, mapping, sfCustomerNames) {
           sfJobNumber: best.number || best.job_number || best.id,
           resqCode: wo.code, resqStatus: wo.status,
           sfStatus: best.status || 'Unscheduled',
-          facility: wo.facility, customer: sfCustomerKey, title: wo.title,
+          facility: wo.facility, customer: sfCustomerKey, customerQboId: cust.qbo_customer_id, customerName, title: wo.title,
           createdAt: new Date().toISOString(), lastSyncAt: new Date().toISOString(),
           linkedExisting: true, reconciled: true,
         };
@@ -278,7 +274,7 @@ async function processNewWO(wo, mapping, sfCustomerNames) {
         sfJobNumber: fallback.number || fallback.job_number || fallback.id,
         resqCode: wo.code, resqStatus: wo.status,
         sfStatus: fallback.status || 'Unscheduled',
-        facility: wo.facility, customer: sfCustomerKey, title: wo.title,
+        facility: wo.facility, customer: sfCustomerKey, customerQboId: cust.qbo_customer_id, customerName, title: wo.title,
         createdAt: new Date().toISOString(), lastSyncAt: new Date().toISOString(),
         linkedExisting: true, reconciled: true,
       };
@@ -307,10 +303,10 @@ async function processNewWO(wo, mapping, sfCustomerNames) {
     // a punctuation/spacing drift (e.g. "STARBIRD CHICKEN: RESQ" vs the actual
     // record) makes every create throw and the WO never maps — ResQ then drifts
     // away from SF. Self-heal small mismatches; otherwise fail loudly so the
-    // operator can correct the SF record / SF_CUSTOMERS entry.
+    // operator can correct the SF record / the ops.sync_customers row.
     const resolvedName = await resolveSfCustomerName(customerName, sfCustomerKey);
     if (!resolvedName) {
-      result.errors.push(`SF customer not found for ${wo.code}: configured "${customerName}" (${sfCustomerKey}) matched no SF customer. Fix the SF customer record name or SF_CUSTOMERS.`);
+      result.errors.push(`SF customer not found for ${wo.code}: configured "${customerName}" (${sfCustomerKey}) matched no SF customer. Fix the SF customer record name or the ops.sync_customers row (sync.html → Settings).`);
       result.report?.push({ resqCode: wo.code, reason: 'sf_customer_not_found', message: `No SF customer matches "${customerName}" (stem "${sfCustomerKey}").`, facility: wo.facility });
       return result;
     }
@@ -324,7 +320,7 @@ async function processNewWO(wo, mapping, sfCustomerNames) {
       sfJobId: sfJob.id,
       sfJobNumber: sfJob.number || sfJob.job_number || sfJob.id,
       resqCode: wo.code, resqStatus: wo.status, sfStatus: targetSfStatus,
-      facility: wo.facility, customer: sfCustomerKey, title: wo.title,
+      facility: wo.facility, customer: sfCustomerKey, customerQboId: cust.qbo_customer_id, customerName, title: wo.title,
       createdAt: new Date().toISOString(), lastSyncAt: new Date().toISOString(),
       reconciled: true,
     };
@@ -508,7 +504,8 @@ async function syncBidirectional(session, resqWO, mapEntry) {
 }
 
 // --- Fetch syncable ResQ WOs ---
-async function fetchSyncableWOs(session) {
+async function fetchSyncableWOs(session, syncCustomers) {
+  const facilityKeywords = allFacilityKeywords(syncCustomers);
   const data = await resqGql(session, `{
     workOrders(first: 500, orderBy: "-raised_on") {
       edges { node {
@@ -533,7 +530,7 @@ async function fetchSyncableWOs(session) {
       const v = `${e.node.vendor?.name || ''} ${e.node.executingVendor?.name || ''}`.toLowerCase();
       if (!BRIX_VENDOR_KEYWORDS.some(k => v.includes(k))) return false;
       const f = (e.node.facility?.name || '').toLowerCase();
-      return FACILITY_MAP.some(fm => fm.keywords.some(k => f.includes(k)));
+      return facilityKeywords.some(k => f.includes(k));
     })
     .map(e => {
       const n = e.node;
@@ -702,14 +699,6 @@ async function createSfJob(resqWO, customerName) {
     priority: resqWO.isUrgent ? 'Urgent' : 'Normal',
     po_number: resqRef,
   });
-}
-
-function classifyFacility(facilityName) {
-  const f = (facilityName || '').toLowerCase();
-  for (const fm of FACILITY_MAP) {
-    if (fm.keywords.some(k => f.includes(k))) return fm.sfCustomer;
-  }
-  return null;
 }
 
 // --- Transfer SF Photos → ResQ ---

--- a/netlify/functions/sync-customers.mjs
+++ b/netlify/functions/sync-customers.mjs
@@ -1,0 +1,132 @@
+// sync-customers — manage which customers are linked to the ResQ <-> SF sync.
+//
+// A "linked customer" is a QBO/SF customer with RESQ in its name. This endpoint
+// backs the Settings section in sync.html.
+//
+//   GET                          -> { customers: [...all rows], candidates: [...QBO RESQ customers not yet linked] }
+//   POST { action: 'link', ... } -> upsert a row (linked=true)
+//   POST { action: 'update', id, ...fields } -> patch a row
+//   POST { action: 'unlink', id }            -> soft-unlink (linked=false)
+//   POST { action: 'relink', id }            -> set linked=true
+//
+// Reads use the anon key (RLS allows SELECT). Writes use the service-role key.
+// Superadmin JWT required (requireAuth).
+
+import { qboQuery, corsHeaders } from './qbo-helpers.mjs';
+import { requireAuth } from './lib/auth.mjs';
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from './supabase-helpers.mjs';
+
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const TABLE = `${SUPABASE_URL}/rest/v1/sync_customers`;
+
+function json(body, status = 200) {
+  return { statusCode: status, headers: { ...corsHeaders(), 'Content-Type': 'application/json' }, body: JSON.stringify(body) };
+}
+
+// --- Supabase REST (ops schema) ---
+async function sbRead() {
+  const res = await fetch(`${TABLE}?select=*&order=qbo_customer_name.asc`, {
+    headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${SUPABASE_ANON_KEY}`, 'Accept-Profile': 'ops' },
+  });
+  if (!res.ok) throw new Error(`read ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  return res.json();
+}
+
+async function sbWrite(method, body, query = '') {
+  if (!SERVICE_KEY) throw new Error('SUPABASE_SERVICE_ROLE_KEY not configured');
+  const res = await fetch(`${TABLE}${query}`, {
+    method,
+    headers: {
+      apikey: SERVICE_KEY,
+      Authorization: `Bearer ${SERVICE_KEY}`,
+      'Content-Type': 'application/json',
+      'Accept-Profile': 'ops',
+      'Content-Profile': 'ops',
+      Prefer: 'return=representation,resolution=merge-duplicates',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw new Error(`${method} ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const text = await res.text();
+  return text ? JSON.parse(text) : null;
+}
+
+// Normalize an incoming keyword list to lowercase, trimmed, de-duped.
+function normKeywords(v) {
+  if (Array.isArray(v)) return [...new Set(v.map((k) => String(k || '').trim().toLowerCase()).filter(Boolean))];
+  if (typeof v === 'string') return normKeywords(v.split(','));
+  return [];
+}
+
+export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: corsHeaders(), body: '' };
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
+  try {
+    if (event.httpMethod === 'GET') {
+      const customers = await sbRead();
+      const known = new Set(customers.map((c) => String(c.qbo_customer_id)));
+      // Discover QBO customers with RESQ in the name that aren't linked yet.
+      let candidates = [];
+      try {
+        const q = await qboQuery("SELECT Id, DisplayName FROM Customer WHERE DisplayName LIKE '%RESQ%' MAXRESULTS 100");
+        candidates = (q.QueryResponse?.Customer || [])
+          .map((c) => ({ qbo_customer_id: String(c.Id), qbo_customer_name: c.DisplayName }))
+          .filter((c) => !known.has(c.qbo_customer_id));
+      } catch (e) {
+        // Candidate discovery is best-effort — the linked list still renders.
+        return json({ customers, candidates: [], candidatesError: e.message.slice(0, 200) });
+      }
+      return json({ customers, candidates });
+    }
+
+    if (event.httpMethod !== 'POST') return json({ error: 'GET or POST only' }, 405);
+
+    const body = JSON.parse(event.body || '{}');
+    const action = body.action;
+
+    if (action === 'link') {
+      if (!body.qbo_customer_id || !body.qbo_customer_name) return json({ error: 'qbo_customer_id and qbo_customer_name required' }, 400);
+      const row = {
+        qbo_customer_id: String(body.qbo_customer_id),
+        qbo_customer_name: body.qbo_customer_name,
+        sf_customer_name: body.sf_customer_name || body.qbo_customer_name,
+        resq_facility_keywords: normKeywords(body.resq_facility_keywords),
+        qbo_cogs_account_id: body.qbo_cogs_account_id || null,
+        entity: body.entity || null,
+        linked: true,
+        notes: body.notes || null,
+      };
+      const result = await sbWrite('POST', [row], '?on_conflict=qbo_customer_id');
+      return json({ ok: true, customer: Array.isArray(result) ? result[0] : result });
+    }
+
+    if (action === 'update') {
+      if (!body.id) return json({ error: 'id required' }, 400);
+      const patch = {};
+      if (body.qbo_customer_name !== undefined) patch.qbo_customer_name = body.qbo_customer_name;
+      if (body.sf_customer_name !== undefined) patch.sf_customer_name = body.sf_customer_name || null;
+      if (body.resq_facility_keywords !== undefined) patch.resq_facility_keywords = normKeywords(body.resq_facility_keywords);
+      if (body.qbo_cogs_account_id !== undefined) patch.qbo_cogs_account_id = body.qbo_cogs_account_id || null;
+      if (body.entity !== undefined) patch.entity = body.entity || null;
+      if (body.notes !== undefined) patch.notes = body.notes || null;
+      if (body.linked !== undefined) patch.linked = !!body.linked;
+      if (Object.keys(patch).length === 0) return json({ error: 'no fields to update' }, 400);
+      const result = await sbWrite('PATCH', patch, `?id=eq.${encodeURIComponent(body.id)}`);
+      return json({ ok: true, customer: Array.isArray(result) ? result[0] : result });
+    }
+
+    if (action === 'unlink' || action === 'relink') {
+      if (!body.id) return json({ error: 'id required' }, 400);
+      const result = await sbWrite('PATCH', { linked: action === 'relink' }, `?id=eq.${encodeURIComponent(body.id)}`);
+      return json({ ok: true, customer: Array.isArray(result) ? result[0] : result });
+    }
+
+    return json({ error: `unknown action "${action}"` }, 400);
+  } catch (e) {
+    console.error('sync-customers error:', e);
+    return json({ error: e.message }, 500);
+  }
+}

--- a/public/sync.html
+++ b/public/sync.html
@@ -214,6 +214,12 @@ td a:hover,.review-head .code a:hover,.review-job .meta a:hover{color:#2E75B6;bo
       <button class="secondary" id="clearErrBtn" onclick="clearErrors()">🧹 Clear Errors</button>
     </div>
 
+    <!-- Linked Customers (Settings) -->
+    <div class="section" id="settingsSection">
+      <h2>⚙️ Linked Customers <span style="font-weight:400;font-size:0.75rem;color:#9CA3AF">— customers with “RESQ” in the name that sync to Service Fusion</span></h2>
+      <div id="syncCustomersBox" style="padding:16px 20px"><div class="empty">Loading…</div></div>
+    </div>
+
     <!-- Mapping Table -->
     <div class="section">
       <h2>Work Order Mappings</h2>
@@ -293,7 +299,77 @@ APBG.auth.requireSuperadmin().then(() => {
   document.getElementById('authLoading').style.display = 'none';
   document.getElementById('mainApp').style.display = 'block';
   loadStatus();
+  loadSyncCustomers();
 });
+
+function esc(s){ return String(s==null?'':s).replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+
+// --- Linked Customers (Settings) ---
+async function loadSyncCustomers() {
+  const box = document.getElementById('syncCustomersBox');
+  try {
+    const res = await fetch(`${API_BASE}/sync-customers`);
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || res.status);
+    renderSyncCustomers(data);
+  } catch (e) {
+    box.innerHTML = `<div class="upload-result err" style="display:block">Failed to load linked customers: ${esc(e.message)}</div>`;
+  }
+}
+
+function renderSyncCustomers(data) {
+  const box = document.getElementById('syncCustomersBox');
+  const rows = (data.customers || []).map(c => {
+    const kws = (c.resq_facility_keywords || []).join(', ');
+    const badge = c.linked
+      ? '<span class="badge" style="background:#D1FAE5;color:#065F46">Linked</span>'
+      : '<span class="badge" style="background:#F3F4F6;color:#6B7280">Off</span>';
+    const toggle = c.linked
+      ? `<button class="clear-btn" onclick="setLinked(${c.id},false)">Unlink</button>`
+      : `<button class="upload-btn" onclick="setLinked(${c.id},true)">Re-link</button>`;
+    return `<tr>
+      <td style="padding:6px 8px"><strong>${esc(c.qbo_customer_name)}</strong><div style="color:#9CA3AF;font-size:0.72rem">QBO #${esc(c.qbo_customer_id)}</div></td>
+      <td style="padding:6px 8px;font-size:0.8rem">${esc(c.sf_customer_name || c.qbo_customer_name)}</td>
+      <td style="padding:6px 8px"><input value="${esc(kws)}" onchange="saveKeywords(${c.id}, this.value)" placeholder="facility keywords, comma-separated" style="width:100%;font-size:0.8rem;padding:4px 6px;border:1px solid #D1D5DB;border-radius:4px"></td>
+      <td style="padding:6px 8px">${badge}</td>
+      <td style="padding:6px 8px">${toggle}</td>
+    </tr>`;
+  }).join('');
+
+  const candidates = (data.candidates || []).map(c =>
+    `<div class="expense-item"><div class="info"><strong>${esc(c.qbo_customer_name)}</strong> <span class="cat">QBO #${esc(c.qbo_customer_id)}</span></div>
+     <button class="upload-btn" onclick="linkCandidate('${esc(c.qbo_customer_id)}', '${esc(c.qbo_customer_name).replace(/'/g,'&#39;')}')">+ Link</button></div>`
+  ).join('');
+
+  box.innerHTML = `
+    <table style="width:100%;border-collapse:collapse">
+      <thead><tr style="text-align:left;color:#6B7280;font-size:0.72rem;text-transform:uppercase">
+        <th style="padding:6px 8px">QBO Customer</th><th style="padding:6px 8px">SF Name</th>
+        <th style="padding:6px 8px">ResQ Facility Keywords</th><th style="padding:6px 8px">Status</th><th></th>
+      </tr></thead>
+      <tbody>${rows || '<tr><td colspan="5" class="empty" style="padding:14px">No linked customers yet.</td></tr>'}</tbody>
+    </table>
+    ${data.candidatesError ? `<div style="color:#B45309;font-size:0.75rem;margin-top:10px">Couldn't list RESQ candidates from QBO: ${esc(data.candidatesError)}</div>` : ''}
+    ${candidates ? `<div style="margin-top:14px"><div style="font-size:0.72rem;color:#6B7280;text-transform:uppercase;margin-bottom:6px">Available “RESQ” customers to link</div>${candidates}</div>` : ''}
+  `;
+}
+
+async function setLinked(id, linked) { await postSyncCustomer({ action: linked ? 'relink' : 'unlink', id }); }
+async function saveKeywords(id, value) { await postSyncCustomer({ action: 'update', id, resq_facility_keywords: value }); }
+async function linkCandidate(qboId, qboName) {
+  const stem = String(qboName||'').toLowerCase().replace(/resq/g,'').replace(/[^a-z ]/g,'').trim().split(/\s+/)[0] || '';
+  const kw = prompt(`Link “${qboName}”.\nResQ facility keyword(s), comma-separated — used to match work orders to this customer:`, stem);
+  if (kw === null) return;
+  await postSyncCustomer({ action: 'link', qbo_customer_id: qboId, qbo_customer_name: qboName, resq_facility_keywords: kw });
+}
+async function postSyncCustomer(body) {
+  try {
+    const res = await fetch(`${API_BASE}/sync-customers`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || res.status);
+    loadSyncCustomers();
+  } catch (e) { alert('Failed: ' + e.message); }
+}
 
 // --- Load Status ---
 async function loadStatus() {

--- a/public/sync.html
+++ b/public/sync.html
@@ -329,7 +329,7 @@ function renderSyncCustomers(data) {
       : `<button class="upload-btn" onclick="setLinked(${c.id},true)">Re-link</button>`;
     return `<tr>
       <td style="padding:6px 8px"><strong>${esc(c.qbo_customer_name)}</strong><div style="color:#9CA3AF;font-size:0.72rem">QBO #${esc(c.qbo_customer_id)}</div></td>
-      <td style="padding:6px 8px;font-size:0.8rem">${esc(c.sf_customer_name || c.qbo_customer_name)}</td>
+      <td style="padding:6px 8px"><input value="${esc(c.sf_customer_name || c.qbo_customer_name)}" onchange="saveSfName(${c.id}, this.value)" placeholder="SF customer name" title="The Service Fusion customer name jobs are created under" style="width:100%;font-size:0.8rem;padding:4px 6px;border:1px solid #D1D5DB;border-radius:4px"></td>
       <td style="padding:6px 8px"><input value="${esc(kws)}" onchange="saveKeywords(${c.id}, this.value)" placeholder="facility keywords, comma-separated" style="width:100%;font-size:0.8rem;padding:4px 6px;border:1px solid #D1D5DB;border-radius:4px"></td>
       <td style="padding:6px 8px">${badge}</td>
       <td style="padding:6px 8px">${toggle}</td>
@@ -356,6 +356,7 @@ function renderSyncCustomers(data) {
 
 async function setLinked(id, linked) { await postSyncCustomer({ action: linked ? 'relink' : 'unlink', id }); }
 async function saveKeywords(id, value) { await postSyncCustomer({ action: 'update', id, resq_facility_keywords: value }); }
+async function saveSfName(id, value) { await postSyncCustomer({ action: 'update', id, sf_customer_name: value }); }
 async function linkCandidate(qboId, qboName) {
   const stem = String(qboName||'').toLowerCase().replace(/resq/g,'').replace(/[^a-z ]/g,'').trim().split(/\s+/)[0] || '';
   const kw = prompt(`Link “${qboName}”.\nResQ facility keyword(s), comma-separated — used to match work orders to this customer:`, stem);

--- a/supabase/migrations/20260602a_sync_customers.sql
+++ b/supabase/migrations/20260602a_sync_customers.sql
@@ -1,0 +1,60 @@
+-- 20260602a_sync_customers.sql
+-- Phase 1 of ResQ <-> SF sync v2: a single identity map for the RESQ-linked
+-- customers. A "linked customer" is a QBO/SF customer with RESQ in its name
+-- (today there are exactly two: THE MELT RESQ, STARBIRD CHICKEN RESQ).
+--
+-- This replaces the hand-maintained string literals that had drifted apart:
+--   * resq-sf-sync-background.mjs  SF_CUSTOMERS / FACILITY_MAP  ('STARBIRD CHICKEN: RESQ' — wrong, had a colon)
+--   * expense-to-bill.mjs          RESQ_CUSTOMER_MAP            ('STARBIRD CHICKEN RESQ')
+-- Both now read ops.sync_customers instead.
+
+create table if not exists ops.sync_customers (
+  id                      bigint generated always as identity primary key,
+  qbo_customer_id         text unique not null,            -- QBO Customer.Id (e.g. '1945')
+  qbo_customer_name       text not null,                   -- QBO DisplayName
+  sf_customer_name        text,                            -- seed for resolveSfCustomerName(); null => use qbo name
+  resq_facility_keywords  text[] not null default '{}',    -- lowercase substrings that match a ResQ WO facility -> this customer
+  qbo_cogs_account_id     text,                            -- per-customer COGS default (nullable; category map remains the fallback)
+  entity                  text,                            -- brix|AS|freeflow|FF|shared (nullable)
+  linked                  boolean not null default true,   -- is this customer active in the sync
+  notes                   text,
+  created_at              timestamptz not null default now(),
+  updated_at              timestamptz not null default now()
+);
+
+comment on table ops.sync_customers is
+  'Identity map for RESQ-linked customers (ResQ facility <-> SF customer <-> QBO customer). Phase 1 of resq-sf-sync v2. Writer: Netlify function sync-customers.';
+
+alter table ops.sync_customers enable row level security;
+
+-- anon + authenticated may read (the sync dashboard and the Netlify functions
+-- read with the public anon key). All writes go through the service-role key
+-- in the sync-customers endpoint, which bypasses RLS.
+drop policy if exists sync_customers_read on ops.sync_customers;
+create policy sync_customers_read on ops.sync_customers
+  for select to anon, authenticated using (true);
+
+-- keep updated_at fresh on UPDATE
+create or replace function ops.tg_sync_customers_touch() returns trigger
+  language plpgsql as $$
+begin
+  new.updated_at := now();
+  return new;
+end $$;
+
+drop trigger if exists trg_sync_customers_touch on ops.sync_customers;
+create trigger trg_sync_customers_touch
+  before update on ops.sync_customers
+  for each row execute function ops.tg_sync_customers_touch();
+
+-- Seed the two live RESQ customers (idempotent on qbo_customer_id).
+insert into ops.sync_customers
+  (qbo_customer_id, qbo_customer_name, sf_customer_name, resq_facility_keywords, linked, notes)
+values
+  ('1945', 'STARBIRD CHICKEN RESQ', 'STARBIRD CHICKEN RESQ', array['starbird','star bird'], true, 'Seeded in Phase 1 from QBO (realm 9130352144155116).'),
+  ('1944', 'THE MELT RESQ',         'THE MELT RESQ',         array['melt','homeroom'],      true, 'Seeded in Phase 1 from QBO (realm 9130352144155116).')
+on conflict (qbo_customer_id) do update set
+  qbo_customer_name      = excluded.qbo_customer_name,
+  sf_customer_name       = excluded.sf_customer_name,
+  resq_facility_keywords = excluded.resq_facility_keywords,
+  linked                 = excluded.linked;

--- a/supabase/migrations/20260602b_sync_customers_brix.sql
+++ b/supabase/migrations/20260602b_sync_customers_brix.sql
@@ -1,0 +1,20 @@
+-- 20260602b_sync_customers_brix.sql
+-- Add the Brix warehouse as a third linked customer in the ResQ <-> SF sync.
+-- QBO anchor: "BRIX WAREHOUSE EQUIPMENT" (id 1412). Unlike Melt/Starbird this
+-- one does NOT have RESQ in its QBO name, but it IS a real SF customer the
+-- ResQ warehouse/equipment-storage work orders should sync to.
+--
+-- sf_customer_name is seeded to the operator-stated SF name ("BRIX BEVERAGE
+-- WAREHOUSE"); confirm/adjust the exact SF spelling in sync.html -> Settings.
+-- resolveSfCustomerName() self-heals minor drift at job-create time.
+
+insert into ops.sync_customers
+  (qbo_customer_id, qbo_customer_name, sf_customer_name, resq_facility_keywords, linked, notes)
+values
+  ('1412', 'BRIX WAREHOUSE EQUIPMENT', 'BRIX BEVERAGE WAREHOUSE', array['brix','equipment storage','warehouse'], true,
+   'Brix warehouse. QBO name has no RESQ; SF name confirmed by operator. Added 2026-06-02.')
+on conflict (qbo_customer_id) do update set
+  qbo_customer_name      = excluded.qbo_customer_name,
+  sf_customer_name       = excluded.sf_customer_name,
+  resq_facility_keywords = excluded.resq_facility_keywords,
+  linked                 = excluded.linked;


### PR DESCRIPTION
This PR carries three related pieces of the ResQ ↔ Service Fusion sync work.

## 1. Starbird hotfix
- Vendor eligibility filter no longer short-circuits `executingVendor` (WOs where Brix is the executing, not primary, vendor were silently dropped → drift).
- SF job creation resolves the configured customer name against a real SF record (`resolveSfCustomerName`) instead of trusting a hardcoded string, self-healing punctuation/spacing drift and failing loudly otherwise.

## 2. v2 plan (docs)
`architecture/projects/resq-sf-sync-v2/` — PRD, scoping, and decisions for the full-automation rebuild (event-driven, Supabase-backed, SF photos + SF-expense→QBO-bill→Brixpense). Intended to be mirrored into `Skilliosis_Mytosis_Architecture/projects/` (that repo wasn't in session scope).

## 3. Phase 1 — `ops.sync_customers` identity map + Settings UI
Replaces the hand-maintained, drifted customer string literals (`SF_CUSTOMERS`/`FACILITY_MAP` in the worker, `RESQ_CUSTOMER_MAP` in `expense-to-bill`) with one source of truth.

- **Migrations `20260602a` + `20260602b`** (applied to live): `ops.sync_customers` (RLS anon-SELECT, updated_at trigger) seeded with the three linked customers — THE MELT RESQ (1944), STARBIRD CHICKEN RESQ (1945), BRIX WAREHOUSE EQUIPMENT (1412, SF name "BRIX BEVERAGE WAREHOUSE").
- **`lib/sync-customers.mjs`** — shared loader + classify/keyword helpers, with a defensive fallback.
- **`sync-customers.mjs`** — superadmin endpoint: GET lists linked rows + discovers RESQ-named QBO candidates; POST link/update/unlink/relink via service role.
- **`sync.html`** — "⚙️ Linked Customers" Settings section: view/edit facility keywords + SF customer name, link/unlink, link discovered RESQ customers.
- **`resq-sf-sync-background.mjs` + `expense-to-bill.mjs`** read the map; `expense-to-bill` builds the QBO `CustomerRef` from the stored id directly (dropped the fuzzy name search).
- `schema-snapshot.json` + `sync-manifest.json` updated; lint passes.

**Verification after deploy:** open sync.html → Settings (confirm 3 customers, fix the Brix SF name if spelling differs), run a sync, confirm Starbird creates/links correctly.

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU