### PR TITLE
fix(sync): unblock R1020568 — endVisit retry, full error logging, + photo-URL fits varchar(100)

### DIFF
--- a/netlify/functions/lib/resq-sf-links.mjs
+++ b/netlify/functions/lib/resq-sf-links.mjs
@@ -88,6 +88,9 @@ export function eventFromResult(wo, mapEntry, r, defaultDirection) {
     direction: action === 'created' ? 'resq->sf' : defaultDirection,
     action,
     ok: action !== 'error',
-    message: String((r.errors && r.errors[0]) || (r.steps && r.steps[r.steps.length - 1]) || '').slice(0, 300),
+    // Keep enough of the message to carry a full ResQ/SF validation error
+    // (incl. extensions.fields.__all__) into the audit trail — 300 chars cut
+    // the actual reason off mid-JSON.
+    message: String((r.errors && r.errors[0]) || (r.steps && r.steps[r.steps.length - 1]) || '').slice(0, 2000),
   };
 }

--- a/netlify/functions/lib/sf-assets.mjs
+++ b/netlify/functions/lib/sf-assets.mjs
@@ -161,7 +161,15 @@ export async function pictureToPublicUrl(p, sfJobId, index) {
   const r = await fetchSfAssetBytes(srcUrl);
   if (!r.ok) return { ok: false, error: `${name}: ${r.error}` };
   const ext = extFor(r.contentType, name);
-  const path = `${sfJobId}/${index}.${ext}`; // short last-segment filename
+  // ResQ stores the image reference in a varchar(100) column, and the public
+  // URL prefix (host + /storage/v1/object/public/<bucket>/) already eats ~83 of
+  // those chars — so the path must stay tiny. The old
+  // `${sfJobId}/${Date.now()}-${i}.${ext}` ran ~113 chars and ResQ rejected the
+  // push with "value too long for character varying(100)". A 6-char token + ext
+  // keeps the whole URL under 100. The relay bucket is transient, so the path
+  // doesn't need the job id — the WO↔job link lives in resq_sf_links.
+  const token = Math.random().toString(36).slice(2, 8); // 6 chars
+  const path = `${token}.${ext}`;
   const publicUrl = await uploadToRelay(path, r.bytes, r.contentType || inferMime(name));
   if (!publicUrl) return { ok: false, error: `${name}: relay upload failed (SUPABASE_SERVICE_ROLE_KEY set?)` };
   return { ok: true, url: publicUrl };

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -900,37 +900,50 @@ async function provideUpdateToResq(session, resqWO, sfJobId) {
     }
   }
 
-  // 4. End the visit with outcome = RESOLVED
-  try {
-    await resqGql(session, `mutation($input: EndVisitInput!) {
-      endVisit(input: $input) { __typename }
-    }`, { input: {
-      visit: visitId,
-      outcome: 'COMPLETED',
-      notes: completionNotes.substring(0, 2000),
-      recommendations: '',
-      images: [], // Photos uploaded separately via sync.html
-    }});
-    result.steps.push(`✓ ${resqWO.code} visit completed (RESOLVED)`);
-    result.completed = true;
-  } catch (e) {
-    // If endVisit fails, try captureVisitNotes as fallback
-    const errMsg = e.message.substring(0, 200);
-    result.steps.push(`endVisit failed for ${resqWO.code}: ${errMsg}`);
+  // 4. End the visit. Normal path uses outcome COMPLETED (the value ResQ has
+  //    accepted for every WO that already has a started visit). ResQ rejects
+  //    that outcome on some visits (e.g. one we just started this pass) with a
+  //    "malformed/unprocessable arguments" ValidationError, so retry once with
+  //    RESOLVED before falling back to captureVisitNotes. The retry only runs
+  //    after the normal attempt fails, so it can't regress the happy path.
+  const cleanNotes = completionNotes.substring(0, 2000);
+  const endErrors = [];
+  for (const outcome of ['COMPLETED', 'RESOLVED']) {
     try {
-      await resqGql(session, `mutation($input: CaptureVisitNotesInput!) {
-        captureVisitNotes(input: $input) { __typename }
+      await resqGql(session, `mutation($input: EndVisitInput!) {
+        endVisit(input: $input) { __typename }
       }`, { input: {
         visit: visitId,
-        notes: completionNotes.substring(0, 2000),
+        outcome,
+        notes: cleanNotes,
         recommendations: '',
-        images: [],
+        images: [], // Photos uploaded separately via sync.html
       }});
-      result.steps.push(`→ ${resqWO.code} visit notes captured (fallback)`);
+      result.steps.push(`✓ ${resqWO.code} visit completed (${outcome})`);
       result.completed = true;
-    } catch (e2) {
-      result.errors.push(`Complete visit ${resqWO.code}: endVisit (${errMsg}), captureVisitNotes (${e2.message.substring(0, 200)})`);
+      return result;
+    } catch (e) {
+      // Keep the full ResQ error (incl. extensions.fields.__all__) — the old
+      // substring(0,200) cut it off right before the actual reason.
+      endErrors.push(`outcome=${outcome}: ${e.message.substring(0, 600)}`);
+      result.steps.push(`endVisit (${outcome}) failed for ${resqWO.code}`);
     }
+  }
+
+  // Fallback: capture notes without ending the visit.
+  try {
+    await resqGql(session, `mutation($input: CaptureVisitNotesInput!) {
+      captureVisitNotes(input: $input) { __typename }
+    }`, { input: {
+      visit: visitId,
+      notes: cleanNotes,
+      recommendations: '',
+      images: [],
+    }});
+    result.steps.push(`→ ${resqWO.code} visit notes captured (fallback)`);
+    result.completed = true;
+  } catch (e2) {
+    result.errors.push(`Complete visit ${resqWO.code}: endVisit [${endErrors.join(' | ')}], captureVisitNotes (${e2.message.substring(0, 600)})`);
   }
 
   return result;


### PR DESCRIPTION
Two fixes found while checking why **R1020568** (Origins-Starbird manual info → STARBIRD CHICKEN: RESQ) wasn't completing its lifecycle. Both are scoped to the ResQ↔SF sync, failure-path only.

## 1. Visit completion — retry + surface the real error
`ops.sync_events` showed the visit step failing every pass, with the reason cut off mid-JSON:
> `endVisit … "Some of the arguments are malformed or unprocessable." … "fields":{"__all__":[` ← **truncated here**

- Error was chopped by `substring(0,200)` + a `slice(0,300)` in the event writer — both stop right at `extensions.fields.__all__`. Widened to 600 / 2000 so the actual cause now lands in the audit trail.
- `endVisit` sends `outcome:'COMPLETED'` (works for WOs with an existing visit, but ResQ rejected it here — the no-prior-visit path that `startVisit`s the same pass). Now retries with `outcome:'RESOLVED'` before the `captureVisitNotes` fallback. Retry runs only after the normal attempt fails, so the happy path can't regress.
- Fixed the log that always said `(RESOLVED)` while sending `COMPLETED`.

*Outcome:* the un-truncation immediately exposed the next problem ↓, and R1020568's visit has since completed (`resq_status=COMPLETED`, `visit_completed=true`).

## 2. Photo relay URL was overflowing ResQ's `varchar(100)`
With the visit complete, the photo push fired and failed:
> `addAfterImagesToVisit … InternalServerError … "value too long for character varying(100)"`

The relay path was `${sfJobId}/${Date.now()}-${i}.${ext}`, making the public URL **~113 chars** — over ResQ's 100-char image-ref column, even though the relay bucket exists specifically to keep URLs short (#137). Replaced with a **6-char random token + ext** (no job-id folder, no 13-digit timestamp); the full URL is now ~93–94 chars. The WO↔job link lives in `resq_sf_links`, so the path doesn't need the job id.

## Scope / risk
Three files, failure-path/format only. No schema or migration changes. **Must be merged + deployed to `main`** to take effect on the live sync.