### PR TITLE
fix(sync): verify ResQ vendor invoice exists before marking submitted

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -1362,6 +1362,34 @@ async function buildAndSubmitInvoice(session, sfJobId, resqWO) {
     return result;
   }
 
+  // Step 4b: VERIFY a vendor invoice actually exists on the WO before claiming
+  // success. createOriginalVendorInvoice returns cleanly (no GraphQL error) even
+  // when the WO is still WAITING_FOR_COORDINATOR_APPROVAL — the record of work
+  // hasn't been approved yet, so ResQ accepts the mutation as a no-op and NO
+  // invoice is created. Marking invoice_submitted=true on that false success
+  // permanently blocked the real submission once the coordinator approved and the
+  // WO moved to "awaiting invoice" (R1023748, R1020568, R0875542 — all Starbird
+  // coordinator-gated). Re-query and only proceed if a vendorInvoice is present;
+  // otherwise leave the WO retryable so the next sync invoices it post-approval.
+  try {
+    const verifyData = await resqGql(session, `{
+      workOrders(first: 1, code: "${resqWO.code}") {
+        edges { node { status invoiceSets { id vendorInvoices { id } } } }
+      }
+    }`);
+    const vNode = verifyData.data?.workOrders?.edges?.[0]?.node;
+    const vendorInvoices = (vNode?.invoiceSets || []).flatMap(s => s.vendorInvoices || []);
+    if (vendorInvoices.length === 0) {
+      result.errors.push(`Invoice not present on ${resqWO.code} after create (WO status: ${vNode?.status || 'unknown'}) — likely awaiting coordinator approval; left retryable`);
+      return result; // do NOT mark invoice_submitted — retry next run
+    }
+    result.steps.push(`→ ${resqWO.code} vendor invoice verified (${vendorInvoices.length})`);
+  } catch (e) {
+    // Verification call failed — be conservative and don't claim success.
+    result.errors.push(`Verify invoice ${resqWO.code}: ${e.message.substring(0, 150)} — left retryable`);
+    return result;
+  }
+
   // Step 5: Set payout offer (Standard)
   if (vendorId) {
     try {


### PR DESCRIPTION
## Summary

Fixes the root cause of "WO synced but no invoice went into ResQ" for coordinator-gated facilities (Starbird, and The Melt).

`createOriginalVendorInvoice` returns **cleanly (no GraphQL error)** when the WO is still `WAITING_FOR_COORDINATOR_APPROVAL` — ResQ accepts the mutation as a **no-op and creates no invoice**. The code marked `invoice_submitted=true` on that false success, which then **permanently blocked** the real submission once the coordinator approved and the WO advanced to "awaiting invoice."

This is the same class of false-success bug as PR #180, but at the `createOriginalVendorInvoice` step rather than the failure path.

## Fix

After the create call, re-query the WO and only report success (set payout + `updated`, which sets `invoice_submitted=true`) when a `vendorInvoice` actually exists on the WO. Otherwise surface the real state and leave the WO **retryable**, so the next sync invoices it once the coordinator has approved.

## Affected WOs (live data)

All 4 currently stuck with the false flag:

| WO | Facility | ResQ state |
|---|---|---|
| R0875542 | Starbird – Marina Del Rey | awaiting coordinator approval |
| R1020568 | Starbird – Torrance | awaiting coordinator approval |
| R1023748 | Starbird – Campbell | awaiting invoice |
| R1014524 | The Melt – Sac State | awaiting coordinator approval |

## After merge

1. Deploy
2. Run "🧹 Cleanup Closed WOs" to clear the 4 false `invoice_submitted` flags
3. Subsequent syncs will: no-op + retry for WOs still awaiting coordinator approval; actually create + verify the invoice for WOs the coordinator has approved (awaiting invoice)

## Note (separate, not in this PR)

The ResQ photo push (`addAfterImagesToVisit`) is failing every run — ResQ now rejects `{url: "..."}` objects and wants plain string URLs (`String cannot represent a non string value: {'url': ...}`). Non-fatal and independent of the invoice path. Can fix in a follow-up.

https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_