### PR TITLE
diag(sync): one-shot introspect of ResQ image input types

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -74,6 +74,28 @@ export async function handler(event) {
     const session = await resqLogin();
     log.steps.push('ResQ OK');
 
+    // One-shot schema probe: photos have never attached because we don't know
+    // ResQ's image input shape ("Expected type 'Image' to be a mapping" on
+    // endVisit; AuthorizationError on addAfterImages). Introspect the relevant
+    // input types ONCE and log the field shapes to ops.sync_events so we can
+    // build the correct payload. Gated by a blob flag; remove after we have it.
+    try {
+      const probed = await loadBlob('image-schema-probed-v1');
+      if (!probed) {
+        const types = ['AddAfterImagesToVisitInput', 'AddBeforeImagesToVisitInput', 'EndVisitInput', 'Image', 'ImageInput', 'StartVisitMutationInput'];
+        const out = {};
+        for (const t of types) {
+          try {
+            const d = await resqGql(session, `{ __type(name: "${t}") { name kind inputFields { name type { name kind ofType { name kind ofType { name kind } } } } } }`);
+            out[t] = d.data?.__type || null;
+          } catch (e) { out[t] = { error: String(e.message).substring(0, 150) }; }
+        }
+        syncEvents.push({ resq_wo_id: 'schema-probe', resq_code: null, sf_job_id: null, direction: 'system', action: 'introspect', ok: true, message: ('IMAGE-SCHEMA ' + JSON.stringify(out)).slice(0, 8000) });
+        await saveBlob('image-schema-probed-v1', new Date().toISOString());
+        log.steps.push('Probed ResQ image schema (one-shot)');
+      }
+    } catch (e) { log.errors.push('image probe: ' + String(e.message).substring(0, 150)); }
+
     // 2. Verify SF
     log.steps.push('Checking SF...');
     await saveProgress();


### PR DESCRIPTION
Diagnostic only. Photos have never attached and we don't actually know ResQ's image input shape — `endVisit` rejected URL strings (`"Expected type 'Image' to be a mapping"`) and `addAfterImagesToVisit` 401s for both vendor and facility.

This adds a **one-shot, gated** introspection in the cron (server-side, has ResQ creds): it queries `__type` for `AddAfterImagesToVisitInput`, `AddBeforeImagesToVisitInput`, `EndVisitInput`, `Image`, `ImageInput`, `StartVisitMutationInput` once and logs their `inputFields` to `ops.sync_events` (gated by a blob flag so it runs a single time). I read it from the DB, learn the exact image-object shape, then ship the real fix and remove this probe.

No behavior change to the sync; additive + non-fatal.

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_