### PR TITLE
feat(sync): reliable triggers — Supabase pg_cron + sync-on-dashboard-load (retire Netlify cron dependency)

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -61,8 +61,16 @@ const SYNC_LOCK_KEY = 'sync-lock';
 const SYNC_LOCK_TTL_MS = 10 * 60 * 1000; // 10 min
 
 export async function handler(event) {
-  const auth = await requireAuth(event);
-  if (!auth.ok) return auth.response;
+  // Auth: a superadmin JWT, the in-process cron flag (_internalCron, honored by
+  // requireAuth), OR a matching CRON_SECRET — the latter lets Supabase pg_cron
+  // POST this endpoint directly (a more reliable scheduler than Netlify's, which
+  // silently stopped firing resq-sf-sync-cron). Set CRON_SECRET in Netlify env.
+  const qs = event.queryStringParameters || {};
+  const cronOk = !!(qs.cronKey && process.env.CRON_SECRET && qs.cronKey === process.env.CRON_SECRET);
+  if (!cronOk) {
+    const auth = await requireAuth(event);
+    if (!auth.ok) return auth.response;
+  }
 
   const log = { started: new Date().toISOString(), steps: [], errors: [], created: 0, updated: 0 };
   const dedupeReport = [];

--- a/public/sync.html
+++ b/public/sync.html
@@ -271,7 +271,21 @@ APBG.auth.requireSuperadmin().then(() => {
   document.getElementById('mainApp').style.display = 'block';
   loadStatus();
   loadSyncEvents();
+  autoSyncOnLoad();
 });
+
+// Event-driven freshness: kick a background sync whenever someone opens the
+// dashboard (throttled to once / 5 min per browser), so data is current when
+// you're actually working — independent of the scheduled reconciler.
+async function autoSyncOnLoad() {
+  try {
+    const last = +(localStorage.getItem('apbg_last_autosync') || 0);
+    if (Date.now() - last < 5 * 60 * 1000) return;
+    localStorage.setItem('apbg_last_autosync', String(Date.now()));
+    await fetch(`${API_BASE}/resq-sf-sync`, { method: 'POST' });
+    setTimeout(() => { loadStatus(); loadSyncEvents(); }, 8000);
+  } catch (e) { /* non-fatal */ }
+}
 
 // --- Recent Sync Events (Phase 2) ---
 async function loadSyncEvents() {


### PR DESCRIPTION
## Why
The Netlify scheduled function (`resq-sf-sync-cron`) silently stopped firing (0 heartbeats in 30 min; config is valid in both `netlify.toml` and inline — it's Netlify-side). Meanwhile **all 18 other syncs on this project run on Supabase `pg_cron` and fire reliably**. So move the ResQ↔SF trigger onto the proven path, and add event-driven freshness.

## What
**#1 — Supabase `pg_cron` reconciler (reliable):**
- `resq-sf-sync-background` accepts a `CRON_SECRET` via `?cronKey=` to bypass the superadmin gate, so `pg_cron` can POST the background directly (15-min budget, no double-hop). `_internalCron` + superadmin JWT paths unchanged.
- Companion `pg_cron` job (every 5 min) created in Supabase, calling `…/resq-sf-sync-background?cronKey=…`.

**#2 — sync-on-dashboard-load (event-driven):**
- `sync.html` kicks a background sync on load, throttled to once/5 min per browser, via the authed fetch — data's fresh whenever someone's actually working, independent of any timer.

Together: two independent, observable trigger paths; neither relies on Netlify's scheduler.

## ⚠️ Requires one env var
Set **`CRON_SECRET`** on the apbg-billing Netlify site to the value I'll provide, then the `pg_cron` job's calls authenticate. Until then the cron calls 401 harmlessly (and the dashboard-load trigger already works, since it uses the operator JWT).

## Scope / risk
Additive; existing auth paths untouched; `sync.html` is static (no build). The dashboard-load trigger works immediately on deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_