### PR TITLE
Photo pull: relay pics through a public bucket, give ResQ a short URL (fix varchar-100)

### DIFF
--- a/netlify/functions/lib/sf-assets.mjs
+++ b/netlify/functions/lib/sf-assets.mjs
@@ -127,3 +127,42 @@ export async function pictureToBase64(p) {
     contentType: r.contentType || inferMime(name),
   };
 }
+
+const RELAY_BUCKET = 'resq-photo-relay';
+
+function extFor(contentType, name) {
+  const m = (contentType || '').split('/')[1] || (name || '').split('.').pop() || 'jpg';
+  return m.toLowerCase().replace('jpeg', 'jpg').replace(/[^a-z0-9]/g, '') || 'jpg';
+}
+
+// Upload bytes to the PUBLIC relay bucket and return a public URL with a short
+// filename. ResQ stores the image reference in a varchar(100) column, so it
+// needs a short fetchable URL — not an inline base64 data URL.
+export async function uploadToRelay(path, bytes, contentType) {
+  if (!SERVICE_KEY) return null;
+  const res = await fetch(`${SUPABASE_URL}/storage/v1/object/${RELAY_BUCKET}/${encodeURI(path)}`, {
+    method: 'POST',
+    headers: {
+      apikey: SERVICE_KEY,
+      Authorization: `Bearer ${SERVICE_KEY}`,
+      'Content-Type': contentType || 'application/octet-stream',
+      'x-upsert': 'true',
+    },
+    body: Buffer.from(bytes),
+  });
+  if (!res.ok) return null;
+  return `${SUPABASE_URL}/storage/v1/object/public/${RELAY_BUCKET}/${encodeURI(path)}`;
+}
+
+// Fetch a SF picture and relay it to the public bucket; returns a short public URL.
+export async function pictureToPublicUrl(p, sfJobId, index) {
+  const name = (p.name && p.name.trim()) || String(p.file_location).split('/').pop() || `pic${index}`;
+  const srcUrl = resolveSfAssetUrl('picture', p.file_location);
+  const r = await fetchSfAssetBytes(srcUrl);
+  if (!r.ok) return { ok: false, error: `${name}: ${r.error}` };
+  const ext = extFor(r.contentType, name);
+  const path = `${sfJobId}/${index}.${ext}`; // short last-segment filename
+  const publicUrl = await uploadToRelay(path, r.bytes, r.contentType || inferMime(name));
+  if (!publicUrl) return { ok: false, error: `${name}: relay upload failed (SUPABASE_SERVICE_ROLE_KEY set?)` };
+  return { ok: true, url: publicUrl };
+}

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -299,7 +299,18 @@ async function handleVisitPhotos(event, resqWoId) {
     const files = body.files || [];
     const photoType = body.type || 'after'; // 'before' or 'after'
     if (!files.length) return json({ error: 'No files. Send { type: "before"|"after", files: [{ name, base64, contentType }] }' }, 400);
-    const result = await pushFilesToVisit(resqWoId, photoType, files);
+    // Relay manually-uploaded files through the public bucket → short URLs.
+    const { uploadToRelay } = await import('./lib/sf-assets.mjs');
+    const imageUrls = [];
+    for (let i = 0; i < files.length; i++) {
+      const f = files[i];
+      const ct = f.contentType || 'image/jpeg';
+      const ext = (ct.split('/')[1] || 'jpg').replace('jpeg', 'jpg').replace(/[^a-z0-9]/gi, '') || 'jpg';
+      const url = await uploadToRelay(`manual/${resqWoId}/${Date.now()}-${i}.${ext}`, Buffer.from(f.base64, 'base64'), ct);
+      if (url) imageUrls.push(url);
+    }
+    if (!imageUrls.length) return json({ error: 'Could not relay uploaded files (SUPABASE_SERVICE_ROLE_KEY set?)' }, 502);
+    const result = await pushImagesToVisit(resqWoId, photoType, imageUrls);
     return json(result, result.ok ? 200 : (result.status || 500));
   } catch (e) {
     return json({ error: e.message }, 500);
@@ -329,20 +340,21 @@ async function handleAutoPhotos(event, resqWoId) {
     }
     if (!sfJobId) return json({ error: 'No SF job id — pass ?sfJob=<id> or ensure the WO is mapped' }, 400);
 
-    const { listJobPictures, pictureToBase64 } = await import('./lib/sf-assets.mjs');
+    const { listJobPictures, pictureToPublicUrl } = await import('./lib/sf-assets.mjs');
     const pics = await listJobPictures(sfJobId);
     if (!pics.length) return json({ ok: true, imagesUploaded: 0, picturesFound: 0, message: 'No pictures on SF job' });
 
-    const files = [];
+    // Fetch each pic from SF and relay it to the public bucket → short URL.
+    const imageUrls = [];
     const fetchErrors = [];
-    for (const p of pics) {
-      const r = await pictureToBase64(p);
-      if (r.ok) files.push({ name: r.name, base64: r.base64, contentType: r.contentType });
+    for (let i = 0; i < pics.length; i++) {
+      const r = await pictureToPublicUrl(pics[i], sfJobId, i);
+      if (r.ok) imageUrls.push(r.url);
       else fetchErrors.push(r.error);
     }
-    if (!files.length) return json({ ok: false, error: 'Could not fetch any pictures from SF', picturesFound: pics.length, fetchErrors }, 502);
+    if (!imageUrls.length) return json({ ok: false, error: 'Could not relay any pictures', picturesFound: pics.length, fetchErrors }, 502);
 
-    const result = await pushFilesToVisit(resqWoId, photoType, files);
+    const result = await pushImagesToVisit(resqWoId, photoType, imageUrls);
     return json({ ...result, sfJobId, picturesFound: pics.length, fetchErrors }, result.ok ? 200 : (result.status || 500));
   } catch (e) {
     return json({ error: e.message }, 500);
@@ -352,7 +364,7 @@ async function handleAutoPhotos(event, resqWoId) {
 // Core: resolve the ResQ visit for a WO and upload before/after images.
 // files: [{ base64, contentType }]. Returns { ok, mutation, visitId, imagesUploaded }
 // or { ok:false, status, error }. Shared by the manual upload + auto-pull paths.
-async function pushFilesToVisit(resqWoId, photoType, files) {
+async function pushImagesToVisit(resqWoId, photoType, images) {
   const { resqLogin, resqGql } = await import('./resq-helpers.mjs');
   const session = await resqLogin();
 
@@ -398,12 +410,8 @@ async function pushFilesToVisit(resqWoId, photoType, files) {
     startedVisit = true;
   }
 
-  // Build image array — ResQ expects data URLs
-  const images = files.map(f => {
-    const ct = f.contentType || 'image/jpeg';
-    return `data:${ct};base64,${f.base64}`;
-  });
-
+  // `images` is an array of short public URLs (ResQ stores the reference in a
+  // varchar(100) column — inline base64 data URLs overflow it).
   const mutation = photoType === 'before' ? 'addBeforeImagesToVisit' : 'addAfterImagesToVisit';
   const inputType = photoType === 'before' ? 'AddBeforeImagesToVisitInput' : 'AddAfterImagesToVisitInput';
 
@@ -427,7 +435,7 @@ async function pushFilesToVisit(resqWoId, photoType, files) {
     }
   } catch (e) {}
 
-  return { ok: true, mutation, visitId, imagesUploaded: files.length, startedVisit };
+  return { ok: true, mutation, visitId, imagesUploaded: images.length, startedVisit };
 }
 
 // --- Reset Flags: Clear photosSent/invoiceSubmitted for a WO code ---


### PR DESCRIPTION
ResQ's `addAfterImagesToVisit` failed with `value too long for type character varying(100)` — it stores each `images[]` entry in a **varchar(100)** column, so a full inline base64 **data URL** overflows it. ResQ wants a short, fetchable **URL**.

Fix: relay each picture through a new **public** Storage bucket (`resq-photo-relay`, created) with a short filename, and hand ResQ that public URL.
- `lib/sf-assets.mjs`: `uploadToRelay()` + `pictureToPublicUrl()` (fetch from SF via cookie/S3 → upload → public URL).
- `pushImagesToVisit()` now takes URLs (not base64).
- Both auto-pull and manual-upload paths relay through the bucket.

Builds on the visit-start fix (#136) and host-aware fetch (#135). Requires `SUPABASE_SERVICE_ROLE_KEY` (already set) for the relay upload.

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU)_