### PR TITLE
Sync: stop auto-landing SF expenses as 'posted' (drafts only; none ever hit QBO)

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -499,8 +499,12 @@ async function syncBidirectional(session, resqWO, mapEntry) {
     // mass-backfill historical jobs. SF_EXPENSE_BACKFILL is an explicit one-off
     // allowlist for specific jobs that were invoiced before this landed (e.g.
     // 1086695007, whose expense was lost). Idempotent via expenseLandedId.
-    const needsExpenseLanding = sfIsInvoiced && !mapEntry.expenseLandedId
-      && (needsInvoiceSubmit || SF_EXPENSE_BACKFILL.has(String(mapEntry.sfJobId)));
+    // DISABLED 2026-06: this path auto-landed SF expenses as status='posted'
+    // (no review, no vendor), which is not what we want. SF expenses now flow
+    // through sf-expense-sweep, which lands them as reviewable DRAFTS and lets
+    // Brixpense post the QBO bill on submit. Kept as a no-op so the rest of the
+    // lifecycle logic is untouched.
+    const needsExpenseLanding = false;
     // "Provide Update" — complete the visit in ResQ when SF is completed
     // Also trigger if WO is COMPLETED (visit done but needs to transition to NEEDS_INVOICE)
     const needsVisitComplete = sfIsCompleted && !mapEntry.visitCompleted

--- a/netlify/functions/sf-expense-sweep.mjs
+++ b/netlify/functions/sf-expense-sweep.mjs
@@ -20,7 +20,9 @@ const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const MAX_PAGES = 6;            // up to 600 most-recent jobs examined per run
 const MAX_DETAIL_FETCHES = 120; // cap per-job expense fetches when the list omits them
 const MAX_LANDINGS = 150;       // cap rows landed per run (idempotent — next run continues)
-const MAX_AGE_DAYS = 180;       // ignore jobs older than this
+// Only land expenses dated on/after this — start fresh, no historical backlog.
+// Override with the SF_SWEEP_START_DATE env var (YYYY-MM-DD).
+const SWEEP_START_DATE = process.env.SF_SWEEP_START_DATE || '2026-06-03';
 
 const ACCOUNT_MAP = {
   equipment: { id: '42', name: 'Equipment Sales COGS' },
@@ -107,7 +109,8 @@ async function sweep() {
   if (!submitter) return { ok: false, error: 'could not resolve a submitter user id' };
   const landedIds = await loadLandedExpenseIds();
 
-  const cutoff = Date.now() - MAX_AGE_DAYS * 86400000;
+  const startMs = Date.parse(`${SWEEP_START_DATE}T00:00:00Z`) || 0;
+  const scanFloor = startMs - 7 * 86400000; // buffer: a recently-touched older job may carry a fresh expense
   let scanned = 0, examined = 0, detailFetches = 0, landed = 0;
 
   for (let page = 1; page <= MAX_PAGES && landed < MAX_LANDINGS; page++) {
@@ -119,11 +122,11 @@ async function sweep() {
     if (!jobs.length) break;
     scanned += jobs.length;
 
-    const allTooOld = jobs.every((j) => j.created_at && new Date(j.created_at).getTime() < cutoff);
+    const allTooOld = jobs.every((j) => j.created_at && new Date(j.created_at).getTime() < scanFloor);
 
     for (const job of jobs) {
       if (landed >= MAX_LANDINGS) break;
-      if (job.created_at && new Date(job.created_at).getTime() < cutoff) continue;
+      if (job.created_at && new Date(job.created_at).getTime() < scanFloor) continue;
       if (!isDoneStatus(job.status)) continue;
       examined++;
 
@@ -144,6 +147,9 @@ async function sweep() {
         if (!exId || landedIds.has(exId)) continue;
         const amount = Number(ex.amount) || 0;
         if (amount <= 0) continue;
+        // Start date floor — only pull expenses dated on/after SWEEP_START_DATE.
+        const exDate = ex.expense_date || ex.created_at || null;
+        if (exDate && Date.parse(exDate) < startMs) continue;
 
         const acct = ACCOUNT_MAP[String(ex.category || '').toLowerCase()] || DEFAULT_ACCOUNT;
         const receiptUrl = ex.receipt_url || ex.receipt || null;


### PR DESCRIPTION
**Root cause of the "all these June bills with no vendor" + "posted straight to QuickBooks."**

It was an older auto-land path in the ResQ background sync (`landSfJobExpense` via `needsExpenseLanding`) that I hadn't caught. On invoice it inserted SF expenses into Brixpense as **`status='posted'` with no vendor** — but it **never called QBO** (no `qbo_bill_id`, no `/bill`). So **nothing actually posted to QuickBooks**; the rows were just mislabeled "Posted," which bypassed the review flow and looked like QBO bills.

**This PR:**
- Disables that path (`needsExpenseLanding` is now always `false`). SF expenses now flow **only** through `sf-expense-sweep`, which lands reviewable **drafts** (no QBO) — Brixpense posts the bill on submit.

**Already done out-of-band (DB):**
- Verified the 28 such rows had **zero** `qbo_bill_id` (none in QBO), then deleted them + their attachments. `Service Fusion (system)` rows remaining: 0.

Net: nothing was ever in QuickBooks; the clutter is gone; and going forward SF expenses are drafts you review before anything posts.

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU)_