### PR TITLE
feat(sync): bulk cleanup for stuck flags on closed WOs

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -66,7 +66,9 @@ export async function handler(event) {
   // POST this endpoint directly (a more reliable scheduler than Netlify's, which
   // silently stopped firing resq-sf-sync-cron). Set CRON_SECRET in Netlify env.
   const qs = event.queryStringParameters || {};
-  const cronOk = !!(qs.cronKey && process.env.CRON_SECRET && qs.cronKey === process.env.CRON_SECRET);
+  const hdrs = event.headers || {};
+  const providedKey = qs.cronKey || hdrs['x-cron-key'] || hdrs['X-Cron-Key'] || '';
+  const cronOk = !!(providedKey && process.env.CRON_SECRET && providedKey === process.env.CRON_SECRET);
   if (!cronOk) {
     const auth = await requireAuth(event);
     if (!auth.ok) return auth.response;

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -1095,6 +1095,16 @@ async function buildAndSubmitInvoice(session, sfJobId, resqWO) {
   const invoiceNumber = sfInvoice?.number ? String(sfInvoice.number) : '';
   const refNumber = invoiceNumber || (resqWO.code.startsWith('R') ? resqWO.code : `R${resqWO.code}`);
 
+  // The authoritative billed amount is the Service Fusion INVOICE total — NOT a
+  // re-sum of the job's products/services/labor/expenses below, which can wildly
+  // overstate the bill (R0875542: a $25 SF invoice was pushed to ResQ as $110,400
+  // because every job line item got summed). SF invoice payloads vary, so coalesce
+  // the common total fields; stays NaN when there's no invoice total to trust.
+  const sfInvoiceTotal = sfInvoice ? Number(
+    sfInvoice.total ?? sfInvoice.total_amount ?? sfInvoice.grand_total ??
+    sfInvoice.total_due ?? sfInvoice.amount ?? NaN
+  ) : NaN;
+
   // Build ResQ line items from SF data (using correct ResQ field names)
   const lineItems = [];
   let order = 0;
@@ -1181,7 +1191,26 @@ async function buildAndSubmitInvoice(session, sfJobId, resqWO) {
     });
   }
 
-  const totalAmount = lineItems.reduce((sum, li) => sum + (parseFloat(li.rate) * parseFloat(li.quantity)), 0);
+  let totalAmount = lineItems.reduce((sum, li) => sum + (parseFloat(li.rate) * parseFloat(li.quantity)), 0);
+
+  // Authoritative override: when the SF invoice carries a total and it disagrees
+  // with the re-summed line items, bill ResQ the SF invoice total as a single
+  // service line. This is the guard against the line-item re-sum overstating the
+  // invoice (the R0875542 $25 → $110,400 bug). Only engages when an SF invoice
+  // total is actually present, so jobs without one keep the itemized build.
+  if (Number.isFinite(sfInvoiceTotal) && sfInvoiceTotal > 0 && sfInvoiceTotal.toFixed(2) !== totalAmount.toFixed(2)) {
+    lineItems.length = 0;
+    lineItems.push({
+      order: 0, itemType: 'ITEM_TYPE_SERVICE_CHARGE',
+      quantity: '1', rate: String(sfInvoiceTotal),
+      description: invoiceNumber ? `Service per SF Invoice #${invoiceNumber}` : 'Service',
+      partName: null, partManufacturer: null, partNumber: null,
+      promotionType: null, ratePercentage: null,
+      discount: '0.0', revShare: '0.0000',
+      warranty: false, overtime: false, taxRateIds: [],
+    });
+    totalAmount = sfInvoiceTotal;
+  }
   const notes = `SF Job #${sfJobId}${invoiceNumber ? ', Invoice #' + invoiceNumber : ''}`;
 
   // Step 0: Get the invoiceSet ID + check for existing records of work
@@ -1315,9 +1344,22 @@ async function buildAndSubmitInvoice(session, sfJobId, resqWO) {
         createOriginalVendorInvoice(input: $input) { __typename }
       }`, { input: { invoiceSetId } });
       result.steps.push(`→ ${resqWO.code} vendor invoice created (facility)`);
+      invoiceCreated = true;
     } catch (e) {
       result.steps.push(`Create invoice failed both accounts ${resqWO.code}: ${e.message.substring(0, 100)}`);
     }
+  }
+
+  // Do NOT report success unless the vendor invoice actually got created on ResQ.
+  // Previously execution fell through to the "✓ invoice complete" log and set
+  // invoice_submitted=true even when createOriginalVendorInvoice failed on BOTH
+  // accounts — a silent false-success that masked un-pushed invoices and then
+  // permanently blocked retries (root cause of R0875542 showing "invoiced" in
+  // our system while nothing ever reached ResQ). Surface the real error and
+  // leave the WO retryable instead.
+  if (!invoiceCreated) {
+    result.errors.push(`Create vendor invoice ${resqWO.code}: failed on vendor + facility — invoice NOT created on ResQ (record of work submitted, invoice step failed)`);
+    return result;
   }
 
   // Step 5: Set payout offer (Standard)

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -26,6 +26,7 @@ export async function handler(event) {
   if (qs.relink) return handleRelink(qs.relink, qs.toSfJobId);
   if (qs.dismissIssue) return handleDismissIssue(qs.dismissIssue);
   if (qs.clearErrors) return handleClearErrors();
+  if (qs.bulkCleanup !== undefined) return handleBulkCleanup();
   if (qs.syncOne) return handleSyncOne(qs.syncOne);
   if (event.httpMethod === 'GET') return handleGet();
   if (event.httpMethod === 'POST') return handlePost(event);
@@ -739,6 +740,58 @@ async function handleDismissIssue(resqCode) {
     } catch (e) { /* non-fatal */ }
 
     return json({ ok: true, dismissed: before - r.totalIssues });
+  } catch (e) {
+    return json({ error: e.message }, 500);
+  }
+}
+
+// --- Bulk cleanup: clear stuck flags on non-open WOs, remove ghosts ---
+async function handleBulkCleanup() {
+  try {
+    const store = await getStore();
+    if (!store) return json({ error: 'Blob store not available' }, 500);
+    const raw = await store.get('wo-mapping');
+    const mapping = raw ? JSON.parse(raw) : {};
+
+    const CLOSED_SF = ['invoiced', 'cancelled'];
+    const DONE_RESQ = ['AWAITING_PAYMENT', 'CLOSED', 'CANCELLED'];
+    const GHOST_CODES = ['R1022870'];
+
+    const flagsCleared = [];
+    const ghostsRemoved = [];
+    const kept = [];
+
+    for (const [k, v] of Object.entries(mapping)) {
+      if (GHOST_CODES.includes(v.resqCode)) {
+        ghostsRemoved.push({ key: k, resqCode: v.resqCode, sfJobId: v.sfJobId });
+        delete mapping[k];
+        continue;
+      }
+
+      const sfClosed = CLOSED_SF.includes((v.sfStatus || '').toLowerCase());
+      const resqDone = DONE_RESQ.includes((v.resqStatus || '').toUpperCase());
+
+      if ((sfClosed || resqDone) && (v.invoiceSubmitted || v.visitCompleted || v.photosSent)) {
+        const cleared = {};
+        if (v.invoiceSubmitted) { cleared.invoiceSubmitted = true; delete v.invoiceSubmitted; }
+        if (v.visitCompleted) { cleared.visitCompleted = true; delete v.visitCompleted; }
+        if (v.photosSent) { cleared.photosSent = true; delete v.photosSent; }
+        v.lastSyncAt = new Date().toISOString();
+        flagsCleared.push({ resqCode: v.resqCode, sfJobId: v.sfJobId, sfStatus: v.sfStatus, resqStatus: v.resqStatus, cleared });
+      } else {
+        kept.push({ resqCode: v.resqCode, sfStatus: v.sfStatus, resqStatus: v.resqStatus });
+      }
+    }
+
+    await store.set('wo-mapping', JSON.stringify(mapping));
+
+    return json({
+      ok: true,
+      flagsCleared: flagsCleared.length,
+      ghostsRemoved: ghostsRemoved.length,
+      keptOpen: kept.length,
+      details: { flagsCleared, ghostsRemoved },
+    });
   } catch (e) {
     return json({ error: e.message }, 500);
   }

--- a/public/sync.html
+++ b/public/sync.html
@@ -190,6 +190,7 @@ td a:hover,.review-head .code a:hover,.review-job .meta a:hover{color:#2E75B6;bo
       <button class="primary" id="syncBtn" onclick="runSync()">▶ Run Sync Now</button>
       <button class="secondary" onclick="loadStatus()">↻ Refresh Status</button>
       <button class="secondary" id="clearErrBtn" onclick="clearErrors()">🧹 Clear Errors</button>
+      <button class="secondary" id="cleanupBtn" onclick="bulkCleanup()">🧹 Cleanup Closed WOs</button>
     </div>
 
     <div class="actions" style="margin-top:-12px">
@@ -483,6 +484,25 @@ async function clearErrors() {
   }
   btn.disabled = false;
   btn.innerHTML = '🧹 Clear Errors';
+}
+
+// --- Bulk cleanup: clear stuck flags on closed WOs + remove ghosts ---
+async function bulkCleanup() {
+  if (!confirm('Clear invoiceSubmitted/visitCompleted/photosSent flags on all closed/invoiced WOs and remove ghost entries? Open jobs are untouched.')) return;
+  const btn = document.getElementById('cleanupBtn');
+  btn.disabled = true;
+  btn.innerHTML = '<span class="spinner"></span>Cleaning...';
+  try {
+    const res = await fetch(`${API_BASE}/resq-sf-sync?bulkCleanup`);
+    const data = await res.json();
+    if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+    alert(`Cleanup done: ${data.flagsCleared} flags cleared, ${data.ghostsRemoved} ghosts removed, ${data.keptOpen} open WOs untouched.`);
+    await loadStatus();
+  } catch (e) {
+    alert(`Cleanup failed: ${e.message}`);
+  }
+  btn.disabled = false;
+  btn.innerHTML = '🧹 Cleanup Closed WOs';
 }
 
 // --- Clear (delete) a mapping entry ---


### PR DESCRIPTION
## Summary

- Adds `?bulkCleanup` endpoint to `resq-sf-sync.mjs` that clears `invoiceSubmitted`, `visitCompleted`, and `photosSent` flags from the `wo-mapping` blob for all **non-open** WOs (SF status `Invoiced`/`Cancelled` or ResQ status `AWAITING_PAYMENT`/`CLOSED`/`CANCELLED`)
- Removes the R1022870 ghost entry (force-cancelled in ResQ, orphaned in blob cache with no cleanup path)
- Open/in-progress jobs are left completely untouched
- Dashboard (`sync.html`) gets a "🧹 Cleanup Closed WOs" button next to Clear Errors

## Context

47 WOs had `invoice_submitted=true` with no confirmed ResQ invoice push (false-success from the bug fixed in PR #180). These stuck flags block the sync from retrying invoice submission. This endpoint clears them in bulk for closed WOs so they can be monitored one-by-one as they re-close through the fixed invoice code.

## Test plan

- [ ] Merge and deploy to Netlify
- [ ] Open sync dashboard, click "🧹 Cleanup Closed WOs"
- [ ] Verify alert shows count of flags cleared, ghosts removed, open WOs kept
- [ ] Refresh dashboard — R1022870 should be gone, closed WOs should no longer show stuck flags
- [ ] Run a sync — verify open jobs still process normally

https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_