### PR TITLE
diag(sync): surface ResQ's real error when scheduling push is rejected

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -489,8 +489,8 @@ async function syncBidirectional(session, resqWO, mapEntry) {
     // for the completion + photo steps below. Non-fatal: log and move on.
     if (resqNeedsSchedule) {
       let scheduled = false;
+      const schedErrors = [];
       for (const ts of ['SCHEDULING', 'APPOINTMENT', 'SITE_VISIT', 'DISPATCH']) {
-        if (scheduled) break;
         try {
           await resqGql(session, `mutation($input: VendorChangeWorkOrderStateInput!) {
             vendorChangeWorkOrderState(input: $input) { workOrder { id status } }
@@ -498,11 +498,15 @@ async function syncBidirectional(session, resqWO, mapEntry) {
           result.steps.push(`→ ResQ ${resqWO.code} scheduled (${ts})`);
           result.updated++;
           scheduled = true;
+          break;
         } catch (e) {
-          result.steps.push(`schedule ${ts} failed for ${resqWO.code}: ${e.message.substring(0, 100)}`);
+          // Keep the FULL ResQ error per target state (incl. extensions.fields
+          // with the valid enum values, if ResQ returns them) so we can see
+          // exactly what it wants instead of a swallowed "all failed".
+          schedErrors.push(`${ts}: ${e.message.substring(0, 300)}`);
         }
       }
-      if (!scheduled) result.errors.push(`ResQ schedule ${resqWO.code}: all targetStates failed`);
+      if (!scheduled) result.errors.push(`ResQ schedule ${resqWO.code}: ${schedErrors.join(' | ')}`);
     }
 
     // --- Provide Update: Complete the visit in ResQ ---


### PR DESCRIPTION
## Why
After #163 deployed, the scheduling push fired for R0875542 but logged only `ResQ schedule R0875542: all targetStates failed` — ResQ is rejecting `vendorChangeWorkOrderState` for all four target states, and **the actual rejection reason is swallowed.**

## What
Collect the **full ResQ error per target state** (incl. `extensions.fields` where ResQ often returns the valid enum values, like it does for SF `customer_name`) and persist it instead of the summary. Next run will show exactly what ResQ wants — so we either correct the target-state value/fields or confirm the vendor can't self-schedule and it must originate in ResQ.

## Scope / risk
One block, logging-only. Behavior unchanged; just stops swallowing the error.

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_