### PR TITLE
diag(sync): cron heartbeat to pin why the 5-min scheduler isn't firing

### DIFF
--- a/netlify/functions/resq-sf-sync-cron.mjs
+++ b/netlify/functions/resq-sf-sync-cron.mjs
@@ -3,8 +3,35 @@
 
 import { handler as bgHandler } from './resq-sf-sync-background.mjs';
 import { requireScheduled } from './lib/auth.mjs';
+import { SUPABASE_URL } from './supabase-helpers.mjs';
+
+// Heartbeat: log EVERY invocation to ops.sync_log BEFORE the gate, so we can
+// tell whether the Netlify scheduler is firing this function at all, and what
+// scheduled-context fields it provides (to confirm requireScheduled matches).
+async function heartbeat(context) {
+  try {
+    const k = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!k) return;
+    const ctxKeys = context ? Object.keys(context).join(',') : '(no context)';
+    const sched = !!(context?.next_run || context?.scheduledTime || context?.scheduled_time);
+    const now = new Date().toISOString();
+    await fetch(`${SUPABASE_URL}/rest/v1/sync_log`, {
+      method: 'POST',
+      headers: {
+        apikey: k, Authorization: `Bearer ${k}`, 'Content-Type': 'application/json',
+        'Accept-Profile': 'ops', 'Content-Profile': 'ops', Prefer: 'return=minimal',
+      },
+      body: JSON.stringify([{
+        source: 'resq-sf-sync-cron', sync_type: 'heartbeat',
+        status: sched ? 'scheduled' : 'unscheduled', started_at: now, completed_at: now,
+        records_synced: 0, metadata: { ctxKeys, sched },
+      }]),
+    });
+  } catch { /* non-fatal */ }
+}
 
 export default async (req, context) => {
+  await heartbeat(context);
   // Reject manual HTTP hits to this URL — only the Netlify scheduler may invoke.
   const gate = requireScheduled(req, context);
   if (!gate.ok) return gate.response;


### PR DESCRIPTION
## Why
The 5-min ResQ↔SF cron hasn't fired in hours — no `sync_events`, and runs correlated with manual clicks, not a clean cadence. Netlify's MCP doesn't expose scheduled-function invocation history, so this gives us the signal directly.

## What
`resq-sf-sync-cron` now logs a **heartbeat** row to `ops.sync_log` on **every invocation, before** `requireScheduled`, recording the `context` keys and whether it looks scheduled.

Interpretation on the next ticks:
- **No `source='resq-sf-sync-cron'` rows** → Netlify isn't invoking the function at all → Netlify-side (redeploy / re-enable the scheduled function).
- **Rows with `status='unscheduled'`** → `requireScheduled` isn't matching the runtime's scheduled-context field → code fix (the logged `ctxKeys` shows the right field).
- **Rows with `status='scheduled'`** → cron fires and passes the gate → look downstream.

Diagnostic only; non-fatal.

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_