### PR TITLE
Sync v2 Phase 3: on-demand single-job sync + auto-pull SF photos → ResQ

### DIFF
--- a/netlify/functions/lib/sf-assets.mjs
+++ b/netlify/functions/lib/sf-assets.mjs
@@ -1,0 +1,121 @@
+// SF asset fetch — pull a Service Fusion job's picture/document bytes.
+//
+// SF exposes picture METADATA via the API (GET /jobs/{id}?expand=pictures) but
+// not the bytes. Two storage classes, two fetch strategies:
+//   - pictures/signatures live on a public-read S3 prefix
+//     (servicefusion.s3.amazonaws.com/images/estimates|sign/) → anonymous GET.
+//   - documents/receipts live behind the web-portal session on
+//     admin.servicefusion.com → require the SF portal cookie.
+// We try the public S3 URL first and fall back to the portal cookie when the
+// asset is on a portal host AND a cookie is available. The cookie lives in the
+// shared Supabase row `sf_portal_session` (id=1), readable only with the
+// service-role key — so the cookie path is a no-op until SUPABASE_SERVICE_ROLE_KEY
+// is set on this site; the public-S3 path works without it.
+
+import { sfRequest } from '../sf-helpers.mjs';
+
+const SF_S3_BASE = 'https://servicefusion.s3.amazonaws.com';
+const SUPABASE_URL = process.env.SUPABASE_URL || 'https://gfsdpwiqzshhexkofiif.supabase.co';
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+const ALLOWED_COOKIE_HOSTS = new Set(['admin.servicefusion.com', 'api.servicefusion.com']);
+
+export function resolveSfAssetUrl(kind, fileLocation) {
+  if (/^https?:\/\//i.test(fileLocation)) return fileLocation;
+  const fname = String(fileLocation).replace(/^\/+/, '');
+  const prefix = kind === 'signature' ? 'images/sign' : 'images/estimates';
+  return `${SF_S3_BASE}/${prefix}/${fname}`;
+}
+
+function inferMime(name = '') {
+  const l = name.toLowerCase();
+  if (l.endsWith('.png')) return 'image/png';
+  if (l.endsWith('.jpg') || l.endsWith('.jpeg')) return 'image/jpeg';
+  if (l.endsWith('.gif')) return 'image/gif';
+  if (l.endsWith('.webp')) return 'image/webp';
+  if (l.endsWith('.heic')) return 'image/heic';
+  if (l.endsWith('.pdf')) return 'application/pdf';
+  return 'application/octet-stream';
+}
+
+// Cookie lookup is memoized per cold start. undefined = not looked up yet,
+// null = looked up and unavailable, string = the assembled Cookie header.
+let _cookieCache;
+export async function getPortalCookies() {
+  if (_cookieCache !== undefined) return _cookieCache;
+  _cookieCache = null;
+  if (!SERVICE_KEY) return _cookieCache;
+  try {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/sf_portal_session?id=eq.1&select=*`, {
+      headers: { apikey: SERVICE_KEY, Authorization: `Bearer ${SERVICE_KEY}` },
+    });
+    if (!res.ok) return _cookieCache;
+    const rows = await res.json();
+    const r = Array.isArray(rows) ? rows[0] : null;
+    if (!r) return _cookieCache;
+    const parts = [];
+    if (r.xsrf_token) parts.push(`XSRF-TOKEN=${r.xsrf_token}`);
+    if (r.servicefusion_session) parts.push(`servicefusion_session=${r.servicefusion_session}`);
+    if (r.session_token) parts.push(`session_token=${r.session_token}`);
+    if (r.phpsessid) parts.push(`PHPSESSID=${r.phpsessid}`);
+    if (r.remember_me_company) parts.push(`remember_me_company=${r.remember_me_company}`);
+    if (r.remember_me_user) parts.push(`remember_me_user=${r.remember_me_user}`);
+    if (r.remember_me_company_id) parts.push(`remember_me_company_id=${r.remember_me_company_id}`);
+    _cookieCache = parts.length ? parts.join('; ') : null;
+  } catch { /* leave as null */ }
+  return _cookieCache;
+}
+
+function isBinaryOk(res, ct) {
+  return res.ok && !/text\/html|application\/xml/i.test(ct);
+}
+
+// Fetch asset bytes: anonymous first, cookie fallback for SF portal hosts.
+export async function fetchSfAssetBytes(url) {
+  const baseHeaders = { Accept: 'image/*,application/pdf,*/*', 'User-Agent': 'apbg-billing-sync/1.0' };
+
+  // 1. Anonymous (works for the public S3 prefix).
+  try {
+    const res = await fetch(url, { headers: baseHeaders, redirect: 'follow' });
+    const ct = res.headers.get('content-type') || 'application/octet-stream';
+    if (isBinaryOk(res, ct)) return { ok: true, bytes: await res.arrayBuffer(), contentType: ct };
+  } catch { /* fall through to cookie */ }
+
+  // 2. Cookie fallback (only for SF portal hosts, only if a cookie is loaded).
+  let host = '';
+  try { host = new URL(url).hostname; } catch { /* malformed */ }
+  if (ALLOWED_COOKIE_HOSTS.has(host)) {
+    const cookie = await getPortalCookies();
+    if (cookie) {
+      try {
+        const res = await fetch(url, { headers: { ...baseHeaders, Cookie: cookie }, redirect: 'follow' });
+        const ct = res.headers.get('content-type') || 'application/octet-stream';
+        if (isBinaryOk(res, ct)) return { ok: true, bytes: await res.arrayBuffer(), contentType: ct };
+        return { ok: false, error: `${url} -> ${res.status} ${ct} (cookie)` };
+      } catch (e) {
+        return { ok: false, error: `${url} threw ${e.message} (cookie)` };
+      }
+    }
+    return { ok: false, error: `${url} needs portal cookie but none available (set SUPABASE_SERVICE_ROLE_KEY)` };
+  }
+  return { ok: false, error: `${url} not fetchable anonymously` };
+}
+
+// List a SF job's non-private pictures (metadata only).
+export async function listJobPictures(sfJobId) {
+  const job = await sfRequest('GET', `/jobs/${encodeURIComponent(sfJobId)}?expand=pictures`);
+  return (job.pictures || []).filter((p) => !p.is_private && p.file_location);
+}
+
+// Resolve one SF picture object to base64 bytes ready for the ResQ mutation.
+export async function pictureToBase64(p) {
+  const name = (p.name && p.name.trim()) || String(p.file_location).split('/').pop() || 'pic';
+  const url = resolveSfAssetUrl('picture', p.file_location);
+  const r = await fetchSfAssetBytes(url);
+  if (!r.ok) return { ok: false, error: `${name}: ${r.error}` };
+  return {
+    ok: true,
+    name,
+    base64: Buffer.from(r.bytes).toString('base64'),
+    contentType: r.contentType || inferMime(name),
+  };
+}

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -1244,3 +1244,65 @@ async function saveBlob(key, value) {
     if (store) await store.set(key, value);
   } catch (e) {}
 }
+
+// --- Single work-order sync (Phase 3: on-demand / webhook target) ---
+// Runs the same bidirectional sync as the cron, but for exactly one ResQ WO,
+// identified by its code. Reuses the proven create/dedup + status/invoice
+// logic. Returns { steps, errors, created, updated }.
+export async function syncSingleByCode(resqCode) {
+  const out = { steps: [], errors: [], created: 0, updated: 0, resqCode };
+  const code = String(resqCode || '').replace(/^R/i, '').trim();
+  if (!code) { out.errors.push('resqCode required'); return out; }
+
+  let session;
+  try { session = await resqLogin(); }
+  catch (e) { out.errors.push(`ResQ login: ${e.message}`); return out; }
+
+  // Fetch this one WO with the same node shape fetchSyncableWOs uses.
+  let n;
+  try {
+    const data = await resqGql(session, `query($code:String){ workOrders(first:5, code:$code){ edges { node {
+      id code title description status statusDescription
+      raisedOn completedOn scheduledForStart scheduledForEnd
+      spend vendorTotal isUrgent isCallback onHold serviceCategory
+      facility { id name } equipment { id name } vendor { id name } executingVendor { id name }
+    } } } }`, { code });
+    const edges = data.data?.workOrders?.edges || [];
+    n = (edges.find(e => e.node.code === code) || edges[0])?.node;
+  } catch (e) { out.errors.push(`ResQ lookup ${code}: ${e.message}`); return out; }
+  if (!n) { out.errors.push(`ResQ WO ${code} not found`); return out; }
+
+  const wo = {
+    id: n.id, code: n.code, title: n.title || '', description: n.description || '',
+    status: n.status, statusDescription: n.statusDescription || '',
+    raisedOn: n.raisedOn, completedOn: n.completedOn,
+    scheduledStart: n.scheduledForStart, scheduledEnd: n.scheduledForEnd,
+    spend: n.spend ? parseFloat(n.spend) : null, vendorTotal: n.vendorTotal ? parseFloat(n.vendorTotal) : null,
+    isUrgent: n.isUrgent, isCallback: n.isCallback, onHold: n.onHold, serviceCategory: n.serviceCategory,
+    facility: n.facility?.name || '', facilityId: n.facility?.id || '', equipment: n.equipment?.name || '',
+  };
+
+  const mapping = await loadMapping();
+  const syncCustomers = await loadSyncCustomers();
+
+  try {
+    let r;
+    if (mapping[wo.id]) {
+      if (mapping[wo.id].sfDeleted) { out.steps.push(`${wo.code}: linked SF job was deleted — skipped`); return out; }
+      r = await syncBidirectional(session, wo, mapping[wo.id]);
+      out.updated += r.updated || 0;
+    } else {
+      const st = (wo.status || '').toUpperCase();
+      if (RESQ_DONE_STATUSES.includes(st)) { out.steps.push(`${wo.code}: already ${wo.status} — no SF job created`); return out; }
+      r = await processNewWO(wo, mapping, syncCustomers);
+      out.created += r.created || 0;
+    }
+    if (r.steps?.length) out.steps.push(...r.steps);
+    if (r.errors?.length) out.errors.push(...r.errors);
+    await saveMapping(mapping);
+  } catch (e) {
+    out.errors.push(`${wo.code}: ${e.message}`);
+  }
+  return out;
+}
+

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -18,6 +18,7 @@ export async function handler(event) {
   if (qs.deleteMapping) return handleDeleteMapping(qs.deleteMapping);
   if (qs.uploadPhoto) return handleUploadPhoto(event, qs.uploadPhoto);
   if (qs.visitPhotos) return handleVisitPhotos(event, qs.visitPhotos);
+  if (qs.autoPhotos) return handleAutoPhotos(event, qs.autoPhotos);
   if (qs.introspect) return handleIntrospect(qs.introspect);
   if (qs.dedupeReport) return handleDedupeReport();
   if (qs.cancelSfJob) return handleCancelSfJob(qs.cancelSfJob, qs.resqCode);
@@ -294,75 +295,122 @@ async function handleUploadPhoto(event, resqWoId) {
 async function handleVisitPhotos(event, resqWoId) {
   if (event.httpMethod !== 'POST') return json({ error: 'POST required' }, 405);
   try {
-    const { resqLogin, resqGql } = await import('./resq-helpers.mjs');
     const body = JSON.parse(event.body || '{}');
     const files = body.files || [];
     const photoType = body.type || 'after'; // 'before' or 'after'
     if (!files.length) return json({ error: 'No files. Send { type: "before"|"after", files: [{ name, base64, contentType }] }' }, 400);
-
-    const session = await resqLogin();
-
-    // Get the visit ID from the WO — try by code first, then scan
-    // resqWoId could be a base64 WO ID or a code like R0960134
-    const isCode = /^R?\d+$/.test(resqWoId);
-    let visitId;
-    if (isCode) {
-      const code = resqWoId.startsWith('R') ? resqWoId : `R${resqWoId}`;
-      const woData = await resqGql(session, `{
-        workOrders(first: 1, code: "${code}") {
-          edges { node { latestVisit { id outcome } inProgressVisit { id outcome } } }
-        }
-      }`);
-      const woNode = woData.data?.workOrders?.edges?.[0]?.node;
-      visitId = woNode?.inProgressVisit?.id || woNode?.latestVisit?.id;
-    } else {
-      // Try to find by scanning recent WOs
-      const woData = await resqGql(session, `{
-        workOrders(first: 100, orderBy: "-raised_on") {
-          edges { node { id latestVisit { id outcome } inProgressVisit { id outcome } } }
-        }
-      }`);
-      const match = woData.data?.workOrders?.edges?.find(e => e.node.id === resqWoId);
-      visitId = match?.node?.inProgressVisit?.id || match?.node?.latestVisit?.id;
-    }
-    if (!visitId) return json({ error: 'No visit found on this work order' }, 404);
-
-    // Build image array — ResQ expects data URLs
-    const images = files.map(f => {
-      const ct = f.contentType || 'image/jpeg';
-      return `data:${ct};base64,${f.base64}`;
-    });
-
-    const mutation = photoType === 'before' ? 'addBeforeImagesToVisit' : 'addAfterImagesToVisit';
-    const inputType = photoType === 'before' ? 'AddBeforeImagesToVisitInput' : 'AddAfterImagesToVisitInput';
-
-    const result = await resqGql(session, `mutation($input: ${inputType}!) {
-      ${mutation}(input: $input) { __typename }
-    }`, { input: {
-      visit: visitId,
-      images,
-    }});
-
-    // Mark photosSent in mapping
-    try {
-      const store = await getStore();
-      if (store) {
-        const raw = await store.get('wo-mapping');
-        const mapping = raw ? JSON.parse(raw) : {};
-        for (const [k, v] of Object.entries(mapping)) {
-          if (k === resqWoId || v.resqCode === resqWoId) {
-            v.photosSent = true;
-            v.lastSyncAt = new Date().toISOString();
-          }
-        }
-        await store.set('wo-mapping', JSON.stringify(mapping));
-      }
-    } catch (e) {}
-
-    return json({ ok: true, mutation, visitId, imagesUploaded: files.length });
+    const result = await pushFilesToVisit(resqWoId, photoType, files);
+    return json(result, result.ok ? 200 : (result.status || 500));
   } catch (e) {
     return json({ error: e.message }, 500);
   }
+}
+
+// --- Auto Photos: pull a SF job's pictures from SF and push to the ResQ visit ---
+// GET or POST ?autoPhotos=<resqWoIdOrCode>[&sfJob=<id>][&type=before|after]
+// Replaces the manual "upload pictures into the sync program" step: the bytes
+// come straight from Service Fusion (public S3, cookie fallback for portal-hosted
+// assets). If sfJob is omitted we resolve it from the wo-mapping blob by code/id.
+async function handleAutoPhotos(event, resqWoId) {
+  try {
+    const qs = event.queryStringParameters || {};
+    const photoType = qs.type || 'after';
+    let sfJobId = qs.sfJob || null;
+
+    if (!sfJobId) {
+      try {
+        const store = await getStore();
+        const raw = store ? await store.get('wo-mapping') : null;
+        const mapping = raw ? JSON.parse(raw) : {};
+        for (const [k, v] of Object.entries(mapping)) {
+          if (k === resqWoId || v.resqCode === resqWoId) { sfJobId = v.sfJobId; break; }
+        }
+      } catch (e) { /* fall through */ }
+    }
+    if (!sfJobId) return json({ error: 'No SF job id — pass ?sfJob=<id> or ensure the WO is mapped' }, 400);
+
+    const { listJobPictures, pictureToBase64 } = await import('./lib/sf-assets.mjs');
+    const pics = await listJobPictures(sfJobId);
+    if (!pics.length) return json({ ok: true, imagesUploaded: 0, picturesFound: 0, message: 'No pictures on SF job' });
+
+    const files = [];
+    const fetchErrors = [];
+    for (const p of pics) {
+      const r = await pictureToBase64(p);
+      if (r.ok) files.push({ name: r.name, base64: r.base64, contentType: r.contentType });
+      else fetchErrors.push(r.error);
+    }
+    if (!files.length) return json({ ok: false, error: 'Could not fetch any pictures from SF', picturesFound: pics.length, fetchErrors }, 502);
+
+    const result = await pushFilesToVisit(resqWoId, photoType, files);
+    return json({ ...result, sfJobId, picturesFound: pics.length, fetchErrors }, result.ok ? 200 : (result.status || 500));
+  } catch (e) {
+    return json({ error: e.message }, 500);
+  }
+}
+
+// Core: resolve the ResQ visit for a WO and upload before/after images.
+// files: [{ base64, contentType }]. Returns { ok, mutation, visitId, imagesUploaded }
+// or { ok:false, status, error }. Shared by the manual upload + auto-pull paths.
+async function pushFilesToVisit(resqWoId, photoType, files) {
+  const { resqLogin, resqGql } = await import('./resq-helpers.mjs');
+  const session = await resqLogin();
+
+  // Get the visit ID from the WO — try by code first, then scan
+  // resqWoId could be a base64 WO ID or a code like R0960134
+  const isCode = /^R?\d+$/.test(resqWoId);
+  let visitId;
+  if (isCode) {
+    const code = resqWoId.startsWith('R') ? resqWoId : `R${resqWoId}`;
+    const woData = await resqGql(session, `{
+      workOrders(first: 1, code: "${code}") {
+        edges { node { latestVisit { id outcome } inProgressVisit { id outcome } } }
+      }
+    }`);
+    const woNode = woData.data?.workOrders?.edges?.[0]?.node;
+    visitId = woNode?.inProgressVisit?.id || woNode?.latestVisit?.id;
+  } else {
+    // Try to find by scanning recent WOs
+    const woData = await resqGql(session, `{
+      workOrders(first: 100, orderBy: "-raised_on") {
+        edges { node { id latestVisit { id outcome } inProgressVisit { id outcome } } }
+      }
+    }`);
+    const match = woData.data?.workOrders?.edges?.find(e => e.node.id === resqWoId);
+    visitId = match?.node?.inProgressVisit?.id || match?.node?.latestVisit?.id;
+  }
+  if (!visitId) return { ok: false, status: 404, error: 'No visit found on this work order' };
+
+  // Build image array — ResQ expects data URLs
+  const images = files.map(f => {
+    const ct = f.contentType || 'image/jpeg';
+    return `data:${ct};base64,${f.base64}`;
+  });
+
+  const mutation = photoType === 'before' ? 'addBeforeImagesToVisit' : 'addAfterImagesToVisit';
+  const inputType = photoType === 'before' ? 'AddBeforeImagesToVisitInput' : 'AddAfterImagesToVisitInput';
+
+  await resqGql(session, `mutation($input: ${inputType}!) {
+    ${mutation}(input: $input) { __typename }
+  }`, { input: { visit: visitId, images } });
+
+  // Mark photosSent in mapping
+  try {
+    const store = await getStore();
+    if (store) {
+      const raw = await store.get('wo-mapping');
+      const mapping = raw ? JSON.parse(raw) : {};
+      for (const [k, v] of Object.entries(mapping)) {
+        if (k === resqWoId || v.resqCode === resqWoId) {
+          v.photosSent = true;
+          v.lastSyncAt = new Date().toISOString();
+        }
+      }
+      await store.set('wo-mapping', JSON.stringify(mapping));
+    }
+  } catch (e) {}
+
+  return { ok: true, mutation, visitId, imagesUploaded: files.length };
 }
 
 // --- Reset Flags: Clear photosSent/invoiceSubmitted for a WO code ---

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -24,9 +24,21 @@ export async function handler(event) {
   if (qs.relink) return handleRelink(qs.relink, qs.toSfJobId);
   if (qs.dismissIssue) return handleDismissIssue(qs.dismissIssue);
   if (qs.clearErrors) return handleClearErrors();
+  if (qs.syncOne) return handleSyncOne(qs.syncOne);
   if (event.httpMethod === 'GET') return handleGet();
   if (event.httpMethod === 'POST') return handlePost(event);
   return { statusCode: 405, body: 'GET or POST only' };
+}
+
+// --- Sync one WO now (authed; powers the dashboard "force sync" button) ---
+async function handleSyncOne(code) {
+  try {
+    const { syncSingleByCode } = await import('./resq-sf-sync-background.mjs');
+    const result = await syncSingleByCode(code);
+    return json(result, result.errors.length ? 207 : 200);
+  } catch (e) {
+    return json({ error: e.message }, 500);
+  }
 }
 
 // --- Lookup: Query ResQ for a specific WO code ---

--- a/netlify/functions/sf-webhook.mjs
+++ b/netlify/functions/sf-webhook.mjs
@@ -1,8 +1,9 @@
-// sf-webhook — on-demand single-job ResQ <-> SF sync target (Phase 3).
+// sf-webhook — on-demand single-job ResQ <-> SF sync (Phase 3).
 //
-// Trigger-agnostic: call it from a Service Fusion webhook/automation, a Zapier/
-// Make scenario, or by hand. It syncs ONE work order immediately instead of
-// waiting for the 5-min cron.
+// Internal trigger only (SF has no outbound webhook and we are NOT using
+// Zapier). Call it from our own code, a scheduled job, or by hand to sync ONE
+// work order immediately instead of waiting for the 5-min cron. The dashboard
+// "force-sync" button uses the authed resq-sf-sync?syncOne path instead.
 //
 //   POST { resq_code: "R12345" }      — sync that WO now
 //   POST { sf_job_id: "1088..." }     — resolve the WO via the SF job's po_number, then sync

--- a/netlify/functions/sf-webhook.mjs
+++ b/netlify/functions/sf-webhook.mjs
@@ -1,0 +1,65 @@
+// sf-webhook — on-demand single-job ResQ <-> SF sync target (Phase 3).
+//
+// Trigger-agnostic: call it from a Service Fusion webhook/automation, a Zapier/
+// Make scenario, or by hand. It syncs ONE work order immediately instead of
+// waiting for the 5-min cron.
+//
+//   POST { resq_code: "R12345" }      — sync that WO now
+//   POST { sf_job_id: "1088..." }     — resolve the WO via the SF job's po_number, then sync
+//   GET  ?resq_code=R12345            — same, convenience for quick manual hits
+//
+// Auth: shared secret via ?secret= or X-Webhook-Secret header
+// (SF_WEBHOOK_SECRET, falling back to INBOUND_EMAIL_SECRET). If neither env var
+// is set the endpoint warns and processes anyway (it only triggers a sync, no
+// destructive surface) — set a secret in production.
+
+import { syncSingleByCode } from './resq-sf-sync-background.mjs';
+import { sfRequest } from './sf-helpers.mjs';
+
+const SECRET = process.env.SF_WEBHOOK_SECRET || process.env.INBOUND_EMAIL_SECRET || '';
+
+function json(body, status = 200) {
+  return { statusCode: status, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) };
+}
+
+export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, body: '' };
+
+  const qs = event.queryStringParameters || {};
+  const h = event.headers || {};
+  const provided = qs.secret || h['x-webhook-secret'] || h['X-Webhook-Secret'] || '';
+  if (SECRET) {
+    if (provided !== SECRET) return json({ error: 'bad or missing secret' }, 401);
+  } else {
+    console.warn('[sf-webhook] No SF_WEBHOOK_SECRET / INBOUND_EMAIL_SECRET set — endpoint is open.');
+  }
+
+  let body = {};
+  if (event.body) { try { body = JSON.parse(event.body); } catch { /* tolerate non-JSON */ } }
+
+  let resqCode = body.resq_code || body.resqCode || qs.resq_code || null;
+  const sfJobId = body.sf_job_id || body.sfJobId || body.job_id || body.id || qs.sf_job_id || null;
+
+  // If only an SF job id was given, read its po_number (we store R<code> there).
+  if (!resqCode && sfJobId) {
+    try {
+      const job = await sfRequest('GET', `/jobs/${encodeURIComponent(sfJobId)}`);
+      const po = String(job.po_number || '').trim();
+      if (po) resqCode = po;
+      else return json({ error: `SF job ${sfJobId} has no po_number to map to a ResQ WO` }, 422);
+    } catch (e) {
+      return json({ error: `SF job ${sfJobId} lookup failed: ${e.message}` }, 502);
+    }
+  }
+
+  if (!resqCode) return json({ error: 'resq_code or sf_job_id required' }, 400);
+
+  try {
+    const result = await syncSingleByCode(resqCode);
+    const ok = result.errors.length === 0;
+    return json({ ok, ...result }, ok ? 200 : 207);
+  } catch (e) {
+    console.error('sf-webhook error:', e);
+    return json({ error: e.message }, 500);
+  }
+}

--- a/public/sync.html
+++ b/public/sync.html
@@ -218,6 +218,7 @@ td a:hover,.review-head .code a:hover,.review-job .meta a:hover{color:#2E75B6;bo
     <div class="actions" style="margin-top:-12px">
       <input id="syncOneCode" placeholder="ResQ WO code (e.g. R12345)" style="padding:10px 12px;border:1px solid #D1D5DB;border-radius:8px;font-size:0.9rem;min-width:220px">
       <button class="secondary" id="syncOneBtn" onclick="syncOneWO()">⚡ Sync this WO now</button>
+      <button class="secondary" id="pullPhotosBtn" onclick="pullPhotos()">📷 Pull SF photos → ResQ</button>
       <span id="syncOneResult" style="align-self:center;font-size:0.82rem;color:#6B7280"></span>
     </div>
 
@@ -435,6 +436,25 @@ async function syncOneWO() {
     loadStatus(); loadSyncEvents();
   } catch (e) {
     out.textContent = `${code}: failed — ${e.message}`;
+  } finally { btn.disabled = false; }
+}
+
+// --- Pull SF photos → ResQ visit (auto-pull, no manual upload) ---
+async function pullPhotos() {
+  const code = (document.getElementById('syncOneCode').value || '').trim();
+  const out = document.getElementById('syncOneResult');
+  if (!code) { out.textContent = 'Enter a ResQ WO code first.'; return; }
+  const btn = document.getElementById('pullPhotosBtn');
+  btn.disabled = true; out.textContent = 'Pulling SF photos for ' + code + '…';
+  try {
+    const res = await fetch(`${API_BASE}/resq-sf-sync?autoPhotos=${encodeURIComponent(code)}`);
+    const data = await res.json();
+    if (data.error) throw new Error(data.error);
+    let msg = `${code}: ${data.imagesUploaded || 0}/${data.picturesFound || 0} photo(s) → ResQ`;
+    if (data.fetchErrors && data.fetchErrors.length) msg += ` (${data.fetchErrors.length} fetch error[s])`;
+    out.textContent = msg;
+  } catch (e) {
+    out.textContent = `${code}: photo pull failed — ${e.message}`;
   } finally { btn.disabled = false; }
 }
 

--- a/public/sync.html
+++ b/public/sync.html
@@ -215,6 +215,12 @@ td a:hover,.review-head .code a:hover,.review-job .meta a:hover{color:#2E75B6;bo
       <button class="secondary" id="clearErrBtn" onclick="clearErrors()">🧹 Clear Errors</button>
     </div>
 
+    <div class="actions" style="margin-top:-12px">
+      <input id="syncOneCode" placeholder="ResQ WO code (e.g. R12345)" style="padding:10px 12px;border:1px solid #D1D5DB;border-radius:8px;font-size:0.9rem;min-width:220px">
+      <button class="secondary" id="syncOneBtn" onclick="syncOneWO()">⚡ Sync this WO now</button>
+      <span id="syncOneResult" style="align-self:center;font-size:0.82rem;color:#6B7280"></span>
+    </div>
+
     <!-- Linked Customers moved to Master Control -->
     <div class="section">
       <h2>⚙️ Linked Customers</h2>
@@ -411,6 +417,25 @@ async function loadStatus() {
     document.getElementById('lastSyncSub').textContent = e.message;
     document.getElementById('cardLastSync').className = 'stat-card err';
   }
+}
+
+// --- Sync one WO now (force-sync a single work order) ---
+async function syncOneWO() {
+  const code = (document.getElementById('syncOneCode').value || '').trim();
+  const out = document.getElementById('syncOneResult');
+  if (!code) { out.textContent = 'Enter a ResQ WO code first.'; return; }
+  const btn = document.getElementById('syncOneBtn');
+  btn.disabled = true; out.textContent = 'Syncing ' + code + '…';
+  try {
+    const res = await fetch(`${API_BASE}/resq-sf-sync?syncOne=${encodeURIComponent(code)}`);
+    const data = await res.json();
+    if (data.error) throw new Error(data.error);
+    const msg = (data.steps && data.steps.length) ? data.steps[data.steps.length - 1] : 'No change';
+    out.textContent = `${code}: ${msg}` + (data.errors && data.errors.length ? ` — ${data.errors.length} error(s)` : '');
+    loadStatus(); loadSyncEvents();
+  } catch (e) {
+    out.textContent = `${code}: failed — ${e.message}`;
+  } finally { btn.disabled = false; }
 }
 
 // --- Run Sync ---


### PR DESCRIPTION
Phase 3 of the ResQ ↔ SF sync rebuild: faster, more automatic sync, with no Zapier.

## 1. On-demand single-job sync
SF's REST API has **no outbound webhook** (poll-only), so SF→ResQ stays API-polled — this adds a fast manual/internal path on top of the 5-min cron.
- `syncSingleByCode(resqCode)` in `resq-sf-sync-background.mjs` — same create/dedup + status/invoice logic as the cron, for one WO.
- `sf-webhook.mjs` — secret-gated internal/manual trigger (`{resq_code}` or `{sf_job_id}`). No Zapier.
- `?syncOne=<code>` authed path + **⚡ Sync this WO now** dashboard button.

## 2. Auto-pull SF photos → ResQ (replaces manual upload)
The manual "upload pictures into the sync program" step is gone — photos come straight from Service Fusion.
- **`lib/sf-assets.mjs`** (new) — lists a job's pictures (`expand=pictures`) and fetches bytes **public-S3 first** (`servicefusion.s3.amazonaws.com/images/estimates/…`, anonymous), **portal-cookie fallback** for `admin.servicefusion.com`-hosted assets (reads the shared `sf_portal_session` row; needs `SUPABASE_SERVICE_ROLE_KEY`).
- `resq-sf-sync.mjs` — new `?autoPhotos=<woCode>` handler feeds them to the existing `addBeforeImagesToVisit`/`addAfterImagesToVisit` ResQ mutation; manual + auto paths share one `pushFilesToVisit` core.
- **📷 Pull SF photos → ResQ** dashboard button.

Cron unchanged (safety-net reconciler). No new `ops.*` writers → no manifest change.

## Verify
sync.html → enter a ResQ WO code → **⚡ Sync this WO now** (creates/links/updates) and **📷 Pull SF photos → ResQ** (`N/N photo(s) → ResQ`, then confirm in the ResQ visit).

## Follow-ups (not in this PR)
- Wire auto-pull into the cron on WO completion.
- Flow 2: SF expense receipt → QBO bill **with attachment** (cookie fetch + net-new QBO Attachable/upload helper).

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU