### PR TITLE
Brixpense Tier-1 payout: record payment + QBO BillPayment writeback

### DIFF
--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -269,8 +269,8 @@
         "ops.expense_settings"
       ],
       "multi_writer": true,
-      "notes": "Brixpense surface (app-expense/ Vite SPA at /expense/ + netlify/functions/expense-request-* + expense-to-bill + process-inbound). Frontend uses anon key under permissive RLS (submitters INSERT/UPDATE own rows; anon SELECT/UPDATE gated on approval_token presence for the magic-link approval page). Netlify functions use the anon key bound to the user JWT or service role for cross-cutting status transitions, approval logging, and QBO bill creation. expense_settings is read by useExpenseSettings(); seeded by 20260512_create_expense_tables.sql (auto_approve_threshold + approval_email) and finished by 20260512p_expense_cleanup.sql (cogs_accounts + manager_emails + tags + corrected departments).",
-      "last_verified": "2026-05-12"
+      "notes": "Brixpense surface (app-expense/ Vite SPA at /expense/ + netlify/functions/expense-request-* + expense-to-bill + process-inbound). Frontend uses anon key under permissive RLS (submitters INSERT/UPDATE own rows; anon SELECT/UPDATE gated on approval_token presence for the magic-link approval page). Netlify functions use the anon key bound to the user JWT or service role for cross-cutting status transitions, approval logging, and QBO bill creation. expense_settings is read by useExpenseSettings(); seeded by 20260512_create_expense_tables.sql (auto_approve_threshold + approval_email) and finished by 20260512p_expense_cleanup.sql (cogs_accounts + manager_emails + tags + corrected departments). Tier-1 payout (20260603a): expense-request-pay marks a bill paid (payment_method/reference/account, paid_at/paid_by, status='paid') and optionally writes a QBO BillPayment (qbo_billpayment_id) — superadmin/admin only, service-role write.",
+      "last_verified": "2026-06-03"
     },
     {
       "name": "brix-stock:app-and-rpcs",

--- a/netlify/functions/expense-request-pay.mjs
+++ b/netlify/functions/expense-request-pay.mjs
@@ -1,0 +1,160 @@
+// ============================================================
+// expense-request-pay.mjs — Tier-1 payout.
+// Records a vendor payment on an expense_requests row (marks it paid,
+// captures method + reference + from-account) and, when the row has a
+// QBO bill, optionally writes a matching QBO BillPayment back to QuickBooks.
+//
+// Money movement itself stays manual (QBO Bill Pay, Amex, Zelle, Venmo,
+// check, ACH) — this is the system-of-record + QBO reconciliation step.
+// Auth: Bearer JWT; caller must be superadmin/admin.
+// ============================================================
+import { createClient } from '@supabase/supabase-js';
+import { qboRequest } from './qbo-helpers.mjs';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || 'https://gfsdpwiqzshhexkofiif.supabase.co';
+const SUPABASE_ANON_KEY =
+  process.env.SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdmc2Rwd2lxenNoaGV4a29maWlmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU1OTUyMzcsImV4cCI6MjA5MTE3MTIzN30.AygnPJwQ5NfIeKwPtkO6tgVYmkV3MAxL1lMFwN9HPnY';
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Content-Type': 'application/json',
+};
+
+const ALLOWED_METHODS = ['qbo_bill_pay', 'amex', 'zelle', 'venmo', 'check', 'ach', 'other'];
+// Methods that fund from a credit card (QBO PayType = CreditCard); the rest pay from a bank (Check).
+const CARD_METHODS = ['amex'];
+
+function json(d, s = 200) { return new Response(JSON.stringify(d), { status: s, headers: CORS }); }
+function err(m, s = 400) { return json({ error: m }, s); }
+function round(n) { return Math.round(Number(n || 0) * 100) / 100; }
+
+export default async function handler(req) {
+  if (req.method === 'OPTIONS') return new Response('', { status: 204, headers: CORS });
+  if (req.method !== 'POST') return err('POST only', 405);
+
+  // ── Auth: validate the caller's JWT and require superadmin/admin ──
+  const authHeader = req.headers.get('authorization') || req.headers.get('Authorization') || '';
+  const token = authHeader.replace(/^Bearer\s+/i, '').trim();
+  if (!token) return err('Missing Authorization bearer token', 401);
+
+  const userClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    db: { schema: 'ops' },
+    global: { headers: { Authorization: `Bearer ${token}` } },
+    auth: { persistSession: false },
+  });
+  const { data: userData, error: userErr } = await userClient.auth.getUser();
+  const caller = userData?.user;
+  if (userErr || !caller) return err('Invalid or expired session', 401);
+  const role = caller.user_metadata?.role || caller.app_metadata?.role || '';
+  if (!['superadmin', 'admin'].includes(role)) {
+    return err('Recording a payment requires an admin or superadmin account', 403);
+  }
+
+  let body;
+  try { body = await req.json(); } catch { return err('Invalid JSON body'); }
+
+  const {
+    requestId,
+    method,
+    accountId,            // QBO account id to pay FROM (bank or credit-card account)
+    accountName,
+    accountType,          // 'bank' | 'credit_card' (UI hint; falls back to method)
+    reference,            // confirmation / check / txn number
+    paidAt,               // ISO date string; defaults to now
+    writeToQbo = true,    // create the QBO BillPayment when a qbo_bill_id exists
+  } = body || {};
+
+  if (!requestId) return err('requestId required');
+  if (!method || !ALLOWED_METHODS.includes(method)) {
+    return err(`method must be one of: ${ALLOWED_METHODS.join(', ')}`);
+  }
+
+  // Service-role client for the cross-cutting write (bypasses per-row RLS); fall
+  // back to the caller-bound client if the service key isn't configured.
+  const writer = SUPABASE_SERVICE_ROLE_KEY
+    ? createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { db: { schema: 'ops' }, auth: { persistSession: false } })
+    : userClient;
+
+  // ── Load the row ──
+  const { data: row, error: loadErr } = await writer
+    .from('expense_requests')
+    .select('id, status, vendor_name, vendor_id, total_amount, qbo_bill_id, qbo_billpayment_id, payment_method')
+    .eq('id', requestId)
+    .single();
+  if (loadErr || !row) return err(`Expense request ${requestId} not found`, 404);
+  if (row.status === 'paid' || row.qbo_billpayment_id) {
+    return err('This bill is already marked paid', 409);
+  }
+
+  const isCard = accountType === 'credit_card' || CARD_METHODS.includes(method);
+  const paidStamp = paidAt ? new Date(paidAt).toISOString() : new Date().toISOString();
+  const txnDate = paidStamp.slice(0, 10);
+
+  // ── Optional QBO BillPayment writeback ──
+  let qboBillPaymentId = null;
+  let qboNote = null;
+  if (writeToQbo && row.qbo_bill_id) {
+    if (!accountId) return err('accountId (QBO account to pay from) is required to write the payment to QBO');
+    try {
+      // Fetch the Bill for the authoritative VendorRef + balance.
+      const billRes = await qboRequest('GET', `/bill/${row.qbo_bill_id}`);
+      const bill = billRes?.Bill || billRes;
+      const vendorRef = bill?.VendorRef?.value;
+      const amount = round(bill?.Balance ?? bill?.TotalAmt ?? row.total_amount);
+      if (!vendorRef) throw new Error('Bill has no VendorRef');
+      if (!(amount > 0)) throw new Error('Bill balance is zero — nothing to pay');
+
+      const payload = {
+        VendorRef: { value: String(vendorRef) },
+        TotalAmt: amount,
+        TxnDate: txnDate,
+        PayType: isCard ? 'CreditCard' : 'Check',
+        PrivateNote: `Brixpense payout via ${method}${reference ? ` (ref ${reference})` : ''}`,
+        Line: [{ Amount: amount, LinkedTxn: [{ TxnId: String(row.qbo_bill_id), TxnType: 'Bill' }] }],
+      };
+      if (isCard) payload.CreditCardPayment = { CCAccountRef: { value: String(accountId) } };
+      else payload.CheckPayment = { BankAccountRef: { value: String(accountId) } };
+
+      const payRes = await qboRequest('POST', '/billpayment', payload);
+      qboBillPaymentId = payRes?.BillPayment?.Id || payRes?.Id || null;
+    } catch (e) {
+      // QBO failed — do NOT mark paid, so the operator can retry or pay manually.
+      return err(`QBO BillPayment failed: ${e.message?.substring(0, 300) || e}`, 502);
+    }
+  } else if (writeToQbo && !row.qbo_bill_id) {
+    qboNote = 'No QBO bill linked — recorded payment without a QBO BillPayment.';
+  }
+
+  // ── Mark paid in Brixpense ──
+  const update = {
+    status: 'paid',
+    payment_method: method,
+    payment_reference: reference || null,
+    payment_account_id: accountId || null,
+    payment_account_name: accountName || null,
+    payment_account_type: accountType || (isCard ? 'credit_card' : 'bank'),
+    paid_at: paidStamp,
+    paid_by: caller.email || caller.id,
+    qbo_billpayment_id: qboBillPaymentId,
+    updated_at: new Date().toISOString(),
+  };
+  const { data: updated, error: updErr } = await writer
+    .from('expense_requests')
+    .update(update)
+    .eq('id', requestId)
+    .select()
+    .single();
+  if (updErr) {
+    // The QBO payment may have posted — surface that so it isn't double-paid.
+    return err(
+      `Recorded the QBO payment (${qboBillPaymentId || 'n/a'}) but failed to update Brixpense: ${updErr.message}. Do not re-run.`,
+      500
+    );
+  }
+
+  return json({ ok: true, request: updated, qboBillPaymentId, note: qboNote });
+}

--- a/supabase/migrations/20260603a_expense_payment_fields.sql
+++ b/supabase/migrations/20260603a_expense_payment_fields.sql
@@ -1,0 +1,14 @@
+-- Tier-1 payout: record vendor payments on expense_requests + link the QBO BillPayment.
+-- payment_account_{id,name,type} already exist. status gains a 'paid' value (text column, no enum change).
+alter table ops.expense_requests
+  add column if not exists payment_method      text,
+  add column if not exists payment_reference   text,
+  add column if not exists paid_at             timestamptz,
+  add column if not exists paid_by             text,
+  add column if not exists qbo_billpayment_id  text;
+
+comment on column ops.expense_requests.payment_method     is 'How the bill was paid: qbo_bill_pay | amex | zelle | venmo | check | ach | other';
+comment on column ops.expense_requests.payment_reference  is 'Confirmation / check / transaction number for the payment';
+comment on column ops.expense_requests.paid_at            is 'When the payment was recorded';
+comment on column ops.expense_requests.paid_by            is 'Email of the user who recorded the payment';
+comment on column ops.expense_requests.qbo_billpayment_id is 'QBO BillPayment.Id when the payment was written back to QuickBooks';


### PR DESCRIPTION
Backend for **Tier-1 payout** (record + QBO writeback) — the Pay UI is the follow-up PR.

**Migration `20260603a`** (applied to live): adds `payment_method`, `payment_reference`, `paid_at`, `paid_by`, `qbo_billpayment_id` to `ops.expense_requests` (`payment_account_*` already existed; `status` gains a `paid` value — text, no enum change).

**`expense-request-pay.mjs`** (Bearer JWT, **superadmin/admin only**):
- Marks a bill **paid** with a method — `qbo_bill_pay | amex | zelle | venmo | check | ach | other` — plus from-account + confirmation/reference.
- When the row has a `qbo_bill_id` and `writeToQbo`, POSTs a **QBO BillPayment** linked to the Bill: `CreditCard` PayType for Amex (CCAccountRef), `Check` for bank rails (BankAccountRef), amount from the Bill balance.
- **QBO failure → row stays unpaid** (safe retry); a post-QBO DB failure is surfaced loudly to avoid double-paying.
- Service-role write (validates the caller first); falls back to the JWT-bound client if no service key.

Method-agnostic by design: you pay however you like (Amex, QBO Bill Pay, Zelle/Venmo by hand) and Brixpense becomes the system of record + reconciles to QBO. An embedded rail (Melio) can later replace a manual method without changing this contract.

Manifest note refreshed; `lint-manifest` clean.

**Next PR:** the Pay UI — a "bills to pay" list + Pay modal (method, from-account from QBO accounts, reference, date), styled in the upcoming adaptive light/dark theme.

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU)_