### PR TITLE
Sync: drive SF expense sweep via pg_cron (covers regular SF jobs on invoice)

### DIFF
--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -273,18 +273,18 @@
       "last_verified": "2026-05-12"
     },
     {
-      "name": "sf-expense-sweep",
+      "name": "sf-expense-sweep-background",
       "kind": "netlify-function",
       "source_repo": "skypace/apbg-billing",
-      "schedule": "every 6 hours (cron 0 */6 * * *)",
+      "schedule": "every 30 min via Supabase pg_cron (net.http_post + cronKey)",
       "writes": [
         "ops.expense_requests",
         "ops.expense_request_attachments",
         "ops.sync_log"
       ],
       "multi_writer": true,
-      "notes": "Scheduled sweep of ALL Service Fusion completed/invoiced jobs (not just ResQ-linked) — lands each SF expense + receipt image as a Brixpense review-draft (status='draft', as_bill, tag='Service Fusion') via the service-role key. Deduped by ops.expense_requests.sf_expense_id (migration 20260603d). No QBO post here — Brixpense posts the bill on submit. Idempotent + capped; reuses postExpenseRow from expense-to-bill.",
-      "last_verified": "2026-06-03"
+      "notes": "Background sweep of ALL Service Fusion completed/invoiced jobs (incl. regular non-ResQ jobs) — delegates to lib/sf-expense.landSfJobExpense, which scans each receipt and lands a Brixpense review-DRAFT (status='draft', as_bill, tag='Service Fusion') with the image attached, via the service-role key. Deduped by ops.expense_requests.sf_expense_id (migration 20260603d); gated to SF_SWEEP_START_DATE. No QBO post — Brixpense posts on submit. Driven by pg_cron (cronKey==CRON_SECRET) because Netlify's scheduled-function trigger does not fire on this site.",
+      "last_verified": "2026-06-06"
     },
     {
       "name": "brix-stock:app-and-rpcs",

--- a/netlify.toml
+++ b/netlify.toml
@@ -39,9 +39,8 @@
   timeout = 900
   schedule = "*/5 * * * *"
 
-[functions."sf-expense-sweep"]
+[functions."sf-expense-sweep-background"]
   timeout = 900
-  schedule = "0 */6 * * *"
 
 [functions."health-watchdog"]
   timeout = 60

--- a/netlify/functions/sf-expense-sweep-background.mjs
+++ b/netlify/functions/sf-expense-sweep-background.mjs
@@ -1,14 +1,17 @@
-// Scheduled sweep: land expense RECEIPTS from ALL Service Fusion
-// completed/invoiced jobs into Brixpense as reviewable drafts — not just the
-// ResQ-linked ones. Delegates the per-job work to landSfJobExpense (the same
-// helper the ResQ sync uses), which scans each receipt, lands a DRAFT
-// pre-filled from the scan, attaches the image, dedups by sf_expense_id, and
-// gates to the start date. NOTHING posts to QBO — Brixpense posts on submit.
-// Idempotent + capped; a truncated run simply continues next time. Every 6h.
+// Background sweep: land expense RECEIPTS from ALL Service Fusion
+// completed/invoiced jobs into Brixpense as reviewable drafts — including
+// regular (non-ResQ) jobs. Driven by Supabase pg_cron (net.http_post with
+// ?cronKey=CRON_SECRET), the same scheduler the ResQ sync uses — Netlify's own
+// scheduled-function trigger does NOT fire on this site.
+//
+// Delegates per-job work to landSfJobExpense: scans each receipt, lands a DRAFT
+// pre-filled from the scan, attaches the image, dedups by sf_expense_id, gates
+// to the start date. NOTHING posts to QBO — Brixpense posts on submit.
+// Idempotent + capped; a truncated run continues next time.
 
 import { sfRequest } from './sf-helpers.mjs';
 import { landSfJobExpense } from './lib/sf-expense.mjs';
-import { requireScheduled } from './lib/auth.mjs';
+import { requireAuth } from './lib/auth.mjs';
 import { SUPABASE_URL } from './supabase-helpers.mjs';
 
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -56,7 +59,7 @@ async function sweep() {
   if (!submitter) return { ok: false, error: 'could not resolve a submitter user id' };
 
   const startMs = Date.parse(`${SWEEP_START_DATE}T00:00:00Z`) || 0;
-  const scanFloor = startMs - 7 * 86400000; // buffer: a recently-touched older job may carry a fresh expense
+  const scanFloor = startMs - 7 * 86400000; // buffer for a recently-touched older job
   let scanned = 0, jobsProcessed = 0, drafts = 0, attached = 0;
 
   for (let page = 1; page <= MAX_PAGES && jobsProcessed < MAX_JOBS; page++) {
@@ -102,17 +105,20 @@ async function logRun(result) {
   } catch { /* non-fatal */ }
 }
 
-export default async (req, context) => {
-  const gate = requireScheduled(req, context);
-  if (!gate.ok) return gate.response;
+export async function handler(event) {
+  // Auth: matching CRON_SECRET (pg_cron) OR a superadmin JWT.
+  const qs = event.queryStringParameters || {};
+  const hdrs = event.headers || {};
+  const providedKey = qs.cronKey || hdrs['x-cron-key'] || hdrs['X-Cron-Key'] || '';
+  const cronOk = !!(providedKey && process.env.CRON_SECRET && providedKey === process.env.CRON_SECRET);
+  if (!cronOk) {
+    const auth = await requireAuth(event);
+    if (!auth.ok) return auth.response;
+  }
+
   console.log('[CRON] SF expense sweep starting…');
   const result = await sweep();
   await logRun(result);
   console.log('[CRON] SF expense sweep:', JSON.stringify(result));
-  return new Response(JSON.stringify(result), {
-    status: result.ok ? 200 : 500,
-    headers: { 'Content-Type': 'application/json' },
-  });
-};
-
-export const config = { schedule: '0 */6 * * *' };
+  return { statusCode: result.ok ? 200 : 500, body: JSON.stringify(result) };
+}


### PR DESCRIPTION
Makes the "regular SF jobs → expenses pushed on invoice" actually run automatically.

**Root cause it wasn't:** this project schedules everything through **Supabase pg_cron** (`net.http_post` → function URL with `cronKey==CRON_SECRET`), **not** Netlify's scheduled-function trigger — which silently doesn't fire on this site (the ResQ sync moved to pg_cron for the same reason, per its own code comment). My sweep was a Netlify scheduled function, so it never ran.

**Fix:**
- Replaced `sf-expense-sweep` (Netlify-scheduled) with **`sf-expense-sweep-background`** — an HTTP background function (202 + 900s), authed by `cronKey==CRON_SECRET` exactly like `resq-sf-sync-background`.
- Added **pg_cron job `sf-expense-sweep-30min`** (`*/30`) that POSTs to it (already created live, job 37).
- It sweeps **all** completed/invoiced SF jobs — incl. regular non-ResQ ones — and lands each receipt as a scanned Brixpense **draft**. ResQ-mapped jobs continue to land on the 5-min ResQ sync.
- `netlify.toml` + `sync-manifest.json` updated; lint passes.

Note for the record: the recurring `401 Invalid JWT` pg_net failures are a *different* job (a Supabase-function call), **not** the ResQ sync — that one returns `202` every 5 min and is healthy. I'd misread it earlier.

Once deployed, the next `*/30` tick will land any invoiced SF job's receipts (incl. M-57240-PMS if it has an attachment dated ≥ 2026-06-03).

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU)_