### PR TITLE
fix(sync): treat ResQ "visit already ended" as completed; drop invalid RESOLVED outcome

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -1362,6 +1362,34 @@ async function buildAndSubmitInvoice(session, sfJobId, resqWO) {
     return result;
   }
 
+  // Step 4b: VERIFY a vendor invoice actually exists on the WO before claiming
+  // success. createOriginalVendorInvoice returns cleanly (no GraphQL error) even
+  // when the WO is still WAITING_FOR_COORDINATOR_APPROVAL — the record of work
+  // hasn't been approved yet, so ResQ accepts the mutation as a no-op and NO
+  // invoice is created. Marking invoice_submitted=true on that false success
+  // permanently blocked the real submission once the coordinator approved and the
+  // WO moved to "awaiting invoice" (R1023748, R1020568, R0875542 — all Starbird
+  // coordinator-gated). Re-query and only proceed if a vendorInvoice is present;
+  // otherwise leave the WO retryable so the next sync invoices it post-approval.
+  try {
+    const verifyData = await resqGql(session, `{
+      workOrders(first: 1, code: "${resqWO.code}") {
+        edges { node { status invoiceSets { id vendorInvoices { id } } } }
+      }
+    }`);
+    const vNode = verifyData.data?.workOrders?.edges?.[0]?.node;
+    const vendorInvoices = (vNode?.invoiceSets || []).flatMap(s => s.vendorInvoices || []);
+    if (vendorInvoices.length === 0) {
+      result.errors.push(`Invoice not present on ${resqWO.code} after create (WO status: ${vNode?.status || 'unknown'}) — likely awaiting coordinator approval; left retryable`);
+      return result; // do NOT mark invoice_submitted — retry next run
+    }
+    result.steps.push(`→ ${resqWO.code} vendor invoice verified (${vendorInvoices.length})`);
+  } catch (e) {
+    // Verification call failed — be conservative and don't claim success.
+    result.errors.push(`Verify invoice ${resqWO.code}: ${e.message.substring(0, 150)} — left retryable`);
+    return result;
+  }
+
   // Step 5: Set payout offer (Standard)
   if (vendorId) {
     try {

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -136,6 +136,16 @@ export async function handler(event) {
           if (mapping[wo.id].sfDeleted) {
             continue;
           }
+          // Done in ResQ (awaiting payment / closed / cancelled) — the vendor
+          // invoice has already been accepted; there is nothing left for the
+          // sync to do. Skip so we stop re-hammering 45+ finished WOs every run
+          // (they were piling up photo/invoice-retry errors — 315 in 24h on the
+          // worst offenders). New (unmapped) done WOs are already skipped below;
+          // this applies the same rule to mapped ones.
+          const mappedDone = (wo.status || '').toUpperCase();
+          if (RESQ_DONE_STATUSES.includes(mappedDone)) {
+            continue;
+          }
           // Already mapped — bidirectional status sync
           // 30s timeout — photo/invoice transfers can take longer
           const r = await withTimeout(syncBidirectional(session, wo, mapping[wo.id]), 30000, `sync ${wo.code}`);
@@ -911,19 +921,29 @@ async function transferSfPhotosToResq(session, sfJobId, resqWO, alreadySent = []
   const addImagesMutation = `mutation($input: AddAfterImagesToVisitInput!) {
     addAfterImagesToVisit(input: $input) { __typename }
   }`;
-  // ResQ's Image input is { url: String } (confirmed via schema introspection) —
-  // wrap each relayed URL; bare strings gave "Expected type 'Image' to be a mapping".
-  const addImagesVars = { input: { visit: visitId, images: imageUrls.map((u) => ({ url: u })) } };
+  // ResQ's `images` arg shape has been inconsistent: bare strings once gave
+  // "Expected type 'Image' to be a mapping", but the { url } object shape now
+  // fails with "String cannot represent a non string value: {'url': ...}" — i.e.
+  // the field currently expects [String]. Try plain string URLs first, then fall
+  // back to { url } objects, across both the vendor and facility logins, so a
+  // schema flip on either side can't silently kill every photo push again.
+  const shapes = [
+    (u) => u,            // [String] — current schema
+    (u) => ({ url: u }), // [{ url }] — legacy shape, kept as fallback
+  ];
   const pushErrors = [];
   for (const label of ['vendor', 'facility']) {
-    try {
-      const sess = label === 'vendor' ? session : await resqLogin({ facility: true });
-      await resqGql(sess, addImagesMutation, addImagesVars);
-      result.count = imageUrls.length;
-      result.sentKeys = relayedKeys;
-      return result;
-    } catch (e) {
-      pushErrors.push(`${label}: ${e.message.substring(0, 300)}`);
+    const sess = label === 'vendor' ? session : await resqLogin({ facility: true });
+    for (const shape of shapes) {
+      const addImagesVars = { input: { visit: visitId, images: imageUrls.map(shape) } };
+      try {
+        await resqGql(sess, addImagesMutation, addImagesVars);
+        result.count = imageUrls.length;
+        result.sentKeys = relayedKeys;
+        return result;
+      } catch (e) {
+        pushErrors.push(`${label}: ${e.message.substring(0, 200)}`);
+      }
     }
   }
   result.errors.push(`addAfterImages ${resqWO.code}: ${pushErrors.join(' | ')}`);

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -1039,19 +1039,20 @@ async function provideUpdateToResq(session, resqWO, sfJobId, images = []) {
     }
   }
 
-  // 4. End the visit. Normal path uses outcome COMPLETED (the value ResQ has
-  //    accepted for every WO that already has a started visit). ResQ rejects
-  //    that outcome on some visits (e.g. one we just started this pass) with a
-  //    "malformed/unprocessable arguments" ValidationError, so retry once with
-  //    RESOLVED before falling back to captureVisitNotes. The retry only runs
-  //    after the normal attempt fails, so it can't regress the happy path.
+  // 4. End the visit with outcome COMPLETED (the only valid VisitOutcome ResQ
+  //    accepts here — the old 'RESOLVED' retry was dead code: ResQ rejects it
+  //    with "Value 'RESOLVED' does not exist in 'VisitOutcome' enum"). If ResQ
+  //    reports the visit is already ended, that IS the desired end state — treat
+  //    it as completed rather than erroring every run (R0994830 / R1014524 were
+  //    stuck here: visit ended, but we kept re-ending it and never advanced to
+  //    the invoice step).
   const cleanNotes = completionNotes.substring(0, 2000);
   // ResQ Image input is { url: String } — wrap the relayed URL strings. Attach
   // photos AS PART OF completing the visit (we're authorized to endVisit; ResQ
   // blocks after-image edits on an already-closed visit).
   const imageObjs = (images || []).map((u) => ({ url: u }));
   const endErrors = [];
-  for (const outcome of ['COMPLETED', 'RESOLVED']) {
+  for (const outcome of ['COMPLETED']) {
     try {
       await resqGql(session, `mutation($input: EndVisitInput!) {
         endVisit(input: $input) { __typename }
@@ -1067,6 +1068,14 @@ async function provideUpdateToResq(session, resqWO, sfJobId, images = []) {
       result.completed = true;
       return result;
     } catch (e) {
+      // ResQ says the visit is already ended → that's the state we wanted.
+      // Mark completed so the WO advances to the invoice step instead of
+      // looping on this error forever.
+      if (/already (been )?ended/i.test(e.message)) {
+        result.steps.push(`${resqWO.code} visit already ended — treating as completed`);
+        result.completed = true;
+        return result;
+      }
       // Keep the full ResQ error (incl. extensions.fields.__all__) — the old
       // substring(0,200) cut it off right before the actual reason.
       endErrors.push(`outcome=${outcome}: ${e.message.substring(0, 600)}`);
@@ -1088,6 +1097,12 @@ async function provideUpdateToResq(session, resqWO, sfJobId, images = []) {
     result.steps.push(`→ ${resqWO.code} visit notes captured (fallback)`);
     result.completed = true;
   } catch (e2) {
+    // Same already-ended short-circuit on the fallback path.
+    if (/already (been )?ended/i.test(e2.message)) {
+      result.steps.push(`${resqWO.code} visit already ended — treating as completed`);
+      result.completed = true;
+      return result;
+    }
     result.errors.push(`Complete visit ${resqWO.code}: endVisit [${endErrors.join(' | ')}], captureVisitNotes (${e2.message.substring(0, 600)})`);
   }
 


### PR DESCRIPTION
## Summary

Fixes the `endVisit` failure that kept Melt WOs (R0994830, R1014524) stuck at the visit-completion step, unable to ever reach the invoice stage.

The full ResQ error (previously truncated) was:
```
endVisit [outcome=COMPLETED]: ValidationError __all__: "Visit has already ended."
endVisit [outcome=RESOLVED]: "Value 'RESOLVED' does not exist in 'VisitOutcome' enum."
captureVisitNotes: "Visit has already ended."
```

Two bugs:

1. **"Visit has already ended" treated as an error.** The visit *is* ended — that's the state we want — but the code treated the response as a failure, never set `visit_completed`, and looped on it every run while never advancing the WO to the invoice step. Now we detect "visit (has) already (been) ended" on both `endVisit` and the `captureVisitNotes` fallback and mark the visit completed.

2. **`RESOLVED` is not a valid `VisitOutcome`.** That retry could only ever fail (`Value 'RESOLVED' does not exist in 'VisitOutcome' enum`) and added log noise. Removed it; `COMPLETED` is the only valid outcome here.

## Effect

R0994830 and R1014524 will advance past visit-completion on the next sync, then flow into the (already-fixed) invoice path — which verifies a real vendor invoice before marking submitted.

https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_