### PR TITLE
fix(sync): facility-login fallback for ResQ after-image push (photos never landed)

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -800,15 +800,28 @@ async function transferSfPhotosToResq(session, sfJobId, resqWO, alreadySent = []
     return result;
   }
 
-  try {
-    await resqGql(session, `mutation($input: AddAfterImagesToVisitInput!) {
-      addAfterImagesToVisit(input: $input) { __typename }
-    }`, { input: { visit: visitId, images: imageUrls } });
-    result.count = imageUrls.length;
-    result.sentKeys = relayedKeys;
-  } catch (e) {
-    result.errors.push(`addAfterImages ${resqWO.code}: ${e.message.substring(0, 200)}`);
+  // Vendor session first, then the facility account. The Brix vendor identity
+  // isn't authorized to add after-images (ResQ returns AuthorizationError —
+  // every push since the feature launched failed this way), so fall back to the
+  // facility login, exactly as submitRecordOfWork / createOriginalVendorInvoice
+  // already do for the same vendor-authorization gap.
+  const addImagesMutation = `mutation($input: AddAfterImagesToVisitInput!) {
+    addAfterImagesToVisit(input: $input) { __typename }
+  }`;
+  const addImagesVars = { input: { visit: visitId, images: imageUrls } };
+  const pushErrors = [];
+  for (const label of ['vendor', 'facility']) {
+    try {
+      const sess = label === 'vendor' ? session : await resqLogin({ facility: true });
+      await resqGql(sess, addImagesMutation, addImagesVars);
+      result.count = imageUrls.length;
+      result.sentKeys = relayedKeys;
+      return result;
+    } catch (e) {
+      pushErrors.push(`${label}: ${e.message.substring(0, 300)}`);
+    }
   }
+  result.errors.push(`addAfterImages ${resqWO.code}: ${pushErrors.join(' | ')}`);
   return result;
 }
 

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -416,9 +416,20 @@ async function pushImagesToVisit(resqWoId, photoType, images) {
   const mutation = photoType === 'before' ? 'addBeforeImagesToVisit' : 'addAfterImagesToVisit';
   const inputType = photoType === 'before' ? 'AddBeforeImagesToVisitInput' : 'AddAfterImagesToVisitInput';
 
-  await resqGql(session, `mutation($input: ${inputType}!) {
+  // Vendor session first, then the facility account — the Brix vendor identity
+  // isn't authorized to add images to the visit (ResQ AuthorizationError), same
+  // vendor-auth gap that submitRecordOfWork / createOriginalVendorInvoice handle
+  // with a facility fallback.
+  const imgMutation = `mutation($input: ${inputType}!) {
     ${mutation}(input: $input) { __typename }
-  }`, { input: { visit: visitId, images } });
+  }`;
+  const imgVars = { input: { visit: visitId, images } };
+  try {
+    await resqGql(session, imgMutation, imgVars);
+  } catch (e) {
+    const facSession = await resqLogin({ facility: true });
+    await resqGql(facSession, imgMutation, imgVars);
+  }
 
   // Mark photosSent in mapping
   try {


### PR DESCRIPTION
## Diagnosis
Checking why R1020568's photos still wouldn't land, I found the SF→ResQ photo push has **never worked**: `addAfterImagesToVisit` has **0 successes and 17 `AuthorizationError`s** since the auto-push feature launched at 03:52 today — and it fails for **both** Starbird (R1020568) and Melt (R1021617), so it's not a customer/data issue. The `photos_sent=true` rows in `resq_sf_links` are from the *old manual* upload path (removed in #139), not the auto-push.

Root cause: the **Brix vendor ResQ identity isn't authorized to add after-images.** The codebase already hits this exact vendor-auth gap on other writes — `submitRecordOfWork` and `createOriginalVendorInvoice` both retry with `resqLogin({ facility: true })`. The photo push was the one write op missing that fallback.

## Fix
Add the same vendor→facility fallback to `addAfterImagesToVisit` in:
- `resq-sf-sync-background.mjs` `transferSfPhotosToResq` (live auto-push)
- `resq-sf-sync.mjs` `pushImagesToVisit` (dashboard/manual path)

On failure both attempts' errors are kept, so if the **facility** account is *also* unauthorized, the log will say so plainly — that would make it a ResQ-side permission grant rather than a code fix.

## Scope / risk
Failure-path fallback only; the vendor attempt is unchanged and tried first. Two files. Must merge + deploy to `main` to take effect.

## Caveat
Unverified against ResQ from here (no ResQ creds in this env). High confidence because the facility account already succeeds for the analogous `submitRecordOfWork` / `createOriginalVendorInvoice` writes — but if the facility identity also lacks after-image permission, the next run's log will show `facility: …AuthorizationError` and we'll know to grant it in ResQ instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_