### PR TITLE
Sync: SF work-order receipts land in Brixpense as scanned review-drafts

### DIFF
--- a/netlify/functions/lib/sf-expense.mjs
+++ b/netlify/functions/lib/sf-expense.mjs
@@ -1,27 +1,94 @@
-// Land a Service Fusion job's expenses into Brixpense when the WO is invoiced.
-// ONE combined ops.expense_requests row per job: line_items = the SF expense
-// lines, total = sum, tag 'Service Fusion'. Each SF expense receipt is fetched
-// host-aware and uploaded to the private `expense-attachments` bucket with an
-// expense_request_attachments row, so the receipt shows up in Brixpense.
+// Land a Service Fusion job's expense RECEIPTS into Brixpense as reviewable
+// DRAFTS — one per SF expense that has a receipt attachment.
 //
-// Server-side via the service-role key. Best-effort: the row lands even if a
-// receipt fetch/upload fails. Caller is responsible for idempotency (don't call
-// twice for the same job).
+//   1. fetch the SF job's expenses (host-aware receipt bytes via sf-assets)
+//   2. run the Claude receipt scanner on each receipt → vendor / amount / date
+//   3. land a DRAFT ops.expense_requests row (status='draft', as_bill,
+//      tag='Service Fusion') pre-filled from the scan, with the receipt
+//      attached, so the operator can review and SUBMIT (which posts the QBO
+//      bill). NOTHING posts to QBO here.
+//
+// Deduped by ops.expense_requests.sf_expense_id, gated to a start date, and
+// idempotent — safe to call repeatedly (sync-time + cron sweep both use it).
 import { sfRequest } from '../sf-helpers.mjs';
 import { SUPABASE_URL } from '../supabase-helpers.mjs';
 
 const ATTACH_BUCKET = 'expense-attachments';
+// Only land expenses dated on/after this (fresh start; override per env).
+const START_DATE = process.env.SF_SWEEP_START_DATE || '2026-06-03';
+
+const ACCOUNT_MAP = {
+  equipment: { id: '42', name: 'Equipment Sales COGS' },
+  service:   { id: '101', name: 'Service COGS' },
+};
 
 function srHeaders(extra = {}) {
   const k = process.env.SUPABASE_SERVICE_ROLE_KEY;
   return { apikey: k, Authorization: `Bearer ${k}`, ...extra };
 }
 
+// Pull a receipt reference out of an SF expense (string / object / array shapes).
+function receiptRefs(ex) {
+  const refOf = (v) => {
+    if (!v) return null;
+    if (typeof v === 'string') return v;
+    if (typeof v === 'object') return v.file_location || v.url || v.receipt_url || v.path || v.location || null;
+    return null;
+  };
+  const out = [];
+  for (const k of ['receipt', 'receipt_url', 'file_location', 'picture', 'image', 'photo']) {
+    const r = refOf(ex[k]); if (r) out.push(r);
+  }
+  for (const k of ['receipts', 'pictures', 'images', 'attachments', 'documents', 'files']) {
+    if (Array.isArray(ex[k])) for (const item of ex[k]) { const r = refOf(item); if (r) out.push(r); }
+  }
+  return [...new Set(out)];
+}
+
+// Claude vision scan of a receipt → { vendorName, billDate, lineItems, total }.
+// Best-effort: returns null on any failure (the draft still lands from SF data).
+async function scanReceipt(bytes, contentType) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey || !bytes?.length) return null;
+  const isPdf = (contentType || '').includes('pdf');
+  const b64 = Buffer.from(bytes).toString('base64');
+  const block = isPdf
+    ? { type: 'document', source: { type: 'base64', media_type: 'application/pdf', data: b64 } }
+    : { type: 'image', source: { type: 'base64', media_type: contentType || 'image/jpeg', data: b64 } };
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' },
+      body: JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 2000,
+        system: 'Extract bill/receipt data. Return ONLY valid JSON, no markdown: {"vendorName":string,"billDate":"YYYY-MM-DD"|null,"total":number|null,"lineItems":[{"description":string,"quantity":number,"unitCost":number,"category":"equipment"|"service"}]}. Labor/service/install/repair=service; goods/parts/materials=equipment. qty defaults 1.',
+        messages: [{ role: 'user', content: [block, { type: 'text', text: 'Extract the receipt data as JSON.' }] }],
+      }),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const text = data.content.filter((b) => b.type === 'text').map((b) => b.text).join('');
+    return JSON.parse(text.replace(/```json\s*/g, '').replace(/```\s*/g, '').trim());
+  } catch { return null; }
+}
+
+async function alreadyLanded(sfExpenseId) {
+  try {
+    const r = await fetch(
+      `${SUPABASE_URL}/rest/v1/expense_requests?sf_expense_id=eq.${encodeURIComponent(sfExpenseId)}&select=id&limit=1`,
+      { headers: srHeaders({ 'Accept-Profile': 'ops', Accept: 'application/json' }) },
+    );
+    if (!r.ok) return false;
+    const rows = await r.json();
+    return Array.isArray(rows) && rows.length > 0;
+  } catch { return false; }
+}
+
 export async function landSfJobExpense({ sfJobId, resqCode, submitter }) {
   if (!process.env.SUPABASE_SERVICE_ROLE_KEY) return { ok: false, error: 'no service key' };
   if (!submitter?.id) return { ok: false, error: 'no submitter id' };
 
-  // 1. Pull the SF job's expenses (and customer name).
   let job;
   try {
     job = await sfRequest('GET', `/jobs/${sfJobId}?expand=expenses`);
@@ -31,116 +98,100 @@ export async function landSfJobExpense({ sfJobId, resqCode, submitter }) {
   const expenses = Array.isArray(job.expenses) ? job.expenses : [];
   if (!expenses.length) return { ok: false, empty: true, error: 'no SF expenses on job' };
 
-  // 2. One row per job — just the lines + total.
-  const lineItems = expenses.map((ex) => {
-    const amount = Number(ex.amount ?? ex.total ?? 0) || 0;
-    const description =
-      [ex.category, ex.notes].filter(Boolean).join(' — ') || 'Service Fusion expense';
-    return { description, qty: 1, unit_price: amount, amount };
-  });
-  const total = Math.round(lineItems.reduce((s, l) => s + (l.amount || 0), 0) * 100) / 100;
-
-  const row = {
-    request_type: 'expense',
-    status: 'posted',
-    as_bill: true,
-    auto_approved: true,
-    tag: 'Service Fusion',
-    submitted_by: submitter.id,
-    submitter_name: submitter.user_metadata?.name || submitter.email || 'Service Fusion',
-    submitter_email: submitter.email || null,
-    vendor_name: null,
-    total_amount: total,
-    currency: 'USD',
-    line_items: lineItems,
-    customer_name: job.customer_name || null,
-    job_number: String(sfJobId),
-    memo: [resqCode ? `ResQ ${resqCode}` : null, `SF Job #${sfJobId}`, `${expenses.length} SF expense line(s)`]
-      .filter(Boolean).join(' | '),
-    description: `Service Fusion job #${sfJobId} expenses`,
-    posted_at: new Date().toISOString(),
-  };
-
-  // 3. Insert the expense_requests row.
-  const ins = await fetch(`${SUPABASE_URL}/rest/v1/expense_requests`, {
-    method: 'POST',
-    headers: srHeaders({
-      'Content-Type': 'application/json',
-      'Accept-Profile': 'ops',
-      'Content-Profile': 'ops',
-      Prefer: 'return=representation',
-    }),
-    body: JSON.stringify([row]),
-  });
-  if (!ins.ok) return { ok: false, error: `insert expense: ${ins.status} ${(await ins.text()).slice(0, 200)}` };
-  const out = await ins.json();
-  const requestId = Array.isArray(out) ? out[0]?.id : out?.id;
-  if (!requestId) return { ok: false, error: 'insert returned no id' };
-
-  // 4. Attach receipts (best-effort — the row already landed). The SF expense
-  //    receipt is referenced like a WO picture: a file_location fetched
-  //    host-aware (S3 anon / api Bearer / admin cookie). The field is often an
-  //    object, so pull the ref robustly from strings, objects, and arrays.
+  const startMs = Date.parse(`${START_DATE}T00:00:00Z`) || 0;
   const { fetchSfAssetToBytes } = await import('./sf-assets.mjs');
-  const refOf = (v) => {
-    if (!v) return null;
-    if (typeof v === 'string') return v;
-    if (typeof v === 'object') return v.file_location || v.url || v.receipt_url || v.path || v.location || null;
-    return null;
-  };
-  const receiptRefs = (ex) => {
-    const out = [];
-    for (const k of ['receipt', 'receipt_url', 'file_location', 'picture', 'image', 'photo']) {
-      const r = refOf(ex[k]); if (r) out.push(r);
-    }
-    for (const k of ['receipts', 'pictures', 'images', 'attachments', 'documents', 'files']) {
-      if (Array.isArray(ex[k])) for (const item of ex[k]) { const r = refOf(item); if (r) out.push(r); }
-    }
-    return [...new Set(out)];
-  };
-  const attached = [];
-  const attachErrors = [];
-  let diag = null; // keys of an expense with no resolvable receipt — to find the field
-  for (let i = 0; i < expenses.length; i++) {
-    const ex = expenses[i];
+  let landed = 0, attached = 0;
+  const errors = [];
+
+  for (const ex of expenses) {
+    const exId = String(ex.id ?? '');
+    if (!exId) continue;
+    const exDate = ex.expense_date || ex.created_at || null;
+    if (exDate && Date.parse(exDate) < startMs) continue;      // before the start date
     const refs = receiptRefs(ex);
-    if (!refs.length) { if (!diag) diag = Object.keys(ex).join(','); continue; }
-    for (let j = 0; j < refs.length; j++) {
+    if (!refs.length) continue;                                 // no attachment → nothing to read
+    if (await alreadyLanded(exId)) continue;                    // dedup
+
+    // Fetch the receipt bytes (host-aware) + scan it.
+    let bytes = null, ct = 'application/octet-stream';
+    try {
+      const r = await fetchSfAssetToBytes(refs[0]);
+      if (r.ok) { bytes = r.bytes; ct = r.contentType || ct; }
+      else errors.push(`exp ${exId} fetch: ${r.error}`);
+    } catch (e) { errors.push(`exp ${exId} fetch: ${String(e.message).slice(0, 120)}`); }
+
+    const ocr = bytes ? await scanReceipt(bytes, ct) : null;
+    const sfAmount = Number(ex.amount ?? ex.total ?? 0) || 0;
+    const ocrLines = Array.isArray(ocr?.lineItems) ? ocr.lineItems : [];
+    const lineItems = ocrLines.length
+      ? ocrLines.map((li) => {
+          const amount = Math.round(((li.quantity || 1) * (li.unitCost || 0)) * 100) / 100;
+          return { description: li.description || 'Item', qty: li.quantity || 1, unit_price: li.unitCost || 0, amount };
+        })
+      : [{ description: ex.notes || ex.category || 'Service Fusion expense', qty: 1, unit_price: sfAmount, amount: sfAmount }];
+    const total = (ocr?.total ?? lineItems.reduce((s, l) => s + (l.amount || 0), 0)) || sfAmount;
+    const acct = ACCOUNT_MAP[String(ex.category || '').toLowerCase()] || null;
+
+    const row = {
+      request_type: 'expense',
+      status: 'draft',
+      as_bill: true,
+      tag: 'Service Fusion',
+      sf_expense_id: exId,
+      submitted_by: submitter.id,
+      submitter_name: submitter.user_metadata?.name || submitter.email || 'Service Fusion',
+      submitter_email: submitter.email || null,
+      vendor_name: ocr?.vendorName || null,
+      total_amount: total || null,
+      currency: 'USD',
+      receipt_date: ocr?.billDate || ex.expense_date || null,
+      line_items: lineItems,
+      customer_name: job.customer_name || null,
+      cogs_account_id: acct?.id || null,
+      cogs_account_label: acct?.name || null,
+      job_number: String(job.number || sfJobId),
+      memo: [resqCode ? `ResQ ${resqCode}` : null, `SF Job #${job.number || sfJobId}`, ex.notes]
+        .filter(Boolean).join(' | ') || null,
+      description: `Service Fusion job #${job.number || sfJobId} expense — review & submit`,
+      qbo_bill_id: null,
+    };
+
+    // Insert the draft.
+    let requestId;
+    try {
+      const ins = await fetch(`${SUPABASE_URL}/rest/v1/expense_requests`, {
+        method: 'POST',
+        headers: srHeaders({ 'Content-Type': 'application/json', 'Accept-Profile': 'ops', 'Content-Profile': 'ops', Prefer: 'return=representation' }),
+        body: JSON.stringify([row]),
+      });
+      if (!ins.ok) { errors.push(`exp ${exId} insert: ${ins.status}`); continue; }
+      const out = await ins.json();
+      requestId = Array.isArray(out) ? out[0]?.id : out?.id;
+    } catch (e) { errors.push(`exp ${exId} insert: ${String(e.message).slice(0, 120)}`); continue; }
+    if (!requestId) continue;
+    landed++;
+
+    // Attach the receipt image.
+    if (bytes) {
       try {
-        const r = await fetchSfAssetToBytes(refs[j]);
-        if (!r.ok) { attachErrors.push(`exp ${ex.id || i}: ${r.error}`); continue; }
-        const ct = r.contentType || 'application/octet-stream';
         const ext = (ct.split('/')[1] || 'pdf').replace(/[^a-z0-9]/gi, '') || 'pdf';
-        const fileName = `sf-expense-${ex.id || i}-${j}.${ext}`;
+        const fileName = `sf-receipt-${exId}.${ext}`;
         const storagePath = `${submitter.id}/${requestId}/${fileName}`;
         const up = await fetch(`${SUPABASE_URL}/storage/v1/object/${ATTACH_BUCKET}/${encodeURI(storagePath)}`, {
-          method: 'POST',
-          headers: srHeaders({ 'Content-Type': ct, 'x-upsert': 'true' }),
-          body: Buffer.from(r.bytes),
+          method: 'POST', headers: srHeaders({ 'Content-Type': ct, 'x-upsert': 'true' }), body: Buffer.from(bytes),
         });
-        if (!up.ok) { attachErrors.push(`exp ${ex.id || i} upload: ${up.status}`); continue; }
-        await fetch(`${SUPABASE_URL}/rest/v1/expense_request_attachments`, {
-          method: 'POST',
-          headers: srHeaders({
-            'Content-Type': 'application/json',
-            'Accept-Profile': 'ops',
-            'Content-Profile': 'ops',
-            Prefer: 'return=minimal',
-          }),
-          body: JSON.stringify([{
-            request_id: requestId,
-            file_name: fileName,
-            file_type: ct,
-            file_size: r.bytes.byteLength ?? null,
-            storage_path: storagePath,
-          }]),
-        });
-        attached.push(fileName);
-      } catch (e) {
-        attachErrors.push(`exp ${ex.id || i}: ${String(e.message).slice(0, 150)}`);
-      }
+        if (up.ok) {
+          await fetch(`${SUPABASE_URL}/rest/v1/expense_request_attachments`, {
+            method: 'POST',
+            headers: srHeaders({ 'Content-Type': 'application/json', 'Accept-Profile': 'ops', 'Content-Profile': 'ops', Prefer: 'return=minimal' }),
+            body: JSON.stringify([{ request_id: requestId, file_name: fileName, file_type: ct, file_size: bytes.byteLength ?? null, storage_path: storagePath }]),
+          });
+          attached++;
+        }
+      } catch (e) { errors.push(`exp ${exId} attach: ${String(e.message).slice(0, 120)}`); }
     }
   }
 
-  return { ok: true, id: requestId, lines: lineItems.length, total, attached: attached.length, attachErrors, diag };
+  if (landed === 0) return { ok: false, empty: true, error: errors.join(' | ').slice(0, 200) || 'no new receipts to land' };
+  return { ok: true, landed, attached, errors };
 }

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -499,8 +499,12 @@ async function syncBidirectional(session, resqWO, mapEntry) {
     // mass-backfill historical jobs. SF_EXPENSE_BACKFILL is an explicit one-off
     // allowlist for specific jobs that were invoiced before this landed (e.g.
     // 1086695007, whose expense was lost). Idempotent via expenseLandedId.
-    const needsExpenseLanding = sfIsInvoiced && !mapEntry.expenseLandedId
-      && (needsInvoiceSubmit || SF_EXPENSE_BACKFILL.has(String(mapEntry.sfJobId)));
+    // DISABLED 2026-06: this path auto-landed SF expenses as status='posted'
+    // (no review, no vendor), which is not what we want. SF expenses now flow
+    // through sf-expense-sweep, which lands them as reviewable DRAFTS and lets
+    // Brixpense post the QBO bill on submit. Kept as a no-op so the rest of the
+    // lifecycle logic is untouched.
+    const needsExpenseLanding = false;
     // "Provide Update" — complete the visit in ResQ when SF is completed
     // Also trigger if WO is COMPLETED (visit done but needs to transition to NEEDS_INVOICE)
     const needsVisitComplete = sfIsCompleted && !mapEntry.visitCompleted

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -499,12 +499,12 @@ async function syncBidirectional(session, resqWO, mapEntry) {
     // mass-backfill historical jobs. SF_EXPENSE_BACKFILL is an explicit one-off
     // allowlist for specific jobs that were invoiced before this landed (e.g.
     // 1086695007, whose expense was lost). Idempotent via expenseLandedId.
-    // DISABLED 2026-06: this path auto-landed SF expenses as status='posted'
-    // (no review, no vendor), which is not what we want. SF expenses now flow
-    // through sf-expense-sweep, which lands them as reviewable DRAFTS and lets
-    // Brixpense post the QBO bill on submit. Kept as a no-op so the rest of the
-    // lifecycle logic is untouched.
-    const needsExpenseLanding = false;
+    // When a WO is done (completed or invoiced), land its SF expense RECEIPTS
+    // into Brixpense as reviewable DRAFTS — scanned (vendor/amount from the
+    // receipt image), receipt attached, NOTHING posted to QBO. landSfJobExpense
+    // dedups by sf_expense_id + gates to the start date, so this is idempotent
+    // and won't mass-backfill ancient jobs. expenseLandedId guards re-runs.
+    const needsExpenseLanding = (sfIsInvoiced || sfIsCompleted) && !mapEntry.expenseLandedId;
     // "Provide Update" — complete the visit in ResQ when SF is completed
     // Also trigger if WO is COMPLETED (visit done but needs to transition to NEEDS_INVOICE)
     const needsVisitComplete = sfIsCompleted && !mapEntry.visitCompleted
@@ -612,14 +612,12 @@ async function syncBidirectional(session, resqWO, mapEntry) {
         const { landSfJobExpense } = await import('./lib/sf-expense.mjs');
         const r = await landSfJobExpense({ sfJobId: mapEntry.sfJobId, resqCode: resqWO.code, submitter: SF_EXPENSE_SUBMITTER });
         if (r.ok) {
-          mapEntry.expenseLandedId = r.id;
+          mapEntry.expenseLandedId = true;
           result.updated++;
-          result.steps.push(`💵 SF expense → Brixpense ${resqWO.code} (${r.lines} line(s), $${r.total}, ${r.attached} receipt(s))`);
-          if (r.attached === 0 && (r.attachErrors?.length || r.diag)) {
-            result.steps.push(`📎 ${resqWO.code} no receipt: ${(r.attachErrors || []).join(' | ').slice(0, 200) || 'expense keys=' + r.diag}`);
-          }
+          result.steps.push(`💵 SF receipts → Brixpense ${resqWO.code} (${r.landed} draft(s), ${r.attached} receipt(s))`);
         } else if (r.empty) {
-          mapEntry.expenseLandedId = 'none'; // no SF expenses on the job — don't retry every run
+          mapEntry.expenseLandedId = 'none'; // no receipts to land — don't retry every run
+          if (r.error) result.steps.push(`📎 ${resqWO.code}: ${String(r.error).slice(0, 160)}`);
         } else {
           result.errors.push(`SF expense land ${resqWO.code}: ${r.error}`);
         }

--- a/netlify/functions/sf-expense-sweep.mjs
+++ b/netlify/functions/sf-expense-sweep.mjs
@@ -1,34 +1,21 @@
-// Scheduled sweep: pull expenses from ALL Service Fusion completed/invoiced
-// jobs into Brixpense as review-drafts — not just the ResQ-linked ones.
-//
-// Each SF expense lands as a draft ops.expense_requests row (status='draft',
-// as_bill, tag='Service Fusion') with its receipt image attached. NOTHING posts
-// to QBO here — Brixpense posts the bill when the operator reviews + submits
-// (same flow as the ResQ path).
-//
-// Deduped by ops.expense_requests.sf_expense_id, so re-runs never double-land.
-// Everything is idempotent + capped, so a truncated run simply continues next
-// time. Runs every 6 hours.
+// Scheduled sweep: land expense RECEIPTS from ALL Service Fusion
+// completed/invoiced jobs into Brixpense as reviewable drafts — not just the
+// ResQ-linked ones. Delegates the per-job work to landSfJobExpense (the same
+// helper the ResQ sync uses), which scans each receipt, lands a DRAFT
+// pre-filled from the scan, attaches the image, dedups by sf_expense_id, and
+// gates to the start date. NOTHING posts to QBO — Brixpense posts on submit.
+// Idempotent + capped; a truncated run simply continues next time. Every 6h.
 
-import { sfRequest, getSFAccessToken } from './sf-helpers.mjs';
-import { postExpenseRow } from './expense-to-bill.mjs';
+import { sfRequest } from './sf-helpers.mjs';
+import { landSfJobExpense } from './lib/sf-expense.mjs';
 import { requireScheduled } from './lib/auth.mjs';
 import { SUPABASE_URL } from './supabase-helpers.mjs';
 
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 const MAX_PAGES = 6;            // up to 600 most-recent jobs examined per run
-const MAX_DETAIL_FETCHES = 120; // cap per-job expense fetches when the list omits them
-const MAX_LANDINGS = 150;       // cap rows landed per run (idempotent — next run continues)
-// Only land expenses dated on/after this — start fresh, no historical backlog.
-// Override with the SF_SWEEP_START_DATE env var (YYYY-MM-DD).
+const MAX_JOBS = 150;           // cap jobs processed per run (idempotent — next run continues)
 const SWEEP_START_DATE = process.env.SF_SWEEP_START_DATE || '2026-06-03';
-
-const ACCOUNT_MAP = {
-  equipment: { id: '42', name: 'Equipment Sales COGS' },
-  service:   { id: '101', name: 'Service COGS' },
-};
-const DEFAULT_ACCOUNT = ACCOUNT_MAP.service;
 
 const sbHeaders = () => ({
   apikey: SERVICE_KEY,
@@ -43,80 +30,39 @@ const isDoneStatus = (s) => {
   return t.includes('complet') || t.includes('invoic');
 };
 
-// A valid submitted_by (NOT NULL fk) for system-landed rows:
-// env → most-recent Service Fusion row's submitter → auth-admin lookup by email.
+// A valid submitted_by (NOT NULL fk): env → latest Service Fusion row → auth-admin by email.
 async function resolveSubmitter() {
-  if (process.env.SF_SWEEP_SUBMITTER_ID) return process.env.SF_SWEEP_SUBMITTER_ID;
+  if (process.env.SF_SWEEP_SUBMITTER_ID) return { id: process.env.SF_SWEEP_SUBMITTER_ID, user_metadata: { name: 'Service Fusion' } };
   try {
     const r = await fetch(
-      `${SUPABASE_URL}/rest/v1/expense_requests?tag=eq.Service%20Fusion&select=submitted_by&order=created_at.desc&limit=1`,
+      `${SUPABASE_URL}/rest/v1/expense_requests?tag=eq.Service%20Fusion&select=submitted_by,submitter_email&order=created_at.desc&limit=1`,
       { headers: { ...sbHeaders(), Accept: 'application/json' } },
     );
-    if (r.ok) { const rows = await r.json(); if (rows[0]?.submitted_by) return rows[0].submitted_by; }
+    if (r.ok) { const rows = await r.json(); if (rows[0]?.submitted_by) return { id: rows[0].submitted_by, email: rows[0].submitter_email, user_metadata: { name: 'Service Fusion' } }; }
   } catch { /* fall through */ }
   const email = (process.env.SF_SWEEP_SUBMITTER_EMAIL || 'skypace@brixbev.com').toLowerCase();
   try {
     const r = await fetch(`${SUPABASE_URL}/auth/v1/admin/users?per_page=200`, {
       headers: { apikey: SERVICE_KEY, Authorization: `Bearer ${SERVICE_KEY}` },
     });
-    if (r.ok) { const b = await r.json(); const u = (b.users || []).find((x) => (x.email || '').toLowerCase() === email); if (u?.id) return u.id; }
+    if (r.ok) { const b = await r.json(); const u = (b.users || []).find((x) => (x.email || '').toLowerCase() === email); if (u?.id) return { id: u.id, email: u.email, user_metadata: { name: 'Service Fusion' } }; }
   } catch { /* fall through */ }
   return null;
-}
-
-async function loadLandedExpenseIds() {
-  const ids = new Set();
-  try {
-    const r = await fetch(
-      `${SUPABASE_URL}/rest/v1/expense_requests?sf_expense_id=not.is.null&select=sf_expense_id`,
-      { headers: { ...sbHeaders(), Accept: 'application/json' } },
-    );
-    if (r.ok) { const rows = await r.json(); for (const x of rows) if (x.sf_expense_id) ids.add(String(x.sf_expense_id)); }
-  } catch { /* best effort */ }
-  return ids;
-}
-
-// Best-effort receipt fetch → upload to the expense-attachments bucket.
-// Tries anon first; for SF-hosted URLs that 401/403, retries with the SF bearer.
-async function fetchReceipt(url, sfJobId) {
-  if (!url || !SERVICE_KEY) return null;
-  try {
-    let res = await fetch(url);
-    if ((res.status === 401 || res.status === 403) && /servicefusion/i.test(url)) {
-      const tok = await getSFAccessToken().catch(() => null);
-      if (tok) res = await fetch(url, { headers: { Authorization: `Bearer ${tok}` } });
-    }
-    if (!res.ok) return null;
-    const ct = res.headers.get('content-type') || 'application/octet-stream';
-    const buf = Buffer.from(await res.arrayBuffer());
-    if (!buf.length) return null;
-    const ext = ct.includes('pdf') ? 'pdf' : ct.includes('png') ? 'png' : ct.includes('webp') ? 'webp' : 'jpg';
-    const fileName = `receipt-${Date.now()}.${ext}`;
-    const path = `service-fusion/${sfJobId || 'misc'}/${fileName}`;
-    const up = await fetch(`${SUPABASE_URL}/storage/v1/object/expense-attachments/${path}`, {
-      method: 'POST',
-      headers: { apikey: SERVICE_KEY, Authorization: `Bearer ${SERVICE_KEY}`, 'Content-Type': ct, 'x-upsert': 'true' },
-      body: buf,
-    });
-    if (!up.ok) return null;
-    return { storage_path: path, file_name: fileName, file_type: ct, file_size: buf.length };
-  } catch { return null; }
 }
 
 async function sweep() {
   if (!SERVICE_KEY) return { ok: false, error: 'SUPABASE_SERVICE_ROLE_KEY not set' };
   const submitter = await resolveSubmitter();
   if (!submitter) return { ok: false, error: 'could not resolve a submitter user id' };
-  const landedIds = await loadLandedExpenseIds();
 
   const startMs = Date.parse(`${SWEEP_START_DATE}T00:00:00Z`) || 0;
   const scanFloor = startMs - 7 * 86400000; // buffer: a recently-touched older job may carry a fresh expense
-  let scanned = 0, examined = 0, detailFetches = 0, landed = 0;
+  let scanned = 0, jobsProcessed = 0, drafts = 0, attached = 0;
 
-  for (let page = 1; page <= MAX_PAGES && landed < MAX_LANDINGS; page++) {
+  for (let page = 1; page <= MAX_PAGES && jobsProcessed < MAX_JOBS; page++) {
     let jobs;
     try {
-      const res = await sfRequest('GET', `/jobs?per-page=100&sort=-created_at&expand=expenses&page=${page}`);
+      const res = await sfRequest('GET', `/jobs?per-page=100&sort=-created_at&page=${page}`);
       jobs = res.items || res.data || [];
     } catch { break; }
     if (!jobs.length) break;
@@ -125,70 +71,19 @@ async function sweep() {
     const allTooOld = jobs.every((j) => j.created_at && new Date(j.created_at).getTime() < scanFloor);
 
     for (const job of jobs) {
-      if (landed >= MAX_LANDINGS) break;
+      if (jobsProcessed >= MAX_JOBS) break;
       if (job.created_at && new Date(job.created_at).getTime() < scanFloor) continue;
       if (!isDoneStatus(job.status)) continue;
-      examined++;
-
-      let expenses = Array.isArray(job.expenses) ? job.expenses : null;
-      if (expenses === null) {
-        if (detailFetches >= MAX_DETAIL_FETCHES) continue;
-        detailFetches++;
-        try {
-          const full = await sfRequest('GET', `/jobs/${job.id}?expand=expenses`);
-          expenses = Array.isArray(full.expenses) ? full.expenses : [];
-        } catch { expenses = []; }
-      }
-      if (!expenses.length) continue;
-
-      for (const ex of expenses) {
-        if (landed >= MAX_LANDINGS) break;
-        const exId = String(ex.id ?? '');
-        if (!exId || landedIds.has(exId)) continue;
-        const amount = Number(ex.amount) || 0;
-        if (amount <= 0) continue;
-        // Start date floor — only pull expenses dated on/after SWEEP_START_DATE.
-        const exDate = ex.expense_date || ex.created_at || null;
-        if (exDate && Date.parse(exDate) < startMs) continue;
-
-        const acct = ACCOUNT_MAP[String(ex.category || '').toLowerCase()] || DEFAULT_ACCOUNT;
-        const receiptUrl = ex.receipt_url || ex.receipt || null;
-        const attachment = receiptUrl ? await fetchReceipt(receiptUrl, job.id) : null;
-
-        const row = {
-          request_type: 'expense',
-          status: 'draft',
-          as_bill: true,
-          tag: 'Service Fusion',
-          sf_expense_id: exId,
-          submitted_by: submitter,
-          submitter_name: 'Service Fusion',
-          submitter_email: null,
-          vendor_name: ex.vendor_name || ex.vendor || null,
-          total_amount: amount,
-          currency: 'USD',
-          receipt_date: ex.expense_date || ex.created_at || null,
-          line_items: [{
-            description: ex.notes || ex.category || 'Service Fusion expense',
-            qty: 1, unit_price: amount, amount,
-          }],
-          customer_name: job.customer_name || null,
-          cogs_account_id: acct.id,
-          cogs_account_label: acct.name,
-          job_number: String(job.number || job.id),
-          memo: [`SF Job #${job.number || job.id}`, ex.notes].filter(Boolean).join(' | ') || null,
-          description: `Service Fusion job #${job.number || job.id} expense — review & submit`,
-          qbo_bill_id: null,
-          _attachment: attachment,
-        };
-        const r = await postExpenseRow(row);
-        if (r.ok) { landed++; landedIds.add(exId); }
-      }
+      jobsProcessed++;
+      try {
+        const r = await landSfJobExpense({ sfJobId: job.id, resqCode: null, submitter });
+        if (r.ok) { drafts += r.landed || 0; attached += r.attached || 0; }
+      } catch { /* non-fatal — next job */ }
     }
     if (allTooOld) break;
   }
 
-  return { ok: true, scanned, examined, detailFetches, landed };
+  return { ok: true, scanned, jobsProcessed, drafts, attached };
 }
 
 async function logRun(result) {
@@ -201,7 +96,7 @@ async function logRun(result) {
       body: JSON.stringify([{
         source: 'sf-expense-sweep', sync_type: 'expense-sweep',
         status: result.ok ? 'ok' : 'error', started_at: now, completed_at: now,
-        records_synced: result.landed || 0, metadata: result,
+        records_synced: result.drafts || 0, metadata: result,
       }]),
     });
   } catch { /* non-fatal */ }

--- a/netlify/functions/sf-expense-sweep.mjs
+++ b/netlify/functions/sf-expense-sweep.mjs
@@ -20,7 +20,9 @@ const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const MAX_PAGES = 6;            // up to 600 most-recent jobs examined per run
 const MAX_DETAIL_FETCHES = 120; // cap per-job expense fetches when the list omits them
 const MAX_LANDINGS = 150;       // cap rows landed per run (idempotent — next run continues)
-const MAX_AGE_DAYS = 180;       // ignore jobs older than this
+// Only land expenses dated on/after this — start fresh, no historical backlog.
+// Override with the SF_SWEEP_START_DATE env var (YYYY-MM-DD).
+const SWEEP_START_DATE = process.env.SF_SWEEP_START_DATE || '2026-06-03';
 
 const ACCOUNT_MAP = {
   equipment: { id: '42', name: 'Equipment Sales COGS' },
@@ -107,7 +109,8 @@ async function sweep() {
   if (!submitter) return { ok: false, error: 'could not resolve a submitter user id' };
   const landedIds = await loadLandedExpenseIds();
 
-  const cutoff = Date.now() - MAX_AGE_DAYS * 86400000;
+  const startMs = Date.parse(`${SWEEP_START_DATE}T00:00:00Z`) || 0;
+  const scanFloor = startMs - 7 * 86400000; // buffer: a recently-touched older job may carry a fresh expense
   let scanned = 0, examined = 0, detailFetches = 0, landed = 0;
 
   for (let page = 1; page <= MAX_PAGES && landed < MAX_LANDINGS; page++) {
@@ -119,11 +122,11 @@ async function sweep() {
     if (!jobs.length) break;
     scanned += jobs.length;
 
-    const allTooOld = jobs.every((j) => j.created_at && new Date(j.created_at).getTime() < cutoff);
+    const allTooOld = jobs.every((j) => j.created_at && new Date(j.created_at).getTime() < scanFloor);
 
     for (const job of jobs) {
       if (landed >= MAX_LANDINGS) break;
-      if (job.created_at && new Date(job.created_at).getTime() < cutoff) continue;
+      if (job.created_at && new Date(job.created_at).getTime() < scanFloor) continue;
       if (!isDoneStatus(job.status)) continue;
       examined++;
 
@@ -144,6 +147,9 @@ async function sweep() {
         if (!exId || landedIds.has(exId)) continue;
         const amount = Number(ex.amount) || 0;
         if (amount <= 0) continue;
+        // Start date floor — only pull expenses dated on/after SWEEP_START_DATE.
+        const exDate = ex.expense_date || ex.created_at || null;
+        if (exDate && Date.parse(exDate) < startMs) continue;
 
         const acct = ACCOUNT_MAP[String(ex.category || '').toLowerCase()] || DEFAULT_ACCOUNT;
         const receiptUrl = ex.receipt_url || ex.receipt || null;


### PR DESCRIPTION
Refits the SF→Brixpense flow to exactly what you described: **the receipt attachment from a work order lands in Brixpense, gets scanned, and you take it from there — nothing auto-posts to QuickBooks.**

**`lib/sf-expense.mjs` (rewritten):**
- Lands **one reviewable DRAFT per SF expense that has a receipt attachment**.
- Fetches the receipt host-aware, **runs the Claude scanner on it** (vendor / amount / date / lines — so **vendor is populated**, fixing the "no vendor" complaint), and attaches the image.
- `status='draft'` (not posted), `as_bill`, `tag='Service Fusion'`, no `qbo_bill_id`. Deduped by `sf_expense_id`; gated to `SF_SWEEP_START_DATE` (default 2026-06-03); skips expenses with no attachment. OCR is best-effort (the draft + image still land if the scan fails).

**`resq-sf-sync-background.mjs`:**
- **Re-enabled the on-sync landing** (now that it lands *scanned drafts*, not posted no-vendor rows). So syncing a WO — e.g. **M-57240-PMS** — lands its receipt into Brixpense for review.

**`sf-expense-sweep.mjs`:**
- Now delegates to the same `landSfJobExpense` helper, so the 6-hour cron and the on-sync path produce identical scanned drafts and share dedup.

Context: the 28 mislabeled "posted" rows from the old path were already verified to have **zero** QBO bills and deleted (PR #183). Nothing this flow does posts to QuickBooks.

Syntax-checked; manifest lint passes.

**Live test:** sync **M-57240-PMS** → its receipt should appear in Brixpense → SF Expenses as a draft with the image + scanned vendor/amount → review → submit posts the bill.

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU)_