### PR TITLE
Brixpense: fix payment-accounts 502 — drop multi-column QBO ORDER BY

### DIFF
--- a/netlify/functions/expense-payment-accounts.mjs
+++ b/netlify/functions/expense-payment-accounts.mjs
@@ -112,11 +112,13 @@ export default async function handler(req) {
     }
 
     // Live QBO query of every active Bank + Credit Card account.
+    // NOTE: no ORDER BY — QBO rejects a multi-column sort
+    // (`ORDER BY AccountType, Name`) with a 400, which surfaced here as a 502.
+    // We sort client-side below instead.
     const res = await qboQuery(
       `SELECT Id, Name, AccountType, AccountSubType, Active ` +
         `FROM Account ` +
-        `WHERE Active = true AND AccountType IN ('Bank','Credit Card') ` +
-        `ORDER BY AccountType, Name`
+        `WHERE Active = true AND AccountType IN ('Bank','Credit Card')`
     );
     const rows = res?.QueryResponse?.Account || [];
     const accounts = rows.map((a) => ({
@@ -126,6 +128,9 @@ export default async function handler(req) {
       account_sub_type: a.AccountSubType,
       payment_type: paymentTypeFor(a.AccountType),
     }));
+    accounts.sort(
+      (a, b) => a.account_type.localeCompare(b.account_type) || a.name.localeCompare(b.name),
+    );
     return json({
       accounts: allMode ? accounts : [...accounts, BILL_OPTION],
       source: 'qbo',


### PR DESCRIPTION
## You were right — it's the code, not the token

Both `expense-payment-accounts` and (the old) `expense-gl-accounts` built their QBO query with a **multi-column** sort: `ORDER BY AccountType, Name`. **QBO rejects a multi-column ORDER BY with a 400**, which the handler turns into a **502**. Proof it's the multi-column part: `qbo-pos-preview` uses a *single*-column `ORDER BY MetaData.LastUpdatedTime DESC` and works fine.

It only ever showed on the Settings **`?all=1`** path — the form's "Paid with" dropdown masked it behind the curated-list + "create bill" fallback, so it looked healthy everywhere else.

## Fix
Removed the server-side `ORDER BY` from the payment-accounts query and sort the accounts **client-side** instead (type, then name). This matches the #160 fix for the COGS/Department endpoints.

After this + #160 deploy, all three Settings account pulls (Payment, COGS/Expense, Location) load.

Function syntax-checked. No frontend change.

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU)_