### PR TITLE
Sync v2 Phase 2 (ops.resq_sf_links + sync_events) + Maintenance Mode & Settings

### DIFF
--- a/architecture/schema-snapshot.json
+++ b/architecture/schema-snapshot.json
@@ -64,6 +64,7 @@
     "qbo_pto_cache",
     "qbo_token_cache",
     "reman_jobs",
+    "resq_sf_links",
     "revenue_categories",
     "role_types",
     "sales_plan_lines",
@@ -75,6 +76,7 @@
     "staff",
     "staff_roles",
     "sync_customers",
+    "sync_events",
     "sync_log",
     "team_members",
     "third_party_crews"

--- a/architecture/schema-snapshot.json
+++ b/architecture/schema-snapshot.json
@@ -73,6 +73,7 @@
     "segments",
     "service_jobs",
     "sf_token_cache",
+    "site_settings",
     "staff",
     "staff_roles",
     "sync_customers",

--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -307,7 +307,21 @@
         "ops.sync_customers"
       ],
       "external_inputs": ["QuickBooks Online API: Customer (discovers RESQ-named candidates)"],
-      "notes": "Phase 1 of resq-sf-sync v2. Single identity map for RESQ-linked customers (ResQ facility <-> SF customer <-> QBO customer). Replaces the drifted string literals in resq-sf-sync-background.mjs (SF_CUSTOMERS/FACILITY_MAP) and expense-to-bill.mjs (RESQ_CUSTOMER_MAP). requireAuth superadmin; writes via service-role. Seeded by migration 20260602a_sync_customers.sql with the two live RESQ customers (THE MELT RESQ 1944, STARBIRD CHICKEN RESQ 1945). Read at runtime by resq-sf-sync-background and expense-to-bill via netlify/functions/lib/sync-customers.mjs.",
+      "notes": "Phase 1 of resq-sf-sync v2. Single identity map for RESQ-linked customers (ResQ facility <-> SF customer <-> QBO customer). Replaces the drifted string literals in resq-sf-sync-background.mjs (SF_CUSTOMERS/FACILITY_MAP) and expense-to-bill.mjs (RESQ_CUSTOMER_MAP). requireAuth superadmin; writes via service-role. Seeded by migration 20260602a_sync_customers.sql with the two live RESQ customers (THE MELT RESQ 1944, STARBIRD CHICKEN RESQ 1945) + 20260602b (BRIX WAREHOUSE EQUIPMENT 1412). Read at runtime by resq-sf-sync-background and expense-to-bill via netlify/functions/lib/sync-customers.mjs.",
+      "last_verified": "2026-06-02"
+    },
+    {
+      "name": "resq-sf-sync",
+      "kind": "netlify-function",
+      "source_repo": "skypace/apbg-billing",
+      "schedule": "every 5 min (resq-sf-sync-cron) + on-demand from sync.html",
+      "writes": [
+        "ops.resq_sf_links",
+        "ops.sync_events"
+      ],
+      "multi_writer": true,
+      "external_inputs": ["ResQ GraphQL API", "Service Fusion API"],
+      "notes": "Phase 2 of resq-sf-sync v2. The background worker (resq-sf-sync-background.mjs) dual-writes its state into ops.resq_sf_links (one row per ResQ WO <-> SF job link, replacing the wo-mapping Netlify Blob) and appends an audit trail to ops.sync_events at the end of every run. The Netlify Blob remains the authoritative read source for now; these tables mirror it (additive, non-fatal on failure). Writes via service-role through netlify/functions/lib/resq-sf-links.mjs. sync_events is append-only (multi_writer for future writers). Migration 20260602c_resq_sf_links.sql.",
       "last_verified": "2026-06-02"
     }
   ],

--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -323,6 +323,18 @@
       "external_inputs": ["ResQ GraphQL API", "Service Fusion API"],
       "notes": "Phase 2 of resq-sf-sync v2. The background worker (resq-sf-sync-background.mjs) dual-writes its state into ops.resq_sf_links (one row per ResQ WO <-> SF job link, replacing the wo-mapping Netlify Blob) and appends an audit trail to ops.sync_events at the end of every run. The Netlify Blob remains the authoritative read source for now; these tables mirror it (additive, non-fatal on failure). Writes via service-role through netlify/functions/lib/resq-sf-links.mjs. sync_events is append-only (multi_writer for future writers). Migration 20260602c_resq_sf_links.sql.",
       "last_verified": "2026-06-02"
+    },
+    {
+      "name": "site-settings",
+      "kind": "netlify-function",
+      "source_repo": "skypace/apbg-billing",
+      "schedule": "on-demand (Master Control panel toggles)",
+      "writes": [
+        "ops.site_settings"
+      ],
+      "external_inputs": [],
+      "notes": "Generic key/value site settings (anon-readable so any app can read a flag; service-role writes). First use: the maintenance flag/banner, toggled from public/control.html and read client-side by public/maintenance-banner.js. POST is superadmin-gated (requireAuth). Migration 20260602d_site_settings.sql.",
+      "last_verified": "2026-06-02"
     }
   ],
 

--- a/netlify/functions/lib/resq-sf-links.mjs
+++ b/netlify/functions/lib/resq-sf-links.mjs
@@ -1,0 +1,91 @@
+// Phase 2 data access for the ResQ <-> SF sync state tables:
+//   ops.resq_sf_links  — one row per ResQ WO <-> SF job link (mirrors the
+//                        wo-mapping Netlify Blob)
+//   ops.sync_events    — append-only audit trail
+//
+// The worker DUAL-WRITES into these at the end of each run; the Blob is still
+// the authoritative read source. All writes are non-fatal — a failure here
+// must never break the live sync. Service-role key required for writes.
+
+import { SUPABASE_URL } from '../supabase-helpers.mjs';
+
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+function writeHeaders() {
+  return {
+    apikey: SERVICE_KEY,
+    Authorization: `Bearer ${SERVICE_KEY}`,
+    'Content-Type': 'application/json',
+    'Accept-Profile': 'ops',
+    'Content-Profile': 'ops',
+    Prefer: 'return=minimal,resolution=merge-duplicates',
+  };
+}
+
+// Map a wo-mapping entry to a resq_sf_links row.
+export function mapEntryToLinkRow(resqWoId, e) {
+  const s = (v) => (v == null ? null : String(v));
+  return {
+    resq_wo_id: String(resqWoId),
+    resq_code: e.resqCode || null,
+    sf_job_id: s(e.sfJobId),
+    sf_job_number: s(e.sfJobNumber),
+    resq_status: e.resqStatus || null,
+    sf_status: e.sfStatus || null,
+    facility: e.facility || null,
+    customer_qbo_id: s(e.customerQboId),
+    customer_name: e.customerName || null,
+    title: e.title || null,
+    reconciled: !!e.reconciled,
+    sf_deleted: !!e.sfDeleted,
+    photos_sent: !!e.photosSent,
+    invoice_submitted: !!e.invoiceSubmitted,
+    visit_completed: !!e.visitCompleted,
+    linked_existing: !!e.linkedExisting,
+    replaced_sf_job_id: s(e.replacedSfJobId),
+    raw: e,
+    last_sync_at: e.lastSyncAt || null,
+  };
+}
+
+// Upsert all links in one request (PostgREST array upsert on resq_wo_id).
+// Backfills the table from the current mapping and keeps it current.
+export async function bulkUpsertLinks(rows) {
+  if (!SERVICE_KEY) throw new Error('SUPABASE_SERVICE_ROLE_KEY not set');
+  if (!rows || !rows.length) return 0;
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/resq_sf_links?on_conflict=resq_wo_id`, {
+    method: 'POST',
+    headers: writeHeaders(),
+    body: JSON.stringify(rows),
+  });
+  if (!res.ok) throw new Error(`links upsert ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  return rows.length;
+}
+
+// Append audit events in one request.
+export async function bulkInsertEvents(events) {
+  if (!SERVICE_KEY) throw new Error('SUPABASE_SERVICE_ROLE_KEY not set');
+  if (!events || !events.length) return 0;
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/sync_events`, {
+    method: 'POST',
+    headers: writeHeaders(),
+    body: JSON.stringify(events),
+  });
+  if (!res.ok) throw new Error(`events insert ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  return events.length;
+}
+
+// Build a compact event from a per-WO processing result, or null for no-ops.
+export function eventFromResult(wo, mapEntry, r, defaultDirection) {
+  const action = r?.created ? 'created' : (r?.updated ? 'updated' : ((r?.errors?.length) ? 'error' : null));
+  if (!action) return null;
+  return {
+    resq_wo_id: String(wo.id),
+    resq_code: wo.code || null,
+    sf_job_id: mapEntry?.sfJobId != null ? String(mapEntry.sfJobId) : null,
+    direction: action === 'created' ? 'resq->sf' : defaultDirection,
+    action,
+    ok: action !== 'error',
+    message: String((r.errors && r.errors[0]) || (r.steps && r.steps[r.steps.length - 1]) || '').slice(0, 300),
+  };
+}

--- a/netlify/functions/resq-sf-links.mjs
+++ b/netlify/functions/resq-sf-links.mjs
@@ -1,0 +1,44 @@
+// resq-sf-links — read the Phase 2 sync state tables for the dashboard.
+//
+//   GET                  -> { links: [...], events: [...recent 50] }
+//   GET ?events=1&limit=N -> { events: [...recent N] }
+//
+// Read-only, anon-key reads (RLS allows SELECT). Superadmin-gated like the rest
+// of the sync dashboard endpoints.
+
+import { requireAuth } from './lib/auth.mjs';
+import { corsHeaders } from './qbo-helpers.mjs';
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from './supabase-helpers.mjs';
+
+function json(body, status = 200) {
+  return { statusCode: status, headers: { ...corsHeaders(), 'Content-Type': 'application/json' }, body: JSON.stringify(body) };
+}
+
+async function sbGet(path) {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${SUPABASE_ANON_KEY}`, 'Accept-Profile': 'ops' },
+  });
+  if (!res.ok) throw new Error(`${path} ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  return res.json();
+}
+
+export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: corsHeaders(), body: '' };
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+
+  try {
+    const qs = event.queryStringParameters || {};
+    const limit = Math.min(parseInt(qs.limit, 10) || 50, 200);
+
+    const events = await sbGet(`sync_events?select=*&order=created_at.desc&limit=${limit}`);
+    if (qs.events) return json({ events });
+
+    const links = await sbGet('resq_sf_links?select=resq_code,sf_job_id,sf_job_number,resq_status,sf_status,customer_name,facility,sf_deleted,invoice_submitted,photos_sent,last_sync_at&order=last_sync_at.desc.nullslast&limit=500');
+    return json({ links, events });
+  } catch (e) {
+    console.error('resq-sf-links error:', e);
+    return json({ error: e.message }, 500);
+  }
+}

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -19,6 +19,7 @@ import { resqLogin, resqGql } from './resq-helpers.mjs';
 import { sfRequest } from './sf-helpers.mjs';
 import { requireAuth } from './lib/auth.mjs';
 import { loadSyncCustomers, classifySyncCustomer, allFacilityKeywords, sfNameFor, stemFor } from './lib/sync-customers.mjs';
+import { mapEntryToLinkRow, bulkUpsertLinks, bulkInsertEvents, eventFromResult } from './lib/resq-sf-links.mjs';
 
 const BRIX_VENDOR_KEYWORDS = ['brix'];
 
@@ -50,6 +51,7 @@ export async function handler(event) {
 
   const log = { started: new Date().toISOString(), steps: [], errors: [], created: 0, updated: 0 };
   const dedupeReport = [];
+  const syncEvents = []; // Phase 2: audit trail dual-written to ops.sync_events
 
   const saveProgress = async () => {
     try { await saveBlob('last-sync', JSON.stringify(log)); } catch (x) {}
@@ -116,6 +118,8 @@ export async function handler(event) {
           if (r.errors.length) log.errors.push(...r.errors);
           if (r.report?.length) dedupeReport.push(...r.report);
           log.updated += r.updated || 0;
+          const ev = eventFromResult(wo, mapping[wo.id], r, 'sf->resq');
+          if (ev) syncEvents.push(ev);
         } else {
           // New WO — skip if already done (awaiting payment, closed, etc.)
           const resqStatus = (wo.status || '').toUpperCase();
@@ -129,9 +133,12 @@ export async function handler(event) {
           if (r.errors.length) log.errors.push(...r.errors);
           if (r.report?.length) dedupeReport.push(...r.report);
           log.created += r.created || 0;
+          const ev = eventFromResult(wo, mapping[wo.id], r, 'resq->sf');
+          if (ev) syncEvents.push(ev);
         }
       } catch (e) {
         log.errors.push(`WO ${wo.code} failed: ${e.message}`);
+        syncEvents.push({ resq_wo_id: String(wo.id), resq_code: wo.code || null, sf_job_id: mapping[wo.id]?.sfJobId != null ? String(mapping[wo.id].sfJobId) : null, direction: 'system', action: 'error', ok: false, message: String(e.message || '').slice(0, 300) });
       }
 
       // Persist mapping after every WO so concurrent runs (and crash recovery)
@@ -155,6 +162,19 @@ export async function handler(event) {
       byReason: dedupeReport.reduce((acc, r) => { acc[r.reason] = (acc[r.reason] || 0) + 1; return acc; }, {}),
       items: dedupeReport,
     };
+
+    // Phase 2 dual-write: mirror the full mapping into ops.resq_sf_links and
+    // append this run's events to ops.sync_events. The Blob above stays the
+    // authoritative read source; this is additive and strictly non-fatal so a
+    // Supabase blip can never break the live sync.
+    try {
+      const linkRows = Object.entries(mapping).map(([id, e]) => mapEntryToLinkRow(id, e));
+      const linkCount = await bulkUpsertLinks(linkRows);
+      const evCount = await bulkInsertEvents(syncEvents);
+      log.steps.push(`Dual-write → ops: ${linkCount} links, ${evCount} events`);
+    } catch (e) {
+      log.errors.push(`Dual-write to ops failed (non-fatal): ${e.message.substring(0, 200)}`);
+    }
 
     await Promise.all([
       saveMapping(mapping),

--- a/netlify/functions/site-settings.mjs
+++ b/netlify/functions/site-settings.mjs
@@ -1,0 +1,78 @@
+// site-settings — read/write generic site flags (ops.site_settings).
+//
+//   GET  ?key=maintenance   -> { key, value }            (PUBLIC: the banner must
+//                                                          load for everyone, incl.
+//                                                          logged-out visitors)
+//   POST { key, value }      -> upsert                    (superadmin only)
+//
+// First use: the maintenance flag/banner.
+
+import { requireAuth } from './lib/auth.mjs';
+import { corsHeaders } from './qbo-helpers.mjs';
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from './supabase-helpers.mjs';
+
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const TABLE = `${SUPABASE_URL}/rest/v1/site_settings`;
+
+function json(body, status = 200) {
+  return {
+    statusCode: status,
+    headers: { ...corsHeaders(), 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+    body: JSON.stringify(body),
+  };
+}
+
+export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: corsHeaders(), body: '' };
+
+  // ── GET: public read (no auth) so the banner shows for any visitor ──
+  if (event.httpMethod === 'GET') {
+    const key = (event.queryStringParameters || {}).key || 'maintenance';
+    try {
+      const res = await fetch(`${TABLE}?key=eq.${encodeURIComponent(key)}&select=key,value,updated_at`, {
+        headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${SUPABASE_ANON_KEY}`, 'Accept-Profile': 'ops' },
+      });
+      if (!res.ok) throw new Error(`read ${res.status}`);
+      const rows = await res.json();
+      return json(rows[0] || { key, value: {} });
+    } catch (e) {
+      // Fail safe: never let a settings read error take a page down. Treat as "off".
+      return json({ key, value: {}, error: e.message.slice(0, 150) });
+    }
+  }
+
+  // ── POST: superadmin write ──
+  if (event.httpMethod !== 'POST') return json({ error: 'GET or POST only' }, 405);
+
+  const auth = await requireAuth(event);
+  if (!auth.ok) return auth.response;
+  if (!SERVICE_KEY) return json({ error: 'SUPABASE_SERVICE_ROLE_KEY not configured' }, 500);
+
+  try {
+    const body = JSON.parse(event.body || '{}');
+    if (!body.key) return json({ error: 'key required' }, 400);
+    const row = {
+      key: body.key,
+      value: body.value || {},
+      updated_by: auth.user?.email || auth.role || 'superadmin',
+    };
+    const res = await fetch(`${TABLE}?on_conflict=key`, {
+      method: 'POST',
+      headers: {
+        apikey: SERVICE_KEY,
+        Authorization: `Bearer ${SERVICE_KEY}`,
+        'Content-Type': 'application/json',
+        'Accept-Profile': 'ops',
+        'Content-Profile': 'ops',
+        Prefer: 'return=representation,resolution=merge-duplicates',
+      },
+      body: JSON.stringify([row]),
+    });
+    if (!res.ok) throw new Error(`write ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const out = await res.json();
+    return json({ ok: true, setting: Array.isArray(out) ? out[0] : out });
+  } catch (e) {
+    console.error('site-settings error:', e);
+    return json({ error: e.message }, 500);
+  }
+}

--- a/public/control.html
+++ b/public/control.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script src="maintenance-banner.js"></script>
 <meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <script>if(location.hostname.endsWith('.netlify.app'))location.replace('https://alamedapointbg.com/control'+location.search);</script>
 <title>Master Control — APBG Systems</title>
@@ -113,6 +114,16 @@ header .links a:hover{color:#fff}
     <div class="keepalive-grid" id="keepaliveGrid"></div>
   </div>
 
+  <div class="keepalive-section" style="margin-top:24px">
+    <h2>🛠️ Maintenance Mode</h2>
+    <div id="maintBox" style="background:#fff;border:1px solid #E2E6ED;border-radius:10px;padding:16px 20px;color:#1F2937">Loading…</div>
+  </div>
+
+  <div class="keepalive-section" style="margin-top:24px">
+    <h2>⚙️ Linked Customers <span style="font-weight:400;font-size:0.75rem;color:#9CA3AF">— RESQ customers that sync ResQ ↔ Service Fusion</span></h2>
+    <div id="syncCustomersBox" style="background:#fff;border:1px solid #E2E6ED;border-radius:10px;padding:16px 20px;color:#1F2937">Loading…</div>
+  </div>
+
   <div class="log-section">
     <h2>Activity Log</h2>
     <div class="log" id="log"></div>
@@ -193,6 +204,8 @@ APBG.auth.requireSuperadmin().then(() => {
   document.getElementById('authLoading').style.display = 'none';
   document.getElementById('app').style.display = 'block';
   refreshAll();
+  loadMaintenance();
+  loadSyncCustomers();
   setInterval(refreshAll, 60000); // auto-refresh every 60s
 });
 
@@ -354,6 +367,100 @@ function renderKeepalive() {
     </div>`;
   }).join('');
   grid.innerHTML = items;
+}
+
+// ═══ SETTINGS: Maintenance + Linked Customers ═══
+const APBG_FN = 'https://apbg-billing.netlify.app/.netlify/functions';
+function esc(s){ return String(s==null?'':s).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+const btnCss = (bg)=>`padding:8px 16px;border:0;border-radius:6px;font-weight:600;cursor:pointer;color:#fff;background:${bg}`;
+
+// --- Maintenance ---
+let maintCfg = { enabled:false, title:'', message:'' };
+async function loadMaintenance(){
+  const box=document.getElementById('maintBox');
+  try{
+    const res=await fetch(`${APBG_FN}/site-settings?key=maintenance`);
+    const data=await res.json();
+    maintCfg=(data&&data.value)||{};
+    renderMaintenance();
+  }catch(e){ box.innerHTML=`<span style="color:#EF4444">Failed to load: ${esc(e.message)}</span>`; }
+}
+function renderMaintenance(){
+  const on=!!maintCfg.enabled;
+  document.getElementById('maintBox').innerHTML=`
+    <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:14px">
+      <button onclick="toggleMaintenance()" style="${btnCss(on?'#DC2626':'#059669')}">${on?'🔴 Maintenance is ON — click to turn OFF':'🟢 Maintenance is OFF — click to turn ON'}</button>
+      <span style="font-size:0.82rem;color:#6B7280">${on?'A banner is showing on the billing tools.':'No banner is showing.'}</span>
+    </div>
+    <label style="display:block;font-size:0.72rem;color:#6B7280;text-transform:uppercase;margin-bottom:4px">Banner title</label>
+    <input id="maintTitle" value="${esc(maintCfg.title||'')}" style="width:100%;padding:8px;border:1px solid #D1D5DB;border-radius:6px;margin-bottom:10px">
+    <label style="display:block;font-size:0.72rem;color:#6B7280;text-transform:uppercase;margin-bottom:4px">Banner message</label>
+    <textarea id="maintMsg" rows="3" style="width:100%;padding:8px;border:1px solid #D1D5DB;border-radius:6px;margin-bottom:10px;font-family:inherit">${esc(maintCfg.message||'')}</textarea>
+    <button onclick="saveMaintenanceText()" style="${btnCss('#1F4E79')}">Save message</button>`;
+}
+async function toggleMaintenance(){ await saveMaintenance({ ...maintCfg, enabled: !maintCfg.enabled }); }
+async function saveMaintenanceText(){ await saveMaintenance({ ...maintCfg, title:document.getElementById('maintTitle').value, message:document.getElementById('maintMsg').value }); }
+async function saveMaintenance(value){
+  try{
+    const res=await fetch(`${APBG_FN}/site-settings`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({key:'maintenance',value})});
+    const data=await res.json();
+    if(!res.ok) throw new Error(data.error||res.status);
+    maintCfg=(data.setting&&data.setting.value)||value;
+    renderMaintenance();
+    log(`Maintenance ${maintCfg.enabled?'ON':'OFF'} saved`, maintCfg.enabled?'warn':'ok');
+  }catch(e){ log('Maintenance save failed: '+e.message,'error'); alert('Failed: '+e.message); }
+}
+
+// --- Linked Customers ---
+async function loadSyncCustomers(){
+  const box=document.getElementById('syncCustomersBox');
+  try{
+    const res=await fetch(`${APBG_FN}/sync-customers`);
+    const data=await res.json();
+    if(!res.ok) throw new Error(data.error||res.status);
+    renderSyncCustomers(data);
+  }catch(e){ box.innerHTML=`<span style="color:#EF4444">Failed to load: ${esc(e.message)}</span>`; }
+}
+function renderSyncCustomers(data){
+  const inp='width:100%;font-size:0.8rem;padding:4px 6px;border:1px solid #D1D5DB;border-radius:4px';
+  const rows=(data.customers||[]).map(c=>{
+    const kws=(c.resq_facility_keywords||[]).join(', ');
+    const badge=c.linked?'<span style="background:#D1FAE5;color:#065F46;padding:2px 8px;border-radius:4px;font-size:0.7rem;font-weight:700">LINKED</span>':'<span style="background:#F3F4F6;color:#6B7280;padding:2px 8px;border-radius:4px;font-size:0.7rem;font-weight:700">OFF</span>';
+    const toggle=c.linked?`<button onclick="setLinked(${c.id},false)" style="${btnCss('#DC2626')};padding:4px 10px;font-size:0.72rem">Unlink</button>`:`<button onclick="setLinked(${c.id},true)" style="${btnCss('#059669')};padding:4px 10px;font-size:0.72rem">Re-link</button>`;
+    return `<tr style="border-top:1px solid #F1F3F5">
+      <td style="padding:6px 8px"><strong>${esc(c.qbo_customer_name)}</strong><div style="color:#9CA3AF;font-size:0.7rem">QBO #${esc(c.qbo_customer_id)}</div></td>
+      <td style="padding:6px 8px"><input value="${esc(c.sf_customer_name||c.qbo_customer_name)}" onchange="saveSfName(${c.id},this.value)" title="Service Fusion customer name jobs are created under" style="${inp}"></td>
+      <td style="padding:6px 8px"><input value="${esc(kws)}" onchange="saveKeywords(${c.id},this.value)" placeholder="facility keywords, comma-separated" style="${inp}"></td>
+      <td style="padding:6px 8px">${badge}</td>
+      <td style="padding:6px 8px">${toggle}</td></tr>`;
+  }).join('');
+  const candidates=(data.candidates||[]).map(c=>`<div style="display:flex;align-items:center;justify-content:space-between;padding:8px 10px;background:#F9FAFB;border-radius:6px;margin-bottom:6px;font-size:0.82rem">
+      <span><strong>${esc(c.qbo_customer_name)}</strong> <span style="color:#9CA3AF;font-size:0.72rem">QBO #${esc(c.qbo_customer_id)}</span></span>
+      <button onclick="linkCandidate('${esc(c.qbo_customer_id)}','${esc(c.qbo_customer_name).replace(/'/g,'&#39;')}')" style="${btnCss('#1F4E79')};padding:4px 10px;font-size:0.72rem">+ Link</button></div>`).join('');
+  document.getElementById('syncCustomersBox').innerHTML=`
+    <table style="width:100%;border-collapse:collapse;font-size:0.82rem">
+      <thead><tr style="text-align:left;color:#6B7280;font-size:0.7rem;text-transform:uppercase">
+        <th style="padding:6px 8px">QBO Customer</th><th style="padding:6px 8px">SF Name</th><th style="padding:6px 8px">ResQ Facility Keywords</th><th style="padding:6px 8px">Status</th><th></th></tr></thead>
+      <tbody>${rows||'<tr><td colspan="5" style="padding:14px;color:#9CA3AF">No linked customers yet.</td></tr>'}</tbody></table>
+    ${data.candidatesError?`<div style="color:#B45309;font-size:0.75rem;margin-top:10px">Couldn't list RESQ candidates from QBO: ${esc(data.candidatesError)}</div>`:''}
+    ${candidates?`<div style="margin-top:14px"><div style="font-size:0.72rem;color:#6B7280;text-transform:uppercase;margin-bottom:6px">Available “RESQ” customers to link</div>${candidates}</div>`:''}`;
+}
+async function setLinked(id,linked){ await postSyncCustomer({action:linked?'relink':'unlink',id}); }
+async function saveKeywords(id,v){ await postSyncCustomer({action:'update',id,resq_facility_keywords:v}); }
+async function saveSfName(id,v){ await postSyncCustomer({action:'update',id,sf_customer_name:v}); }
+async function linkCandidate(id,name){
+  const stem=String(name||'').toLowerCase().replace(/resq/g,'').replace(/[^a-z ]/g,'').trim().split(/\s+/)[0]||'';
+  const kw=prompt(`Link “${name}”.\nResQ facility keyword(s), comma-separated — used to match work orders to this customer:`,stem);
+  if(kw===null) return;
+  await postSyncCustomer({action:'link',qbo_customer_id:id,qbo_customer_name:name,resq_facility_keywords:kw});
+}
+async function postSyncCustomer(body){
+  try{
+    const res=await fetch(`${APBG_FN}/sync-customers`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+    const data=await res.json();
+    if(!res.ok) throw new Error(data.error||res.status);
+    loadSyncCustomers();
+  }catch(e){ alert('Failed: '+e.message); }
 }
 </script>
 </body>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script src="maintenance-banner.js"></script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PACER Ops Dashboard</title>

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script src="maintenance-banner.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script>if(location.hostname.endsWith('.netlify.app'))location.replace('https://alamedapointbg.com/billing/'+location.search);</script>

--- a/public/maintenance-banner.js
+++ b/public/maintenance-banner.js
@@ -1,0 +1,79 @@
+/* maintenance-banner.js — drop-in maintenance notice.
+ *
+ * Include with: <script src="/billing/maintenance-banner.js"></script>
+ *
+ * Reads ops.site_settings(key='maintenance') directly with the public anon key
+ * (RLS allows SELECT), so it works on any page/app with zero backend wiring.
+ * Toggled from the Master Control panel (public/control.html). Non-blocking:
+ * a fixed top bar; the app stays usable underneath. Re-checks every 60s so
+ * turning maintenance off clears the bar without a reload.
+ */
+(function () {
+  var SUPABASE_URL = 'https://gfsdpwiqzshhexkofiif.supabase.co';
+  var ANON =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdmc2Rwd2lxenNoaGV4a29maWlmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU1OTUyMzcsImV4cCI6MjA5MTE3MTIzN30.AygnPJwQ5NfIeKwPtkO6tgVYmkV3MAxL1lMFwN9HPnY';
+  var BANNER_ID = 'apbg-maint-banner';
+
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"]/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
+    });
+  }
+
+  function remove() {
+    var el = document.getElementById(BANNER_ID);
+    if (el) {
+      el.parentNode.removeChild(el);
+      document.body.style.paddingTop = el.getAttribute('data-prev-pad') || '';
+    }
+  }
+
+  function show(cfg) {
+    if (document.getElementById(BANNER_ID)) return;
+    if (sessionStorage.getItem('apbg-maint-dismissed') === '1') return;
+    var title = esc(cfg.title || '🛠️ System Maintenance');
+    var message = esc(cfg.message || 'This system is being updated — please check back later.');
+    var bar = document.createElement('div');
+    bar.id = BANNER_ID;
+    bar.setAttribute('data-prev-pad', document.body.style.paddingTop || '');
+    bar.style.cssText =
+      'position:fixed;top:0;left:0;right:0;z-index:2147483647;' +
+      'background:linear-gradient(90deg,#B45309,#D97706);color:#fff;' +
+      'font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;' +
+      'padding:10px 44px 10px 16px;font-size:14px;line-height:1.4;' +
+      'box-shadow:0 2px 10px rgba(0,0,0,.25);text-align:center';
+    bar.innerHTML =
+      '<strong style="font-weight:700">' + title + '</strong> ' +
+      '<span style="opacity:.95">' + message + '</span>' +
+      '<button aria-label="Dismiss" style="position:absolute;top:6px;right:10px;background:transparent;' +
+      'border:0;color:#fff;font-size:20px;line-height:1;cursor:pointer;opacity:.85">×</button>';
+    bar.querySelector('button').onclick = function () {
+      sessionStorage.setItem('apbg-maint-dismissed', '1');
+      remove();
+    };
+    document.body.appendChild(bar);
+    // Nudge content down so the bar doesn't cover fixed headers.
+    var h = bar.offsetHeight || 44;
+    document.body.style.paddingTop = (parseInt(document.body.style.paddingTop || '0', 10) + h) + 'px';
+  }
+
+  function check() {
+    fetch(
+      SUPABASE_URL + '/rest/v1/site_settings?key=eq.maintenance&select=value',
+      { headers: { apikey: ANON, Authorization: 'Bearer ' + ANON, 'Accept-Profile': 'ops' } }
+    )
+      .then(function (r) { return r.ok ? r.json() : []; })
+      .then(function (rows) {
+        var v = (rows && rows[0] && rows[0].value) || {};
+        if (v.enabled) show(v); else remove();
+      })
+      .catch(function () { /* fail safe: no banner */ });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', check);
+  } else {
+    check();
+  }
+  setInterval(check, 60000);
+})();

--- a/public/setup.html
+++ b/public/setup.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script src="maintenance-banner.js"></script>
 <meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>APBG Billing — Connect Services</title>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>

--- a/public/sync.html
+++ b/public/sync.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script src="maintenance-banner.js"></script>
 <meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <script>if(location.hostname.endsWith('.netlify.app'))location.replace('https://alamedapointbg.com/billing/sync.html'+location.search);</script>
 <title>APBG — ResQ ↔ SF Sync</title>
@@ -214,10 +215,10 @@ td a:hover,.review-head .code a:hover,.review-job .meta a:hover{color:#2E75B6;bo
       <button class="secondary" id="clearErrBtn" onclick="clearErrors()">🧹 Clear Errors</button>
     </div>
 
-    <!-- Linked Customers (Settings) -->
-    <div class="section" id="settingsSection">
-      <h2>⚙️ Linked Customers <span style="font-weight:400;font-size:0.75rem;color:#9CA3AF">— customers with “RESQ” in the name that sync to Service Fusion</span></h2>
-      <div id="syncCustomersBox" style="padding:16px 20px"><div class="empty">Loading…</div></div>
+    <!-- Linked Customers moved to Master Control -->
+    <div class="section">
+      <h2>⚙️ Linked Customers</h2>
+      <div style="padding:16px 20px;color:#6B7280;font-size:0.85rem">Managing which customers sync (ResQ ↔ Service Fusion) now lives in <a href="/control" style="color:#1F4E79;font-weight:600">Master Control → Linked Customers</a>, alongside Maintenance Mode.</div>
     </div>
 
     <!-- Mapping Table -->
@@ -305,7 +306,6 @@ APBG.auth.requireSuperadmin().then(() => {
   document.getElementById('authLoading').style.display = 'none';
   document.getElementById('mainApp').style.display = 'block';
   loadStatus();
-  loadSyncCustomers();
   loadSyncEvents();
 });
 
@@ -337,73 +337,7 @@ async function loadSyncEvents() {
 
 function esc(s){ return String(s==null?'':s).replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
 
-// --- Linked Customers (Settings) ---
-async function loadSyncCustomers() {
-  const box = document.getElementById('syncCustomersBox');
-  try {
-    const res = await fetch(`${API_BASE}/sync-customers`);
-    const data = await res.json();
-    if (!res.ok) throw new Error(data.error || res.status);
-    renderSyncCustomers(data);
-  } catch (e) {
-    box.innerHTML = `<div class="upload-result err" style="display:block">Failed to load linked customers: ${esc(e.message)}</div>`;
-  }
-}
-
-function renderSyncCustomers(data) {
-  const box = document.getElementById('syncCustomersBox');
-  const rows = (data.customers || []).map(c => {
-    const kws = (c.resq_facility_keywords || []).join(', ');
-    const badge = c.linked
-      ? '<span class="badge" style="background:#D1FAE5;color:#065F46">Linked</span>'
-      : '<span class="badge" style="background:#F3F4F6;color:#6B7280">Off</span>';
-    const toggle = c.linked
-      ? `<button class="clear-btn" onclick="setLinked(${c.id},false)">Unlink</button>`
-      : `<button class="upload-btn" onclick="setLinked(${c.id},true)">Re-link</button>`;
-    return `<tr>
-      <td style="padding:6px 8px"><strong>${esc(c.qbo_customer_name)}</strong><div style="color:#9CA3AF;font-size:0.72rem">QBO #${esc(c.qbo_customer_id)}</div></td>
-      <td style="padding:6px 8px"><input value="${esc(c.sf_customer_name || c.qbo_customer_name)}" onchange="saveSfName(${c.id}, this.value)" placeholder="SF customer name" title="The Service Fusion customer name jobs are created under" style="width:100%;font-size:0.8rem;padding:4px 6px;border:1px solid #D1D5DB;border-radius:4px"></td>
-      <td style="padding:6px 8px"><input value="${esc(kws)}" onchange="saveKeywords(${c.id}, this.value)" placeholder="facility keywords, comma-separated" style="width:100%;font-size:0.8rem;padding:4px 6px;border:1px solid #D1D5DB;border-radius:4px"></td>
-      <td style="padding:6px 8px">${badge}</td>
-      <td style="padding:6px 8px">${toggle}</td>
-    </tr>`;
-  }).join('');
-
-  const candidates = (data.candidates || []).map(c =>
-    `<div class="expense-item"><div class="info"><strong>${esc(c.qbo_customer_name)}</strong> <span class="cat">QBO #${esc(c.qbo_customer_id)}</span></div>
-     <button class="upload-btn" onclick="linkCandidate('${esc(c.qbo_customer_id)}', '${esc(c.qbo_customer_name).replace(/'/g,'&#39;')}')">+ Link</button></div>`
-  ).join('');
-
-  box.innerHTML = `
-    <table style="width:100%;border-collapse:collapse">
-      <thead><tr style="text-align:left;color:#6B7280;font-size:0.72rem;text-transform:uppercase">
-        <th style="padding:6px 8px">QBO Customer</th><th style="padding:6px 8px">SF Name</th>
-        <th style="padding:6px 8px">ResQ Facility Keywords</th><th style="padding:6px 8px">Status</th><th></th>
-      </tr></thead>
-      <tbody>${rows || '<tr><td colspan="5" class="empty" style="padding:14px">No linked customers yet.</td></tr>'}</tbody>
-    </table>
-    ${data.candidatesError ? `<div style="color:#B45309;font-size:0.75rem;margin-top:10px">Couldn't list RESQ candidates from QBO: ${esc(data.candidatesError)}</div>` : ''}
-    ${candidates ? `<div style="margin-top:14px"><div style="font-size:0.72rem;color:#6B7280;text-transform:uppercase;margin-bottom:6px">Available “RESQ” customers to link</div>${candidates}</div>` : ''}
-  `;
-}
-
-async function setLinked(id, linked) { await postSyncCustomer({ action: linked ? 'relink' : 'unlink', id }); }
-async function saveKeywords(id, value) { await postSyncCustomer({ action: 'update', id, resq_facility_keywords: value }); }
-async function saveSfName(id, value) { await postSyncCustomer({ action: 'update', id, sf_customer_name: value }); }
-async function linkCandidate(qboId, qboName) {
-  const stem = String(qboName||'').toLowerCase().replace(/resq/g,'').replace(/[^a-z ]/g,'').trim().split(/\s+/)[0] || '';
-  const kw = prompt(`Link “${qboName}”.\nResQ facility keyword(s), comma-separated — used to match work orders to this customer:`, stem);
-  if (kw === null) return;
-  await postSyncCustomer({ action: 'link', qbo_customer_id: qboId, qbo_customer_name: qboName, resq_facility_keywords: kw });
-}
-async function postSyncCustomer(body) {
-  try {
-    const res = await fetch(`${API_BASE}/sync-customers`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) });
-    const data = await res.json();
-    if (!res.ok) throw new Error(data.error || res.status);
-    loadSyncCustomers();
-  } catch (e) { alert('Failed: ' + e.message); }
-}
+// (Linked Customers management moved to public/control.html — Master Control.)
 
 // --- Load Status ---
 async function loadStatus() {

--- a/public/sync.html
+++ b/public/sync.html
@@ -241,6 +241,12 @@ td a:hover,.review-head .code a:hover,.review-job .meta a:hover{color:#2E75B6;bo
       <div class="log" id="syncLog">No sync data yet. Click "Run Sync Now" to start.</div>
     </div>
 
+    <!-- Recent Sync Events (Phase 2 audit trail from ops.sync_events) -->
+    <div class="section">
+      <h2>🧾 Recent Sync Events <span style="font-weight:400;font-size:0.75rem;color:#9CA3AF">— audit trail (newest first)</span></h2>
+      <div id="syncEventsBox" style="padding:12px 20px"><div class="empty">Loading…</div></div>
+    </div>
+
     <!-- Health Status -->
     <div class="section">
       <h2>🩺 Integration Health <span id="healthAge" style="font-weight:400;font-size:0.75rem;color:#9CA3AF"></span></h2>
@@ -300,7 +306,34 @@ APBG.auth.requireSuperadmin().then(() => {
   document.getElementById('mainApp').style.display = 'block';
   loadStatus();
   loadSyncCustomers();
+  loadSyncEvents();
 });
+
+// --- Recent Sync Events (Phase 2) ---
+async function loadSyncEvents() {
+  const box = document.getElementById('syncEventsBox');
+  try {
+    const res = await fetch(`${API_BASE}/resq-sf-links?events=1&limit=50`);
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || res.status);
+    const evs = data.events || [];
+    if (!evs.length) { box.innerHTML = '<div class="empty">No events yet — they appear after the next sync run.</div>'; return; }
+    const color = a => a==='error' ? '#991B1B' : a==='created' ? '#065F46' : '#1F4E79';
+    box.innerHTML = `<table style="width:100%;border-collapse:collapse;font-size:0.8rem">
+      <thead><tr style="text-align:left;color:#6B7280;font-size:0.7rem;text-transform:uppercase">
+        <th style="padding:4px 8px">When</th><th style="padding:4px 8px">ResQ</th><th style="padding:4px 8px">SF Job</th>
+        <th style="padding:4px 8px">Dir</th><th style="padding:4px 8px">Action</th><th style="padding:4px 8px">Message</th></tr></thead>
+      <tbody>${evs.map(e => `<tr style="border-top:1px solid #F1F3F5">
+        <td style="padding:4px 8px;color:#9CA3AF;white-space:nowrap">${timeAgo(e.created_at)}</td>
+        <td style="padding:4px 8px">${esc(e.resq_code||'—')}</td>
+        <td style="padding:4px 8px">${esc(e.sf_job_id||'—')}</td>
+        <td style="padding:4px 8px;color:#9CA3AF">${esc(e.direction||'')}</td>
+        <td style="padding:4px 8px;font-weight:600;color:${color(e.action)}">${esc(e.action)}</td>
+        <td style="padding:4px 8px;color:#4B5563">${esc(e.message||'')}</td></tr>`).join('')}</tbody></table>`;
+  } catch (e) {
+    box.innerHTML = `<div class="upload-result err" style="display:block">Failed to load events: ${esc(e.message)}</div>`;
+  }
+}
 
 function esc(s){ return String(s==null?'':s).replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
 

--- a/supabase/migrations/20260602c_resq_sf_links.sql
+++ b/supabase/migrations/20260602c_resq_sf_links.sql
@@ -1,0 +1,70 @@
+-- 20260602c_resq_sf_links.sql
+-- Phase 2 of ResQ <-> SF sync v2: move sync state out of the single Netlify
+-- Blob ("wo-mapping") into queryable ops.* tables + an append-only audit trail.
+--
+-- This migration only CREATES the tables. The worker dual-writes into them each
+-- run (blob stays the authoritative read source for now), so this is additive
+-- and cannot break the live sync. A later phase cuts reads over and drops the
+-- blob.
+
+-- One row per ResQ work order <-> SF job link (replaces the wo-mapping blob).
+create table if not exists ops.resq_sf_links (
+  id                 bigint generated always as identity primary key,
+  resq_wo_id         text unique not null,        -- the wo-mapping key (ResQ WO node id)
+  resq_code          text,
+  sf_job_id          text,
+  sf_job_number      text,
+  resq_status        text,
+  sf_status          text,
+  facility           text,
+  customer_qbo_id    text,                         -- links to ops.sync_customers.qbo_customer_id
+  customer_name      text,
+  title              text,
+  reconciled         boolean default false,
+  sf_deleted         boolean default false,
+  photos_sent        boolean default false,
+  invoice_submitted  boolean default false,
+  visit_completed    boolean default false,
+  linked_existing    boolean default false,
+  replaced_sf_job_id text,
+  raw                jsonb,                         -- full map entry, forward-compat
+  created_at         timestamptz default now(),
+  last_sync_at       timestamptz,
+  updated_at         timestamptz default now()
+);
+create index if not exists resq_sf_links_code_idx  on ops.resq_sf_links (resq_code);
+create index if not exists resq_sf_links_sfjob_idx on ops.resq_sf_links (sf_job_id);
+
+-- Append-only audit trail (replaces the dedupe-report / last-errors blobs).
+create table if not exists ops.sync_events (
+  id          bigint generated always as identity primary key,
+  resq_wo_id  text,
+  resq_code   text,
+  sf_job_id   text,
+  direction   text,                                -- 'resq->sf' | 'sf->resq' | 'system'
+  action      text not null,                       -- created | updated | linked | relinked | cancelled_duplicate | error | ...
+  ok          boolean default true,
+  message     text,
+  payload     jsonb,
+  created_at  timestamptz default now()
+);
+create index if not exists sync_events_code_idx    on ops.sync_events (resq_code);
+create index if not exists sync_events_created_idx on ops.sync_events (created_at desc);
+
+-- RLS: anon/authenticated may read (dashboard); writes via service-role only.
+alter table ops.resq_sf_links enable row level security;
+alter table ops.sync_events  enable row level security;
+
+drop policy if exists resq_sf_links_read on ops.resq_sf_links;
+create policy resq_sf_links_read on ops.resq_sf_links for select to anon, authenticated using (true);
+
+drop policy if exists sync_events_read on ops.sync_events;
+create policy sync_events_read on ops.sync_events for select to anon, authenticated using (true);
+
+-- keep resq_sf_links.updated_at fresh
+create or replace function ops.tg_resq_sf_links_touch() returns trigger
+  language plpgsql as $$
+begin new.updated_at := now(); return new; end $$;
+drop trigger if exists trg_resq_sf_links_touch on ops.resq_sf_links;
+create trigger trg_resq_sf_links_touch before update on ops.resq_sf_links
+  for each row execute function ops.tg_resq_sf_links_touch();

--- a/supabase/migrations/20260602d_site_settings.sql
+++ b/supabase/migrations/20260602d_site_settings.sql
@@ -1,0 +1,31 @@
+-- 20260602d_site_settings.sql
+-- Generic key/value site settings, readable by any app (anon) so a flag set
+-- here is visible everywhere; writes via service-role only.
+-- First use: the maintenance flag / banner.
+
+create table if not exists ops.site_settings (
+  key        text primary key,
+  value      jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now(),
+  updated_by text
+);
+
+alter table ops.site_settings enable row level security;
+drop policy if exists site_settings_read on ops.site_settings;
+create policy site_settings_read on ops.site_settings for select to anon, authenticated using (true);
+
+create or replace function ops.tg_site_settings_touch() returns trigger
+  language plpgsql as $$
+begin new.updated_at := now(); return new; end $$;
+drop trigger if exists trg_site_settings_touch on ops.site_settings;
+create trigger trg_site_settings_touch before update on ops.site_settings
+  for each row execute function ops.tg_site_settings_touch();
+
+-- Seed the maintenance flag (off by default).
+insert into ops.site_settings (key, value) values
+  ('maintenance', jsonb_build_object(
+    'enabled', false,
+    'title', '🛠️ System Maintenance',
+    'message', 'This system is being updated — please check back later. Sky is on a vibe-code bender trying to make this system better. If it''s clogging your day, call or text him and tell him to turn off maintenance so you can get some work done.'
+  ))
+on conflict (key) do nothing;


### PR DESCRIPTION
Two things in this PR (bundled because the GitHub API was rate-limited between them — same branch).

## Phase 2 — sync state → queryable ops.* tables (dual-write)
Moves sync state toward `ops.*` **without changing sync behavior** — the Netlify Blob stays the authoritative read source; the tables are a mirror + audit trail.
- Migration `20260602c` (applied): `ops.resq_sf_links` (one row per ResQ WO ↔ SF job link) + `ops.sync_events` (append-only audit). RLS anon-SELECT, indexes, trigger.
- `lib/resq-sf-links.mjs` — bulk upsert links + insert events (service role); **all writes strictly non-fatal**.
- `resq-sf-sync-background.mjs` — collects an event per processed/errored WO and end-of-run dual-writes the full mapping + events.
- `resq-sf-links.mjs` — read-only superadmin endpoint; `sync.html` gets a "🧾 Recent Sync Events" panel.
- ResQ→SF create/dedup and SF↔ResQ status/visit/invoice logic untouched (the Approve→Unscheduled→…→completion flow is preserved).

## Maintenance Mode + Settings (control panel)
- Migration `20260602d` (applied): `ops.site_settings` (generic key/value, anon-read, service-role write) seeded with a `maintenance` flag (off) + editable title/message.
- `site-settings.mjs` — public GET (banner reads for any visitor), superadmin POST to toggle.
- `maintenance-banner.js` — self-contained drop-in; reads the flag from Supabase with the public anon key, shows a fixed top notice bar when enabled, re-checks every 60s, dismissible per session. Reusable in any app (gateway end-goal). Wired into dashboard / sync / setup / control / index.
- `control.html` (Master Control) — new **Maintenance Mode** card (toggle + editable title/message) and the **Linked Customers** manager (moved here from sync.html, which now points to it).

schema-snapshot + sync-manifest updated for both new tables; lint passes (26 writers / 78 tables).

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU