### PR TITLE
fix(settings): Maintenance + Linked Customers write via caller JWT (no service role)

### DIFF
--- a/netlify/functions/lib/resq-sf-links.mjs
+++ b/netlify/functions/lib/resq-sf-links.mjs
@@ -51,7 +51,9 @@ export function mapEntryToLinkRow(resqWoId, e) {
 // Upsert all links in one request (PostgREST array upsert on resq_wo_id).
 // Backfills the table from the current mapping and keeps it current.
 export async function bulkUpsertLinks(rows) {
-  if (!SERVICE_KEY) throw new Error('SUPABASE_SERVICE_ROLE_KEY not set');
+  // No service-role key on apbg-billing → the Phase 2 mirror stays dormant
+  // (sync still runs fine off the Blob). Skip cleanly rather than error every run.
+  if (!SERVICE_KEY) return 0;
   if (!rows || !rows.length) return 0;
   const res = await fetch(`${SUPABASE_URL}/rest/v1/resq_sf_links?on_conflict=resq_wo_id`, {
     method: 'POST',
@@ -64,7 +66,7 @@ export async function bulkUpsertLinks(rows) {
 
 // Append audit events in one request.
 export async function bulkInsertEvents(events) {
-  if (!SERVICE_KEY) throw new Error('SUPABASE_SERVICE_ROLE_KEY not set');
+  if (!SERVICE_KEY) return 0;
   if (!events || !events.length) return 0;
   const res = await fetch(`${SUPABASE_URL}/rest/v1/sync_events`, {
     method: 'POST',

--- a/netlify/functions/site-settings.mjs
+++ b/netlify/functions/site-settings.mjs
@@ -11,7 +11,6 @@ import { requireAuth } from './lib/auth.mjs';
 import { corsHeaders } from './qbo-helpers.mjs';
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from './supabase-helpers.mjs';
 
-const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const TABLE = `${SUPABASE_URL}/rest/v1/site_settings`;
 
 function json(body, status = 200) {
@@ -46,7 +45,9 @@ export async function handler(event) {
 
   const auth = await requireAuth(event);
   if (!auth.ok) return auth.response;
-  if (!SERVICE_KEY) return json({ error: 'SUPABASE_SERVICE_ROLE_KEY not configured' }, 500);
+  // apbg-billing has no service-role key — write with the caller's superadmin
+  // JWT and let RLS authorize (requireAuth already gated to superadmin).
+  const authHeader = event.headers?.authorization || event.headers?.Authorization;
 
   try {
     const body = JSON.parse(event.body || '{}');
@@ -59,8 +60,8 @@ export async function handler(event) {
     const res = await fetch(`${TABLE}?on_conflict=key`, {
       method: 'POST',
       headers: {
-        apikey: SERVICE_KEY,
-        Authorization: `Bearer ${SERVICE_KEY}`,
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: authHeader,
         'Content-Type': 'application/json',
         'Accept-Profile': 'ops',
         'Content-Profile': 'ops',

--- a/netlify/functions/sync-customers.mjs
+++ b/netlify/functions/sync-customers.mjs
@@ -9,14 +9,13 @@
 //   POST { action: 'unlink', id }            -> soft-unlink (linked=false)
 //   POST { action: 'relink', id }            -> set linked=true
 //
-// Reads use the anon key (RLS allows SELECT). Writes use the service-role key.
-// Superadmin JWT required (requireAuth).
+// Reads use the anon key (RLS allows SELECT). Writes use the caller's superadmin
+// JWT + RLS (apbg-billing has no service-role key). Superadmin required (requireAuth).
 
 import { qboQuery, corsHeaders } from './qbo-helpers.mjs';
 import { requireAuth } from './lib/auth.mjs';
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from './supabase-helpers.mjs';
 
-const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const TABLE = `${SUPABASE_URL}/rest/v1/sync_customers`;
 
 function json(body, status = 200) {
@@ -32,13 +31,14 @@ async function sbRead() {
   return res.json();
 }
 
-async function sbWrite(method, body, query = '') {
-  if (!SERVICE_KEY) throw new Error('SUPABASE_SERVICE_ROLE_KEY not configured');
+// Writes use the caller's superadmin JWT + RLS (apbg-billing has no service
+// role key). requireAuth already gated to superadmin; RLS double-checks.
+async function sbWrite(authHeader, method, body, query = '') {
   const res = await fetch(`${TABLE}${query}`, {
     method,
     headers: {
-      apikey: SERVICE_KEY,
-      Authorization: `Bearer ${SERVICE_KEY}`,
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: authHeader,
       'Content-Type': 'application/json',
       'Accept-Profile': 'ops',
       'Content-Profile': 'ops',
@@ -63,6 +63,7 @@ export async function handler(event) {
 
   const auth = await requireAuth(event);
   if (!auth.ok) return auth.response;
+  const authHeader = event.headers?.authorization || event.headers?.Authorization;
 
   try {
     if (event.httpMethod === 'GET') {
@@ -99,7 +100,7 @@ export async function handler(event) {
         linked: true,
         notes: body.notes || null,
       };
-      const result = await sbWrite('POST', [row], '?on_conflict=qbo_customer_id');
+      const result = await sbWrite(authHeader, 'POST', [row], '?on_conflict=qbo_customer_id');
       return json({ ok: true, customer: Array.isArray(result) ? result[0] : result });
     }
 
@@ -114,13 +115,13 @@ export async function handler(event) {
       if (body.notes !== undefined) patch.notes = body.notes || null;
       if (body.linked !== undefined) patch.linked = !!body.linked;
       if (Object.keys(patch).length === 0) return json({ error: 'no fields to update' }, 400);
-      const result = await sbWrite('PATCH', patch, `?id=eq.${encodeURIComponent(body.id)}`);
+      const result = await sbWrite(authHeader, 'PATCH', patch, `?id=eq.${encodeURIComponent(body.id)}`);
       return json({ ok: true, customer: Array.isArray(result) ? result[0] : result });
     }
 
     if (action === 'unlink' || action === 'relink') {
       if (!body.id) return json({ error: 'id required' }, 400);
-      const result = await sbWrite('PATCH', { linked: action === 'relink' }, `?id=eq.${encodeURIComponent(body.id)}`);
+      const result = await sbWrite(authHeader, 'PATCH', { linked: action === 'relink' }, `?id=eq.${encodeURIComponent(body.id)}`);
       return json({ ok: true, customer: Array.isArray(result) ? result[0] : result });
     }
 

--- a/supabase/migrations/20260602e_settings_write_rls.sql
+++ b/supabase/migrations/20260602e_settings_write_rls.sql
@@ -1,0 +1,35 @@
+-- 20260602e_settings_write_rls.sql
+-- apbg-billing has no service-role key (by design — see CLAUDE.md). Writes go
+-- through the caller's Supabase JWT + RLS, like the Brixpense functions.
+-- The earlier settings/sync-customers writes wrongly assumed a service role,
+-- so the toggle/link buttons failed with "SUPABASE_SERVICE_ROLE_KEY not
+-- configured". This grants superadmin writes via JWT + RLS instead.
+
+-- Superadmin check from the JWT (gateway sets role in app_metadata; fall back
+-- to user_metadata to be safe).
+create or replace function ops.is_superadmin_jwt() returns boolean
+  language sql stable as $$
+  select coalesce(
+    (auth.jwt() -> 'app_metadata'  ->> 'role'),
+    (auth.jwt() -> 'user_metadata' ->> 'role')
+  ) = 'superadmin';
+$$;
+
+-- PostgREST checks table GRANTs before RLS; ops tables had writes revoked from
+-- authenticated (APBG-OPS lockdown 0009), so re-grant on just these two.
+grant insert, update on ops.site_settings  to authenticated;
+grant insert, update on ops.sync_customers to authenticated;
+
+drop policy if exists site_settings_ins on ops.site_settings;
+create policy site_settings_ins on ops.site_settings
+  for insert to authenticated with check (ops.is_superadmin_jwt());
+drop policy if exists site_settings_upd on ops.site_settings;
+create policy site_settings_upd on ops.site_settings
+  for update to authenticated using (ops.is_superadmin_jwt()) with check (ops.is_superadmin_jwt());
+
+drop policy if exists sync_customers_ins on ops.sync_customers;
+create policy sync_customers_ins on ops.sync_customers
+  for insert to authenticated with check (ops.is_superadmin_jwt());
+drop policy if exists sync_customers_upd on ops.sync_customers;
+create policy sync_customers_upd on ops.sync_customers
+  for update to authenticated using (ops.is_superadmin_jwt()) with check (ops.is_superadmin_jwt());


### PR DESCRIPTION
## Fix
The Maintenance toggle (and Linked Customers link/unlink) failed with **"SUPABASE_SERVICE_ROLE_KEY not configured"**. apbg-billing intentionally has **no** service-role key — it writes `ops.*` with the caller's Supabase JWT + RLS (same pattern as the Brixpense functions). My settings writes wrongly used the service role.

- **Migration `20260602e`** (applied to live): `ops.is_superadmin_jwt()` + `INSERT/UPDATE` grants and superadmin RLS write-policies on `ops.site_settings` and `ops.sync_customers`.
- **`site-settings.mjs` + `sync-customers.mjs`**: writes now use the caller's superadmin JWT (anon key + Authorization header). `requireAuth` still gates to superadmin; RLS double-checks in the DB.
- **`lib/resq-sf-links.mjs`**: the Phase 2 mirror writes skip cleanly when there's no service key (sync keeps running off the Blob) instead of erroring every run.

## Verify
Master Control → Maintenance Mode → toggle on/off should now succeed; Linked Customers link/unlink/edit should save.

## Note
The Phase 2 mirror (`ops.resq_sf_links` / `sync_events`) stays **dormant** until a `SUPABASE_SERVICE_ROLE_KEY` is set on the apbg-billing Netlify site (the background cron has no user JWT to write with). Sync itself is unaffected. Easy to activate later by adding that env var (same key the melt-dashboard uses).

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU)_