### PR TITLE
Sync: synchronous sf-receipt-pull (visible SF receipt → Brixpense)

### DIFF
--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -273,17 +273,27 @@
       "last_verified": "2026-05-12"
     },
     {
+      "name": "sf-receipt-pull",
+      "kind": "netlify-function",
+      "source_repo": "skypace/apbg-billing",
+      "schedule": "every 30 min via Supabase pg_cron (synchronous; cronKey)",
+      "writes": ["ops.expense_requests", "ops.expense_request_attachments"],
+      "multi_writer": true,
+      "notes": "Synchronous SF receipt puller — scans recent completed/invoiced SF jobs, lands each receipt as a Brixpense review-DRAFT via lib/sf-expense.landSfJobExpense (scan + attach, no QBO post). Reuses the in-runtime SF auth (single token owner). Returns full diagnostics to the caller. Deduped by sf_expense_id; gated to SF_SWEEP_START_DATE. Replaces the invisible background sweep.",
+      "last_verified": "2026-06-06"
+    },
+    {
       "name": "sf-expense-sweep-background",
       "kind": "netlify-function",
       "source_repo": "skypace/apbg-billing",
-      "schedule": "every 30 min via Supabase pg_cron (net.http_post + cronKey)",
+      "schedule": "deprecated (invisible background fn — superseded by sf-receipt-pull)",
       "writes": [
         "ops.expense_requests",
         "ops.expense_request_attachments",
         "ops.sync_log"
       ],
       "multi_writer": true,
-      "notes": "Background sweep of ALL Service Fusion completed/invoiced jobs (incl. regular non-ResQ jobs) — delegates to lib/sf-expense.landSfJobExpense, which scans each receipt and lands a Brixpense review-DRAFT (status='draft', as_bill, tag='Service Fusion') with the image attached, via the service-role key. Deduped by ops.expense_requests.sf_expense_id (migration 20260603d); gated to SF_SWEEP_START_DATE. No QBO post — Brixpense posts on submit. Driven by pg_cron (cronKey==CRON_SECRET) because Netlify's scheduled-function trigger does not fire on this site.",
+      "notes": "Deprecated in favor of the synchronous sf-receipt-pull. Same landSfJobExpense delegation; kept declared while the file exists.",
       "last_verified": "2026-06-06"
     },
     {

--- a/netlify.toml
+++ b/netlify.toml
@@ -42,6 +42,9 @@
 [functions."sf-expense-sweep-background"]
   timeout = 900
 
+[functions."sf-receipt-pull"]
+  timeout = 26
+
 [functions."health-watchdog"]
   timeout = 60
 

--- a/netlify/functions/sf-receipt-pull.mjs
+++ b/netlify/functions/sf-receipt-pull.mjs
@@ -1,0 +1,88 @@
+// SF receipt → Brixpense, the reliable + debuggable way.
+//
+// SYNCHRONOUS Netlify function (NOT background) so it returns its full result
+// to the caller — no invisible background runtime. Reuses the SF auth that
+// already works in this runtime (single token owner — no rotation conflict),
+// scans recent completed/invoiced SF jobs, and lands each receipt as a
+// Brixpense review-DRAFT via landSfJobExpense. NOTHING posts to QBO.
+//
+// Auth: cronKey==CRON_SECRET (for pg_cron) or a superadmin JWT.
+// Debug: ?sfJob=<id> processes a single SF job and returns the detail.
+// Driven by Supabase pg_cron once verified.
+
+import { sfRequest } from './sf-helpers.mjs';
+import { landSfJobExpense } from './lib/sf-expense.mjs';
+import { requireAuth } from './lib/auth.mjs';
+
+const SUBMITTER = {
+  id: '2da634b7-623d-4f73-b667-cf87975fcdb6',
+  email: 'skypace@brixbev.com',
+  user_metadata: { name: 'Service Fusion (system)' },
+};
+
+const MAX_PAGES = 3;
+const TIME_BUDGET_MS = 22000;
+const SWEEP_START_DATE = process.env.SF_SWEEP_START_DATE || '2026-06-03';
+
+const isDone = (s) => {
+  const t = String(s || '').toLowerCase();
+  return t.includes('complet') || t.includes('invoic');
+};
+
+export async function handler(event) {
+  const qs = event.queryStringParameters || {};
+  const hdrs = event.headers || {};
+  const key = qs.cronKey || hdrs['x-cron-key'] || hdrs['X-Cron-Key'] || '';
+  const cronOk = !!(key && process.env.CRON_SECRET && key === process.env.CRON_SECRET);
+  if (!cronOk) {
+    const a = await requireAuth(event);
+    if (!a.ok) return a.response;
+  }
+
+  const start = Date.now();
+  const startMs = Date.parse(`${SWEEP_START_DATE}T00:00:00Z`) || 0;
+  const scanFloor = startMs - 7 * 86400000;
+  const out = { ok: true, scanned: 0, doneJobs: 0, drafts: 0, attached: 0, perJob: [], errors: [] };
+
+  try {
+    // Single-job debug path.
+    if (qs.sfJob) {
+      const r = await landSfJobExpense({ sfJobId: qs.sfJob, resqCode: qs.resqCode || null, submitter: SUBMITTER });
+      out.perJob.push({ job: qs.sfJob, r });
+      out.drafts += r.landed || 0;
+      out.attached += r.attached || 0;
+      out.ms = Date.now() - start;
+      return { statusCode: 200, body: JSON.stringify(out) };
+    }
+
+    for (let page = 1; page <= MAX_PAGES; page++) {
+      if (Date.now() - start > TIME_BUDGET_MS) { out.timedOut = true; break; }
+      let jobs;
+      try {
+        const res = await sfRequest('GET', `/jobs?per-page=100&sort=-created_at&page=${page}`);
+        jobs = res.items || res.data || [];
+      } catch (e) { out.errors.push(`list p${page}: ${String(e.message).slice(0, 160)}`); break; }
+      if (!jobs.length) break;
+      out.scanned += jobs.length;
+      const allOld = jobs.every((j) => j.created_at && new Date(j.created_at).getTime() < scanFloor);
+
+      for (const job of jobs) {
+        if (Date.now() - start > TIME_BUDGET_MS) { out.timedOut = true; break; }
+        if (job.created_at && new Date(job.created_at).getTime() < scanFloor) continue;
+        if (!isDone(job.status)) continue;
+        out.doneJobs++;
+        try {
+          const r = await landSfJobExpense({ sfJobId: job.id, resqCode: null, submitter: SUBMITTER });
+          if (r.ok) { out.drafts += r.landed || 0; out.attached += r.attached || 0; }
+          if (out.perJob.length < 8) out.perJob.push({ job: job.number || job.id, status: job.status, r });
+        } catch (e) { out.errors.push(`job ${job.id}: ${String(e.message).slice(0, 160)}`); }
+      }
+      if (allOld) break;
+    }
+  } catch (e) {
+    out.ok = false;
+    out.crash = String(e && e.message ? e.message : e).slice(0, 400);
+  }
+  out.ms = Date.now() - start;
+  return { statusCode: 200, body: JSON.stringify(out) };
+}


### PR DESCRIPTION
A **synchronous, debuggable** SF→Brixpense receipt puller — replaces the invisible background sweep.

**Why:** the background function returned 202 but produced no log/landing, and Netlify function logs aren't readable via my tools, so I was blind. This function **returns its full per-job result + errors directly to the caller**, so I can `curl` it and see exactly what happens.

- Reuses the **in-runtime SF auth** (single SF-token owner). Confirmed SF refresh tokens **rotate**, so a standalone edge function would invalidate Netlify's token and break the live Starbird/Melt sync — this avoids that entirely.
- Scans recent **completed/invoiced** SF jobs, lands each **receipt** as a Brixpense **draft** via `landSfJobExpense` (scan + attach, **no QBO post**). Deduped by `sf_expense_id`, gated to `SF_SWEEP_START_DATE`.
- `?sfJob=<id>` debugs a single job.
- pg_cron will drive it every 30 min once verified.

Manifest + lint pass. Once deployed I'll curl it and report exactly what it finds.

https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Heh7xs8d2YuukxWSad5uAU)_