### PR TITLE
Create SF jobs by customer id (bypass /customers 401) + manual SF # field

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -324,13 +324,26 @@ async function processNewWO(wo, mapping, syncCustomers) {
     // record) makes every create throw and the WO never maps — ResQ then drifts
     // away from SF. Self-heal small mismatches; otherwise fail loudly so the
     // operator can correct the SF record / the ops.sync_customers row.
-    const resolvedName = await resolveSfCustomerName(customerName, sfCustomerKey, cust.sf_customer_id);
-    if (!resolvedName) {
-      result.errors.push(`SF customer not found for ${wo.code}: configured "${customerName}" (${sfCustomerKey}) matched no SF customer. Link the SF customer in the control panel (Linked Customers → search Service Fusion).`);
-      result.report?.push({ resqCode: wo.code, reason: 'sf_customer_not_found', message: `No SF customer matches "${customerName}" (stem "${sfCustomerKey}").`, facility: wo.facility });
-      return result;
+    // Prefer the linked SF customer id — create the job by id directly, which
+    // bypasses the /customers lookup that's been returning 401. Falls back to
+    // name resolution only when no id is linked.
+    let sfJob;
+    if (cust.sf_customer_id) {
+      let sfName = null;
+      try {
+        const c = await sfRequest('GET', `/customers/${encodeURIComponent(cust.sf_customer_id)}`);
+        sfName = (c?.customer || c?.data || c)?.customer_name || null;
+      } catch (e) { /* by-id lookup is best-effort; create by id alone */ }
+      sfJob = await createSfJob(wo, sfName, cust.sf_customer_id);
+    } else {
+      const resolvedName = await resolveSfCustomerName(customerName, sfCustomerKey);
+      if (!resolvedName) {
+        result.errors.push(`SF customer not found for ${wo.code}: configured "${customerName}" (${sfCustomerKey}) matched no SF customer. Paste the SF customer # in the control panel (Linked Customers → SF #).`);
+        result.report?.push({ resqCode: wo.code, reason: 'sf_customer_not_found', message: `No SF customer matches "${customerName}" (stem "${sfCustomerKey}").`, facility: wo.facility });
+        return result;
+      }
+      sfJob = await createSfJob(wo, resolvedName);
     }
-    const sfJob = await createSfJob(wo, resolvedName);
 
     // Determine initial SF status based on ResQ status
     const resqStatus = (wo.status || '').toUpperCase();
@@ -714,7 +727,7 @@ async function resolveSfCustomerName(configuredName, stem, sfCustomerId) {
 }
 
 // --- SF Helpers ---
-async function createSfJob(resqWO, customerName) {
+async function createSfJob(resqWO, customerName, customerId) {
   const resqRef = resqWO.code.startsWith('R') ? resqWO.code : `R${resqWO.code}`;
   const description = [
     `ResQ WO: ${resqRef}`,
@@ -725,13 +738,17 @@ async function createSfJob(resqWO, customerName) {
     resqWO.isUrgent ? 'URGENT' : '',
   ].filter(Boolean).join('\n');
 
-  return sfRequest('POST', '/jobs', {
-    customer_name: customerName,
+  const payload = {
     description,
     status: 'Unscheduled',
     priority: resqWO.isUrgent ? 'Urgent' : 'Normal',
     po_number: resqRef,
-  });
+  };
+  // Prefer the SF customer id — creating by id avoids the /customers lookup
+  // entirely. Include the name too when we have it.
+  if (customerId) payload.customer_id = customerId;
+  if (customerName) payload.customer_name = customerName;
+  return sfRequest('POST', '/jobs', payload);
 }
 
 // --- Transfer SF Photos → ResQ ---

--- a/public/control.html
+++ b/public/control.html
@@ -435,6 +435,10 @@ function renderSyncCustomers(data){
           <input id="sfq-${c.id}" placeholder="search Service Fusion…" style="${inp}" onkeydown="if(event.key==='Enter'){event.preventDefault();searchSf(${c.id});}">
           <button onclick="searchSf(${c.id})" style="${btnCss('#1F4E79')};padding:4px 8px;font-size:0.7rem;white-space:nowrap">Find</button>
         </div>
+        <div style="display:flex;gap:4px;margin-top:4px">
+          <input id="sfid-${c.id}" value="${esc(c.sf_customer_id||'')}" placeholder="or paste SF customer # directly" style="${inp}" onkeydown="if(event.key==='Enter'){event.preventDefault();linkSfId(${c.id});}">
+          <button onclick="linkSfId(${c.id})" style="${btnCss('#059669')};padding:4px 8px;font-size:0.7rem;white-space:nowrap">Save #</button>
+        </div>
         <div id="sfres-${c.id}"></div>
       </td>
       <td style="padding:6px 8px"><input value="${esc(kws)}" onchange="saveKeywords(${c.id},this.value)" placeholder="facility keywords, comma-separated" style="${inp}"></td>
@@ -474,6 +478,11 @@ async function searchSf(id){
   }catch(e){ box.innerHTML=`<div style="color:#EF4444;font-size:0.72rem;padding:4px">Search failed: ${esc(e.message)}</div>`; }
 }
 async function linkSf(id,sfId,sfName){ await postSyncCustomer({action:'update',id,sf_customer_id:sfId,sf_customer_name:sfName}); }
+// Manual SF customer number entry (bypasses the SF search entirely).
+async function linkSfId(id){
+  const v=(document.getElementById('sfid-'+id).value||'').trim();
+  await postSyncCustomer({action:'update',id,sf_customer_id:v||null});
+}
 async function linkCandidate(id,name){
   const stem=String(name||'').toLowerCase().replace(/resq/g,'').replace(/[^a-z ]/g,'').trim().split(/\s+/)[0]||'';
   const kw=prompt(`Link “${name}”.\nResQ facility keyword(s), comma-separated — used to match work orders to this customer:`,stem);


### PR DESCRIPTION
Supersedes #129 (which had a squash-merge conflict). Same change, clean off `main`.

The `/customers` SF endpoint returns **401** for the billing functions, so name resolution never finds Melt/Starbird. This creates SF jobs **by SF customer id**, skipping `/customers`:

- `processNewWO`: when `ops.sync_customers.sf_customer_id` is set, create the job with `customer_id` directly (best-effort name via `GET /customers/{id}`).
- `createSfJob` sends `customer_id` (+ `customer_name` when known).
- Control panel → Linked Customers: manual **"SF #"** field to paste the SF customer number directly.

After deploy: `/control` → paste the SF customer number for Melt + Starbird → **Save #** → Run Sync. Bypasses the 401. (If `POST /jobs` also 401s, SF must be reconnected at `/billing/setup.html`.)

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU)_