### PR TITLE
Separate Close button: set SF job to Invoiced

### DIFF
--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -22,6 +22,7 @@ export async function handler(event) {
   if (qs.introspect) return handleIntrospect(qs.introspect);
   if (qs.dedupeReport) return handleDedupeReport();
   if (qs.cancelSfJob) return handleCancelSfJob(qs.cancelSfJob, qs.resqCode);
+  if (qs.closeJob) return handleCloseJob(qs.closeJob, qs.resqCode);
   if (qs.relink) return handleRelink(qs.relink, qs.toSfJobId);
   if (qs.dismissIssue) return handleDismissIssue(qs.dismissIssue);
   if (qs.clearErrors) return handleClearErrors();
@@ -563,6 +564,36 @@ async function handleCancelSfJob(jobId, resqCode) {
     }
 
     return json({ ok: true, jobId, status: 'Cancelled', resqCode });
+  } catch (e) {
+    return json({ error: e.message }, 500);
+  }
+}
+
+// --- Close SF Job: set status to Invoiced (closes it out after the 3rd-party
+// bill is entered). The next sync sees "Invoiced" and submits the ResQ invoice. ---
+async function handleCloseJob(jobId, resqCode) {
+  if (!jobId) return json({ error: 'jobId required' }, 400);
+  try {
+    const { sfRequest } = await import('./sf-helpers.mjs');
+    await sfRequest('PUT', `/jobs/${jobId}`, { status: 'Invoiced' });
+
+    // Reflect immediately in the mapping blob so the dashboard shows Invoiced.
+    try {
+      const store = await getStore();
+      if (store) {
+        const raw = await store.get('wo-mapping');
+        const mapping = raw ? JSON.parse(raw) : {};
+        for (const v of Object.values(mapping)) {
+          if (String(v.sfJobId) === String(jobId) || (resqCode && v.resqCode === resqCode)) {
+            v.sfStatus = 'Invoiced';
+            v.lastSyncAt = new Date().toISOString();
+          }
+        }
+        await store.set('wo-mapping', JSON.stringify(mapping));
+      }
+    } catch (e) { /* non-fatal */ }
+
+    return json({ ok: true, jobId, status: 'Invoiced', resqCode });
   } catch (e) {
     return json({ error: e.message }, 500);
   }

--- a/public/sync.html
+++ b/public/sync.html
@@ -472,6 +472,23 @@ async function clearErrors() {
 }
 
 // --- Clear (delete) a mapping entry ---
+// Close a SF job: set it to Invoiced (after the 3rd-party bill is entered).
+async function closeSfJob(sfJobId, code) {
+  if (!sfJobId) return;
+  if (!confirm(`Close SF job #${sfJobId}?\nSets the Service Fusion status to "Invoiced" — the next sync then submits the ResQ invoice.`)) return;
+  const btn = event?.target;
+  if (btn) { btn.disabled = true; btn.textContent = '...'; }
+  try {
+    const res = await fetch(`${API_BASE}/resq-sf-sync?closeJob=${encodeURIComponent(sfJobId)}&resqCode=${encodeURIComponent(code || '')}`);
+    const data = await res.json();
+    if (data.error) throw new Error(data.error);
+    loadStatus();
+  } catch (e) {
+    if (btn) { btn.disabled = false; btn.textContent = '🔒 Close'; }
+    alert('Close failed: ' + e.message);
+  }
+}
+
 async function clearMapping(code) {
   if (!code) return;
   if (!confirm(`Remove ${code} from sync? This deletes the local mapping only — it does NOT touch ResQ or SF.`)) return;
@@ -525,8 +542,10 @@ function renderMappings(mappings) {
     const sfBadge = statusBadge(m.sfStatus);
     const synced = m.lastSyncAt ? timeAgo(new Date(m.lastSyncAt)) : '—';
     const sfJob = m.sfJobId || '';
+    const sfInvoiced = (m.sfStatus || '').toLowerCase().includes('invoic');
     const expenseBtn = sfJob
       ? `<button class="expense-btn" onclick="openExpense('${sfJob}','${m.resqCode || ''}')">💰 Bill</button>`
+        + (sfInvoiced ? '' : ` <button class="clear-btn" onclick="closeSfJob('${sfJob}','${m.resqCode || ''}')" title="Set SF job to Invoiced (closes it out)">🔒 Close</button>`)
       : '—';
 
     const resqLink = resqLinkHtml(resqId, m.resqCode);


### PR DESCRIPTION
Adds the separate **Close** step you described: the SF job stops at *Completed - Service* (which already drives the ResQ visit + photo update), and a distinct button closes it out to **Invoiced** once the 3rd-party bill is entered.

- Per-row **🔒 Close** button in the WO mapping table, next to **💰 Bill** (hidden once already invoiced).
- `?closeJob=<sfJobId>` → `PUT /jobs/{id}` `status: 'Invoiced'`, and reflects immediately in the mapping blob.
- Setting SF → `Invoiced` also triggers the existing sync step that submits the ResQ invoice on the next pass.

Pairs with #140 (landing the expense+bill in Brixpense). Together: 💰 Bill (QBO bill + land in Brixpense) → 🔒 Close (SF Invoiced → ResQ invoice).

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU)_