### PR TITLE
feat(sync): land SF job expenses (lines + receipt) into Brixpense on Close

### DIFF
--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -317,11 +317,13 @@
       "schedule": "every 5 min (resq-sf-sync-cron) + on-demand from sync.html",
       "writes": [
         "ops.resq_sf_links",
-        "ops.sync_events"
+        "ops.sync_events",
+        "ops.expense_requests",
+        "ops.expense_request_attachments"
       ],
       "multi_writer": true,
       "external_inputs": ["ResQ GraphQL API", "Service Fusion API"],
-      "notes": "Phase 2 of resq-sf-sync v2. The background worker (resq-sf-sync-background.mjs) dual-writes its state into ops.resq_sf_links (one row per ResQ WO <-> SF job link, replacing the wo-mapping Netlify Blob) and appends an audit trail to ops.sync_events at the end of every run. The Netlify Blob remains the authoritative read source for now; these tables mirror it (additive, non-fatal on failure). Writes via service-role through netlify/functions/lib/resq-sf-links.mjs. sync_events is append-only (multi_writer for future writers). Migration 20260602c_resq_sf_links.sql.",
+      "notes": "Phase 2 of resq-sf-sync v2. The background worker (resq-sf-sync-background.mjs) dual-writes its state into ops.resq_sf_links (one row per ResQ WO <-> SF job link, replacing the wo-mapping Netlify Blob) and appends an audit trail to ops.sync_events at the end of every run. The Netlify Blob remains the authoritative read source for now; these tables mirror it (additive, non-fatal on failure). Writes via service-role through netlify/functions/lib/resq-sf-links.mjs. sync_events is append-only (multi_writer for future writers). Migration 20260602c_resq_sf_links.sql. ALSO: on 🔒 Close (handleCloseJob → lib/sf-expense.mjs), lands the SF job's expenses into ops.expense_requests (one combined row per job, tag 'Service Fusion') + uploads each SF receipt to the expense-attachments bucket with an ops.expense_request_attachments row. Idempotent via the wo-mapping entry's expenseLandedId. Shares the table with the Brixpense surface (both multi_writer).",
       "last_verified": "2026-06-02"
     },
     {

--- a/netlify/functions/lib/sf-assets.mjs
+++ b/netlify/functions/lib/sf-assets.mjs
@@ -174,3 +174,12 @@ export async function pictureToPublicUrl(p, sfJobId, index) {
   if (!publicUrl) return { ok: false, error: `${name}: relay upload failed (SUPABASE_SERVICE_ROLE_KEY set?)` };
   return { ok: true, url: publicUrl };
 }
+
+// Fetch any SF asset (e.g. an expense receipt) to bytes, host-aware (public S3
+// anon / api→Bearer / admin→Cookie). Returns { ok, bytes, contentType } or
+// { ok:false, error }. Used to pull SF expense receipts for Brixpense.
+export async function fetchSfAssetToBytes(fileLocationOrUrl) {
+  if (!fileLocationOrUrl) return { ok: false, error: 'no file location' };
+  const url = resolveSfAssetUrl('receipt', fileLocationOrUrl);
+  return fetchSfAssetBytes(url);
+}

--- a/netlify/functions/lib/sf-expense.mjs
+++ b/netlify/functions/lib/sf-expense.mjs
@@ -1,0 +1,124 @@
+// Land a Service Fusion job's expenses into Brixpense when the WO is invoiced.
+// ONE combined ops.expense_requests row per job: line_items = the SF expense
+// lines, total = sum, tag 'Service Fusion'. Each SF expense receipt is fetched
+// host-aware and uploaded to the private `expense-attachments` bucket with an
+// expense_request_attachments row, so the receipt shows up in Brixpense.
+//
+// Server-side via the service-role key. Best-effort: the row lands even if a
+// receipt fetch/upload fails. Caller is responsible for idempotency (don't call
+// twice for the same job).
+import { sfRequest } from '../sf-helpers.mjs';
+import { SUPABASE_URL } from '../supabase-helpers.mjs';
+
+const ATTACH_BUCKET = 'expense-attachments';
+
+function srHeaders(extra = {}) {
+  const k = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  return { apikey: k, Authorization: `Bearer ${k}`, ...extra };
+}
+
+export async function landSfJobExpense({ sfJobId, resqCode, submitter }) {
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) return { ok: false, error: 'no service key' };
+  if (!submitter?.id) return { ok: false, error: 'no submitter id' };
+
+  // 1. Pull the SF job's expenses (and customer name).
+  let job;
+  try {
+    job = await sfRequest('GET', `/jobs/${sfJobId}?expand=expenses`);
+  } catch (e) {
+    return { ok: false, error: `fetch SF job ${sfJobId}: ${String(e.message).slice(0, 200)}` };
+  }
+  const expenses = Array.isArray(job.expenses) ? job.expenses : [];
+  if (!expenses.length) return { ok: false, empty: true, error: 'no SF expenses on job' };
+
+  // 2. One row per job — just the lines + total.
+  const lineItems = expenses.map((ex) => {
+    const amount = Number(ex.amount ?? ex.total ?? 0) || 0;
+    const description =
+      [ex.category, ex.notes].filter(Boolean).join(' — ') || 'Service Fusion expense';
+    return { description, qty: 1, unit_price: amount, amount };
+  });
+  const total = Math.round(lineItems.reduce((s, l) => s + (l.amount || 0), 0) * 100) / 100;
+
+  const row = {
+    request_type: 'expense',
+    status: 'posted',
+    as_bill: true,
+    auto_approved: true,
+    tag: 'Service Fusion',
+    submitted_by: submitter.id,
+    submitter_name: submitter.user_metadata?.name || submitter.email || 'Service Fusion',
+    submitter_email: submitter.email || null,
+    vendor_name: null,
+    total_amount: total,
+    currency: 'USD',
+    line_items: lineItems,
+    customer_name: job.customer_name || null,
+    job_number: String(sfJobId),
+    memo: [resqCode ? `ResQ ${resqCode}` : null, `SF Job #${sfJobId}`, `${expenses.length} SF expense line(s)`]
+      .filter(Boolean).join(' | '),
+    description: `Service Fusion job #${sfJobId} expenses`,
+    posted_at: new Date().toISOString(),
+  };
+
+  // 3. Insert the expense_requests row.
+  const ins = await fetch(`${SUPABASE_URL}/rest/v1/expense_requests`, {
+    method: 'POST',
+    headers: srHeaders({
+      'Content-Type': 'application/json',
+      'Accept-Profile': 'ops',
+      'Content-Profile': 'ops',
+      Prefer: 'return=representation',
+    }),
+    body: JSON.stringify([row]),
+  });
+  if (!ins.ok) return { ok: false, error: `insert expense: ${ins.status} ${(await ins.text()).slice(0, 200)}` };
+  const out = await ins.json();
+  const requestId = Array.isArray(out) ? out[0]?.id : out?.id;
+  if (!requestId) return { ok: false, error: 'insert returned no id' };
+
+  // 4. Attach receipts (best-effort — the row already landed).
+  const attached = [];
+  const attachErrors = [];
+  for (let i = 0; i < expenses.length; i++) {
+    const ex = expenses[i];
+    const recRef = ex.receipt_url || ex.receipt || ex.file_location || null;
+    if (!recRef) continue;
+    try {
+      const { fetchSfAssetToBytes } = await import('./sf-assets.mjs');
+      const r = await fetchSfAssetToBytes(recRef);
+      if (!r.ok) { attachErrors.push(`exp ${ex.id || i}: ${r.error}`); continue; }
+      const ct = r.contentType || 'application/octet-stream';
+      const ext = (ct.split('/')[1] || 'pdf').replace(/[^a-z0-9]/gi, '') || 'pdf';
+      const fileName = `sf-expense-${ex.id || i}.${ext}`;
+      const storagePath = `${submitter.id}/${requestId}/${fileName}`;
+      const up = await fetch(`${SUPABASE_URL}/storage/v1/object/${ATTACH_BUCKET}/${encodeURI(storagePath)}`, {
+        method: 'POST',
+        headers: srHeaders({ 'Content-Type': ct, 'x-upsert': 'true' }),
+        body: Buffer.from(r.bytes),
+      });
+      if (!up.ok) { attachErrors.push(`exp ${ex.id || i} upload: ${up.status}`); continue; }
+      await fetch(`${SUPABASE_URL}/rest/v1/expense_request_attachments`, {
+        method: 'POST',
+        headers: srHeaders({
+          'Content-Type': 'application/json',
+          'Accept-Profile': 'ops',
+          'Content-Profile': 'ops',
+          Prefer: 'return=minimal',
+        }),
+        body: JSON.stringify([{
+          request_id: requestId,
+          file_name: fileName,
+          file_type: ct,
+          file_size: r.bytes.byteLength ?? null,
+          storage_path: storagePath,
+        }]),
+      });
+      attached.push(fileName);
+    } catch (e) {
+      attachErrors.push(`exp ${ex.id || i}: ${String(e.message).slice(0, 150)}`);
+    }
+  }
+
+  return { ok: true, id: requestId, lines: lineItems.length, total, attached: attached.length, attachErrors };
+}

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -510,24 +510,19 @@ async function syncBidirectional(session, resqWO, mapEntry) {
     }
 
     // --- Provide Update: Complete the visit in ResQ ---
-    // Relay the SF photos FIRST and attach them as part of completing the visit.
-    // ResQ rejects after-images on an already-closed visit (AuthorizationError),
-    // so the endVisit call itself is the only reliable moment to attach them.
+    // NOTE: photos are NOT attached here. Passing image URLs into endVisit's
+    // `images` field made ResQ reject it ("Expected type 'Image' to be a
+    // mapping") — that field wants image objects, not URL strings, and the
+    // correct shape is still TBD. So complete the visit cleanly (images=[]);
+    // photo attachment stays in the after-image path below as an open item.
     if (needsVisitComplete) {
       try {
-        const relayed = await relaySfPhotos(mapEntry.sfJobId, mapEntry.photosSentKeys || []);
-        if (relayed.errors.length) result.errors.push(`📸 ${resqWO.code} relay: ${relayed.errors[0]}`);
-        const updateResult = await provideUpdateToResq(session, resqWO, mapEntry.sfJobId, relayed.imageUrls);
+        const updateResult = await provideUpdateToResq(session, resqWO, mapEntry.sfJobId);
         if (updateResult.steps.length) result.steps.push(...updateResult.steps);
         if (updateResult.errors.length) result.errors.push(...updateResult.errors);
         if (updateResult.completed) {
           mapEntry.visitCompleted = true;
           result.updated++;
-          if (updateResult.imagesAttached > 0) {
-            result.steps.push(`📸 ${updateResult.imagesAttached} photo(s) attached at completion → ResQ ${resqWO.code}`);
-            mapEntry.photosSentKeys = [...(mapEntry.photosSentKeys || []), ...relayed.relayedKeys];
-            mapEntry.photosSent = true;
-          }
         }
       } catch (e) {
         result.errors.push(`Visit complete ${resqWO.code}: ${e.message.substring(0, 200)}`);

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -22,7 +22,7 @@ export async function handler(event) {
   if (qs.introspect) return handleIntrospect(qs.introspect);
   if (qs.dedupeReport) return handleDedupeReport();
   if (qs.cancelSfJob) return handleCancelSfJob(qs.cancelSfJob, qs.resqCode);
-  if (qs.closeJob) return handleCloseJob(qs.closeJob, qs.resqCode);
+  if (qs.closeJob) return handleCloseJob(qs.closeJob, qs.resqCode, auth.user);
   if (qs.relink) return handleRelink(qs.relink, qs.toSfJobId);
   if (qs.dismissIssue) return handleDismissIssue(qs.dismissIssue);
   if (qs.clearErrors) return handleClearErrors();
@@ -582,7 +582,7 @@ async function handleCancelSfJob(jobId, resqCode) {
 
 // --- Close SF Job: set status to Invoiced (closes it out after the 3rd-party
 // bill is entered). The next sync sees "Invoiced" and submits the ResQ invoice. ---
-async function handleCloseJob(jobId, resqCode) {
+async function handleCloseJob(jobId, resqCode, operator) {
   if (!jobId) return json({ error: 'jobId required' }, 400);
   let expenseLanded = null, expenseError = null;
   try {
@@ -590,7 +590,7 @@ async function handleCloseJob(jobId, resqCode) {
     await sfRequest('PUT', `/jobs/${jobId}`, { status: 'Invoiced' });
 
     // Reflect immediately in the mapping blob so the dashboard shows Invoiced,
-    // and land the deferred SF expense in Brixpense now that it's invoiced.
+    // and land the SF job's expenses in Brixpense now that it's invoiced.
     try {
       const store = await getStore();
       if (store) {
@@ -600,13 +600,26 @@ async function handleCloseJob(jobId, resqCode) {
           if (String(v.sfJobId) === String(jobId) || (resqCode && v.resqCode === resqCode)) {
             v.sfStatus = 'Invoiced';
             v.lastSyncAt = new Date().toISOString();
-            if (v.pendingExpense) {
-              try {
-                const { postExpenseRow } = await import('./expense-to-bill.mjs');
-                const r = await postExpenseRow(v.pendingExpense);
-                if (r.ok) { delete v.pendingExpense; expenseLanded = r.id || true; }
-                else expenseError = r.error;
-              } catch (e) { expenseError = e.message; }
+
+            // Idempotent: only land once per WO.
+            if (!v.expenseLandedId && operator?.id) {
+              // Prefer the deferred 💰 Bill expense if one was stashed; otherwise
+              // pull the SF job's native expense lines.
+              if (v.pendingExpense) {
+                try {
+                  const { postExpenseRow } = await import('./expense-to-bill.mjs');
+                  const r = await postExpenseRow(v.pendingExpense);
+                  if (r.ok) { delete v.pendingExpense; v.expenseLandedId = r.id || true; expenseLanded = r.id || true; }
+                  else expenseError = r.error;
+                } catch (e) { expenseError = e.message; }
+              } else {
+                try {
+                  const { landSfJobExpense } = await import('./lib/sf-expense.mjs');
+                  const r = await landSfJobExpense({ sfJobId: jobId, resqCode: resqCode || v.resqCode, submitter: operator });
+                  if (r.ok) { v.expenseLandedId = r.id; expenseLanded = { id: r.id, lines: r.lines, total: r.total, attached: r.attached, attachErrors: r.attachErrors }; }
+                  else if (!r.empty) expenseError = r.error;
+                } catch (e) { expenseError = e.message; }
+              }
             }
           }
         }


### PR DESCRIPTION
## Why
You enter expenses **natively in Service Fusion** — but #165 only landed the 💰 Bill (receipt→QBO) flow, so your SF expense for 1086695007 never reached Brixpense. This builds the actual path.

## What
**On 🔒 Close (`handleCloseJob`, after SF→Invoiced):**
- Pull the SF job's expenses (`/jobs/{id}?expand=expenses`) and create **one combined `ops.expense_requests` row per job** — `line_items` = the SF expense lines, `total_amount` = sum, `tag='Service Fusion'`, `status='posted'`, `customer_name`, `job_number`, `submitted_by` = the operator who clicked Close.
- For each SF expense **receipt**: fetch bytes host-aware (new `sf-assets.fetchSfAssetToBytes`), upload to the private **`expense-attachments`** bucket at `<operator>/<request_id>/<file>`, and insert an `ops.expense_request_attachments` row.
- **Idempotent** via the WO mapping's `expenseLandedId` (re-Close won't duplicate). The deferred 💰 Bill stash (#165) still takes precedence if present.
- New `lib/sf-expense.mjs`; `sf-assets` exports `fetchSfAssetToBytes`.

**Manifest:** `resq-sf-sync` now declares `ops.expense_requests` + `ops.expense_request_attachments` (both `multi_writer` alongside the Brixpense surface). Lint: clean, 0 warnings.

**Also — photo bug fix:** my #159 attempt passed image URL **strings** into `endVisit`'s `images`, which ResQ rejected (`"Expected type 'Image' to be a mapping"`). Reverted so the visit completes cleanly (`images=[]`). **Photo attachment remains an open item** — it needs ResQ's real `Image` input shape, which I'll chase next.

## Backfill
1086695007 is already invoiced but its expense was lost (old code). After deploy, clicking **🔒 Close** on it again will land it (idempotency flag wasn't set on the prior close).

## Scope / risk
Additive + non-fatal: the row lands even if a receipt fetch fails; nothing blocks the close/invoice. Only the lines + receipt land (no vendor), per your spec. The SF receipt field name is probed defensively (`receipt_url`/`receipt`/`file_location`) — if SF uses a different field, the row still lands and I'll adjust from the logged `attachErrors`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_