### PR TITLE
fix(sync): Starbird SF customer name has no colon (unblocks SF job creation)

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -330,12 +330,13 @@ async function processNewWO(wo, mapping, syncCustomers) {
     // Resolve the SF customer by NAME (auth works now; SF's by-id GET proved
     // unreliable). Exact match on the configured name, then a stem search
     // (e.g. "melt"/"starbird" + "resq") that self-heals punctuation drift.
-    // HARD-CODED SF customer names — the exact values that worked before SF
-    // auth broke. Bypasses all lookup for the two live RESQ customers. (Note
-    // Starbird's colon, which the seeded sync_customers row was missing.)
+    // HARD-CODED SF customer names — the exact values that match the live
+    // Service Fusion records. Bypasses all lookup for the two live RESQ
+    // customers. (Starbird's SF record has NO colon — "STARBIRD CHICKEN RESQ";
+    // the colon variant 422'd on POST /jobs as "Customer Name can not be found".)
     const HARDCODED_SF_CUSTOMER = {
       melt: 'THE MELT RESQ',
-      starbird: 'STARBIRD CHICKEN: RESQ',
+      starbird: 'STARBIRD CHICKEN RESQ',
     };
     const resolvedName = HARDCODED_SF_CUSTOMER[String(sfCustomerKey).toLowerCase()]
       || await resolveSfCustomerName(customerName, sfCustomerKey, cust.sf_customer_id);


### PR DESCRIPTION
## Why
Every Starbird WO was failing to create its Service Fusion job. `ops.sync_events` shows the create 422-ing repeatedly, right up until R1020568's job was made by hand:

> `Create SF job for R1020568: SF API error: 422 [{"field":"customer_name","message":"Customer Name can not be found by given value."}]`

The hardcoded SF customer name was `STARBIRD CHICKEN: RESQ` (with a colon, added in #133 on the assumption SF used the colon). But the live Service Fusion record has **no colon** — so `POST /jobs` couldn't match it, every create threw, and ResQ drifted out of sync. Confirmed with Sky (SF owner).

## What
- `resq-sf-sync-background.mjs` — hardcoded Starbird name `STARBIRD CHICKEN: RESQ` → **`STARBIRD CHICKEN RESQ`** (+ corrected the comment).
- Realigned the live `ops.sync_customers` row (qbo 1945, SF id 408973) `sf_customer_name` to the no-colon value so the fallback resolver (`resolveSfCustomerName` exact-match path) agrees with the hardcode. The `FALLBACK` literal in `lib/sync-customers.mjs` already used the no-colon form.

## Scope / risk
One-line name change + matching DB value. THE MELT entry unchanged. Must be merged + deployed to `main` to take effect on the live sync; new Starbird WOs should then create their SF job instead of looping on 422.

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_