### PR TITLE
Brixpense: installable PWA (manifest + offline-shell service worker)

### DIFF
--- a/app-expense/index.html
+++ b/app-expense/index.html
@@ -5,8 +5,14 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" href="/Brix-Round-Logo.png" />
     <link rel="apple-touch-icon" href="/Brix-Round-Logo.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#06121F" />
+    <!-- iOS home-screen / standalone app -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Brixpense" />
     <title>BRIX · Expense</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/app-expense/public/manifest.webmanifest
+++ b/app-expense/public/manifest.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "Brixpense",
+  "short_name": "Brixpense",
+  "description": "Brix Beverage — expenses, purchase requests & approvals",
+  "id": "/expense/",
+  "start_url": "/expense/",
+  "scope": "/expense/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#06121F",
+  "theme_color": "#06121F",
+  "icons": [
+    { "src": "/expense/Brix-Round-Logo.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
+    { "src": "/expense/Brix-Round-Logo.png", "sizes": "512x512", "type": "image/png", "purpose": "any" },
+    { "src": "/expense/Brix-Round-Logo.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/app-expense/public/sw.js
+++ b/app-expense/public/sw.js
@@ -1,0 +1,71 @@
+/* Brixpense service worker — conservative PWA shell.
+ * - Navigations: network-first (so a new deploy is never masked by a stale cache),
+ *   falling back to the cached shell only when offline.
+ * - Hashed build assets (/expense/assets/*): cache-first (they're immutable).
+ * - Everything else (Supabase, fonts, APIs = cross-origin) is left untouched.
+ * Bump CACHE to invalidate old caches on the next activate. */
+const CACHE = 'brixpense-v1';
+const SHELL = [
+  '/expense/',
+  '/expense/index.html',
+  '/expense/Brix-Round-Logo.png',
+  '/expense/manifest.webmanifest',
+];
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE).then((cache) => Promise.allSettled(SHELL.map((u) => cache.add(u))))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k)));
+      await self.clients.claim();
+    })()
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return; // don't intercept Supabase/fonts/APIs
+
+  // App navigations: always try the network first; fall back to the cached shell offline.
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      (async () => {
+        try {
+          return await fetch(request);
+        } catch {
+          const cache = await caches.open(CACHE);
+          return (
+            (await cache.match('/expense/index.html')) ||
+            (await cache.match('/expense/')) ||
+            Response.error()
+          );
+        }
+      })()
+    );
+    return;
+  }
+
+  // Immutable hashed assets: cache-first.
+  if (url.pathname.startsWith('/expense/assets/')) {
+    event.respondWith(
+      (async () => {
+        const cache = await caches.open(CACHE);
+        const hit = await cache.match(request);
+        if (hit) return hit;
+        const net = await fetch(request);
+        if (net.ok) cache.put(request, net.clone());
+        return net;
+      })()
+    );
+  }
+});

--- a/app-expense/src/main.tsx
+++ b/app-expense/src/main.tsx
@@ -11,3 +11,13 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     </BrowserRouter>
   </React.StrictMode>
 );
+
+// Register the PWA service worker (production only) so Brixpense installs to the
+// home screen and serves an offline shell. Scope is /expense/ via BASE_URL.
+if (import.meta.env.PROD && 'serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register(`${import.meta.env.BASE_URL}sw.js`)
+      .catch(() => { /* non-fatal: app still works without the SW */ });
+  });
+}


### PR DESCRIPTION
First step of the Apple-style PWA pass for Brixpense: make it **installable on web + phone** (like titr8).

- `app-expense/public/manifest.webmanifest` — `/expense/`-scoped, standalone, Brix round-logo icons (192/512 + maskable).
- `index.html` — `<link rel="manifest">`, `apple-mobile-web-app-*` meta, `apple-touch-icon` (already present), `viewport-fit=cover` for safe-area.
- `app-expense/public/sw.js` — conservative service worker: **network-first for navigations** (so a new deploy is never masked by a stale cache), **cache-first only for immutable `/expense/assets/*`**, cross-origin (Supabase/fonts/APIs) left untouched, old caches cleared on activate.
- `src/main.tsx` — registers the SW in production only (non-fatal on failure).

No new dependencies; Vite rewrites the `/`-paths under the `/expense/` base at build. 

Next PRs in this effort: adaptive light/dark (iOS-style) theme refactor, Apple layout in `AppShell` (bottom tabs on mobile / sidebar on desktop, large titles), finishing the open Brixpense gaps, then **payout / real payments** (sandbox-first, rail TBD).

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU)_