### PR TITLE
feat(sync): auto-land SF expense at invoice + 1086695007 backfill (no re-close needed)

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -23,6 +23,21 @@ import { mapEntryToLinkRow, bulkUpsertLinks, bulkInsertEvents, eventFromResult }
 
 const BRIX_VENDOR_KEYWORDS = ['brix'];
 
+// System submitter for SF-sourced expenses landed by the cron (no operator in
+// scope). ops.expense_requests.submitted_by is NOT NULL → attribute to the ops
+// owner's auth user (skypace@brixbev.com). The 🔒 Close button still attributes
+// to whoever clicked it.
+const SF_EXPENSE_SUBMITTER = {
+  id: '2da634b7-623d-4f73-b667-cf87975fcdb6',
+  email: 'skypace@brixbev.com',
+  user_metadata: { name: 'Service Fusion (system)' },
+};
+
+// One-off backfill allowlist: SF job ids that were invoiced before the
+// expense-on-invoice landing existed and whose expense we still want pulled in.
+// (Going-forward jobs land automatically at the invoice transition.)
+const SF_EXPENSE_BACKFILL = new Set(['1086695007']);
+
 // Customer identity (ResQ facility <-> SF customer <-> QBO customer) now lives
 // in ops.sync_customers, loaded once per run and threaded through the worker.
 // See netlify/functions/lib/sync-customers.mjs + migration 20260602a.
@@ -491,12 +506,19 @@ async function syncBidirectional(session, resqWO, mapEntry) {
     // so photos added after the first push still flow (dedup is by file_location).
     const needsPhotoTransfer = sfIsCompleted && !mapEntry.invoiceSubmitted;
     const needsInvoiceSubmit = sfIsInvoiced && !mapEntry.invoiceSubmitted;
+    // Land the SF job's expenses in Brixpense at the invoice transition
+    // (needsInvoiceSubmit) — NOT for every already-invoiced WO, which would
+    // mass-backfill historical jobs. SF_EXPENSE_BACKFILL is an explicit one-off
+    // allowlist for specific jobs that were invoiced before this landed (e.g.
+    // 1086695007, whose expense was lost). Idempotent via expenseLandedId.
+    const needsExpenseLanding = sfIsInvoiced && !mapEntry.expenseLandedId
+      && (needsInvoiceSubmit || SF_EXPENSE_BACKFILL.has(String(mapEntry.sfJobId)));
     // "Provide Update" — complete the visit in ResQ when SF is completed
     // Also trigger if WO is COMPLETED (visit done but needs to transition to NEEDS_INVOICE)
     const needsVisitComplete = sfIsCompleted && !mapEntry.visitCompleted
       && ['SCHEDULED', 'VISIT_SCHEDULED', 'NOT_YET_COMPLETED', 'COMPLETED'].includes(resqStatus);
 
-    if (!sfChanged && !resqChanged && !resqNeedsSchedule && !needsPhotoTransfer && !needsInvoiceSubmit && !needsVisitComplete) return result;
+    if (!sfChanged && !resqChanged && !resqNeedsSchedule && !needsPhotoTransfer && !needsInvoiceSubmit && !needsExpenseLanding && !needsVisitComplete) return result;
 
     if (sfChanged) {
       result.steps.push(`SF ${mapEntry.sfJobId}: "${mapEntry.sfStatus}" → "${sfStatus}"`);
@@ -582,6 +604,26 @@ async function syncBidirectional(session, resqWO, mapEntry) {
           mapEntry.invoiceSubmitted = true;
         }
       } catch (e) { result.errors.push(`ResQ invoice ${resqWO.code}: ${e.message.substring(0, 200)}`); }
+    }
+
+    // --- Land the SF job's expenses in Brixpense (once invoiced, idempotent) ---
+    // Cron-context landing uses the system submitter (no operator in scope).
+    // The 🔒 Close button still lands with the actual operator; whichever runs
+    // first sets expenseLandedId and the other skips.
+    if (needsExpenseLanding) {
+      try {
+        const { landSfJobExpense } = await import('./lib/sf-expense.mjs');
+        const r = await landSfJobExpense({ sfJobId: mapEntry.sfJobId, resqCode: resqWO.code, submitter: SF_EXPENSE_SUBMITTER });
+        if (r.ok) {
+          mapEntry.expenseLandedId = r.id;
+          result.updated++;
+          result.steps.push(`💵 SF expense → Brixpense ${resqWO.code} (${r.lines} line(s), $${r.total}, ${r.attached} receipt(s))`);
+        } else if (r.empty) {
+          mapEntry.expenseLandedId = 'none'; // no SF expenses on the job — don't retry every run
+        } else {
+          result.errors.push(`SF expense land ${resqWO.code}: ${r.error}`);
+        }
+      } catch (e) { result.errors.push(`SF expense land ${resqWO.code}: ${e.message.substring(0, 200)}`); }
     }
 
     // Update mapping with current states


### PR DESCRIPTION
## Why
You shouldn't have to "re-close" a WO to land its expense — and you *can't*, since the 🔒 Close button is gone once a WO is `Invoiced`. So land the SF expense automatically when the sync sees the job invoiced.

## What
- New `needsExpenseLanding` in `syncBidirectional`: lands the SF job's expenses (via `lib/sf-expense.mjs`, one row per job + receipts) at the **invoice transition** (`needsInvoiceSubmit`). Idempotent via `mapEntry.expenseLandedId`.
- **No mass-backfill:** it only fires on the transition, so historical already-invoiced WOs are left alone. An explicit `SF_EXPENSE_BACKFILL` allowlist pulls in specific pre-existing jobs — currently **`1086695007`** (your lost expense).
- Cron-context landing uses a **system submitter** (skypace's auth user, since `submitted_by` is NOT NULL and there's no operator in a cron run). The 🔒 Close button path still attributes to the actual operator.

## Important operational note (separate from this PR)
While checking, I found the **scheduled ResQ↔SF sync has not run since ~01:47** (no `sync_events`, schema probe from #167 hasn't logged). The cron's in-process auth is fine in code, so this looks like the **Netlify scheduler not firing** (or deploy settling). There are also recurring **`pg_net` HTTP 401** failures in `ops.sync_log` — a *separate* Supabase pg_cron hitting an endpoint without auth. Both need a look; until the sync runs, nothing here (or the probe, or the backfill) executes. Triggering a full **Sync Now** from `sync.html` will run the worker and kick all of it off.

## Scope / risk
Additive + non-fatal. One file. Lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_