### PR TITLE
fix(sync): cronKey via header + redeploy to load CRON_SECRET

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -66,7 +66,9 @@ export async function handler(event) {
   // POST this endpoint directly (a more reliable scheduler than Netlify's, which
   // silently stopped firing resq-sf-sync-cron). Set CRON_SECRET in Netlify env.
   const qs = event.queryStringParameters || {};
-  const cronOk = !!(qs.cronKey && process.env.CRON_SECRET && qs.cronKey === process.env.CRON_SECRET);
+  const hdrs = event.headers || {};
+  const providedKey = qs.cronKey || hdrs['x-cron-key'] || hdrs['X-Cron-Key'] || '';
+  const cronOk = !!(providedKey && process.env.CRON_SECRET && providedKey === process.env.CRON_SECRET);
   if (!cronOk) {
     const auth = await requireAuth(event);
     if (!auth.ok) return auth.response;


### PR DESCRIPTION
Background invocations can drop query params, so the cron secret is now also read from an `x-cron-key` header (query still works too). This commit also **forces a fresh deploy** so the function picks up the `CRON_SECRET` env var — Netlify bakes env vars in at deploy time, so the var set after #174's deploy wasn't live yet (the cron's calls were 202-accepted but internally rejected → no sync). After this deploys, the every-5-min `pg_cron` will authenticate and run real syncs.

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_