### PR TITLE
feat(sync): email notification + asset notes for new ResQ jobs

### DIFF
--- a/netlify/functions/email-helpers.mjs
+++ b/netlify/functions/email-helpers.mjs
@@ -97,7 +97,7 @@ async function sendViaSendGrid({ to, subject, html, replyTo, from, sendgridKey }
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      personalizations: [{ to: [{ email: to }] }],
+      personalizations: [{ to: (Array.isArray(to) ? to : [to]).map(e => ({ email: e })) }],
       from: { email: fromAddr, name: fromName },
       reply_to: replyTo ? { email: replyTo } : undefined,
       subject,

--- a/netlify/functions/lib/resq-job-notify.mjs
+++ b/netlify/functions/lib/resq-job-notify.mjs
@@ -1,0 +1,216 @@
+// ResQ new-job notification — when a ResQ WO is first picked up by the sync,
+// email a "here's what's wrong" notification (location, asset, description, and
+// any photos ResQ has on the WO) through alamedapointbg.com via Resend.
+//
+// ResQ's GraphQL schema for WO photos / equipment detail / facility address is
+// not fully known here, and an unknown field would fail the WHOLE query. So we
+// INTROSPECT the relevant types once per cold start and build the enrichment
+// query from only the fields that actually exist — it can never break the sync,
+// and it self-adapts to whatever ResQ exposes. Everything here is best-effort:
+// a failure logs and degrades (email still sends with the fields we do have).
+
+import { resqGql } from '../resq-helpers.mjs';
+import { sendEmail } from '../email-helpers.mjs';
+
+const NOTIFY_TO = process.env.RESQ_JOB_NOTIFY_TO || 'skypace@brixbev.com';
+
+// --- Schema introspection (cached per cold start) ---
+const _typeCache = new Map();
+async function typeFields(session, typeName) {
+  if (_typeCache.has(typeName)) return _typeCache.get(typeName);
+  let fields = [];
+  try {
+    const d = await resqGql(session, `{ __type(name: "${typeName}") {
+      fields { name type { name kind ofType { name kind ofType { name kind } } } }
+    } }`);
+    fields = d.data?.__type?.fields || [];
+  } catch { /* leave empty */ }
+  _typeCache.set(typeName, fields);
+  return fields;
+}
+
+// Unwrap NON_NULL / LIST wrappers to the underlying named type.
+function namedType(t) {
+  let cur = t;
+  while (cur && !cur.name && cur.ofType) cur = cur.ofType;
+  return cur?.name || null;
+}
+function fieldByName(fields, names) {
+  const lower = names.map(n => n.toLowerCase());
+  return fields.find(f => lower.includes(f.name.toLowerCase()))
+    || fields.find(f => lower.some(n => f.name.toLowerCase().includes(n)));
+}
+function fieldsMatching(fields, re) {
+  return fields.filter(f => re.test(f.name));
+}
+
+// Discover, once, how to ask ResQ for a WO's photos + extra asset/location
+// detail. Returns a plan: { photo:{field, urlSub, labelSub}, equipExtra:[],
+// facilityAddr:[] } — any piece may be null/empty if ResQ doesn't expose it.
+let _planPromise;
+function discoverPlan(session) {
+  if (_planPromise) return _planPromise;
+  _planPromise = (async () => {
+    const plan = { photo: null, equipExtra: [], facilityAddr: [] };
+    try {
+      const woFields = await typeFields(session, 'WorkOrder');
+
+      // Photo / attachment collection field on the WO.
+      const photoField = fieldByName(woFields, ['attachments', 'images', 'beforeImages', 'photos', 'media', 'files']);
+      if (photoField) {
+        const inner = namedType(photoField.type);
+        if (inner) {
+          // The collection may be a Relay connection ({ edges { node {...} } })
+          // or a plain list of nodes. Probe the node type's fields.
+          let nodeType = inner;
+          const connFields = await typeFields(session, inner);
+          const edges = connFields.find(f => f.name === 'edges');
+          if (edges) {
+            const edgeType = namedType(edges.type);
+            const edgeFields = await typeFields(session, edgeType);
+            const node = edgeFields.find(f => f.name === 'node');
+            nodeType = namedType(node?.type) || nodeType;
+          }
+          const nodeFields = await typeFields(session, nodeType);
+          const urlSub = fieldByName(nodeFields, ['url', 'fileUrl', 'file', 'src', 'downloadUrl', 'location', 'href']);
+          const labelSub = fieldByName(nodeFields, ['label', 'name', 'caption', 'title', 'filename']);
+          if (urlSub) {
+            plan.photo = {
+              field: photoField.name,
+              isConnection: !!edges,
+              urlSub: urlSub.name,
+              labelSub: labelSub?.name || null,
+            };
+          }
+        }
+      }
+
+      // Extra equipment detail beyond name.
+      const equipFields = await typeFields(session, 'Equipment');
+      plan.equipExtra = fieldsMatching(equipFields, /^(model|make|manufacturer|serial|serialNumber|assetTag|category|type)$/i)
+        .map(f => f.name).slice(0, 6);
+
+      // Facility address fields.
+      const facFields = await typeFields(session, 'Facility');
+      plan.facilityAddr = fieldsMatching(facFields, /(address|street|city|state|zip|postal|line1|line2)/i)
+        .map(f => f.name).slice(0, 8);
+    } catch { /* degrade to nothing */ }
+    return plan;
+  })();
+  return _planPromise;
+}
+
+// Build + run the enrichment query for one WO code, using only fields ResQ
+// confirmed it has. Returns { photos:[{url,label}], equipment:{}, facility:{} }.
+export async function fetchWoEnrichment(session, code) {
+  const out = { photos: [], equipment: {}, facility: {} };
+  let plan;
+  try { plan = await discoverPlan(session); } catch { return out; }
+
+  const equipSel = ['id', 'name', ...plan.equipExtra].join(' ');
+  const facSel = ['id', 'name', ...plan.facilityAddr].join(' ');
+  let photoSel = '';
+  if (plan.photo) {
+    const inner = plan.photo.labelSub
+      ? `${plan.photo.urlSub} ${plan.photo.labelSub}`
+      : plan.photo.urlSub;
+    photoSel = plan.photo.isConnection
+      ? `${plan.photo.field} { edges { node { ${inner} } } }`
+      : `${plan.photo.field} { ${inner} }`;
+  }
+
+  try {
+    const d = await resqGql(session, `{
+      workOrders(first: 1, code: "${code}") {
+        edges { node {
+          equipment { ${equipSel} }
+          facility { ${facSel} }
+          ${photoSel}
+        } }
+      }
+    }`);
+    const node = d.data?.workOrders?.edges?.[0]?.node || {};
+    out.equipment = node.equipment || {};
+    out.facility = node.facility || {};
+    if (plan.photo) {
+      const raw = node[plan.photo.field];
+      const items = plan.photo.isConnection ? (raw?.edges || []).map(e => e.node) : (raw || []);
+      out.photos = items
+        .map(it => ({ url: it?.[plan.photo.urlSub], label: plan.photo.labelSub ? it?.[plan.photo.labelSub] : null }))
+        .filter(p => p.url && /^https?:\/\//i.test(String(p.url)));
+    }
+  } catch { /* degrade */ }
+  return out;
+}
+
+// Compact multi-line asset/location summary for the SF job notes.
+export function assetNotesBlock(wo, enrichment) {
+  const e = enrichment?.equipment || {};
+  const f = enrichment?.facility || {};
+  const lines = [];
+  const assetBits = [e.name, e.make, e.model, e.serialNumber || e.serial, e.assetTag].filter(Boolean);
+  if (assetBits.length) lines.push(`Asset: ${assetBits.join(' / ')}`);
+  const addr = [f.line1 || f.street || f.address, f.city, f.state, f.zip || f.postal].filter(Boolean).join(', ');
+  if (addr) lines.push(`Location: ${f.name || wo.facility}${addr ? ' — ' + addr : ''}`);
+  if (wo.serviceCategory) lines.push(`Service: ${wo.serviceCategory}`);
+  if (enrichment?.photos?.length) lines.push(`Photos on ResQ: ${enrichment.photos.length}`);
+  return lines.join('\n');
+}
+
+function esc(s) {
+  return String(s ?? '').replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+}
+
+function buildEmailHtml(wo, enrichment) {
+  const e = enrichment.equipment || {};
+  const f = enrichment.facility || {};
+  const addr = [f.line1 || f.street || f.address, f.city, f.state, f.zip || f.postal].filter(Boolean).join(', ');
+  const assetBits = [e.name, e.make, e.model, e.serialNumber || e.serial, e.assetTag].filter(Boolean);
+  const photos = enrichment.photos || [];
+
+  const row = (label, val) => val
+    ? `<tr><td style="color:#6b7280;padding:6px 0;font-size:13px;vertical-align:top;width:120px;">${esc(label)}</td><td style="font-size:14px;padding:6px 0;">${val}</td></tr>`
+    : '';
+
+  const photoHtml = photos.length
+    ? `<p style="font-size:13px;font-weight:600;color:#1F4E79;margin:20px 0 8px;">PHOTOS (${photos.length})</p>
+       <div>${photos.map(p => `<a href="${esc(p.url)}" style="text-decoration:none;"><img src="${esc(p.url)}" alt="${esc(p.label || 'photo')}" style="max-width:260px;max-height:200px;border-radius:6px;border:1px solid #e2e6ed;margin:0 8px 8px 0;display:inline-block;"></a>`).join('')}</div>
+       <p style="font-size:11px;color:#9ca3af;">If images don't load, click one to open it in ResQ.</p>`
+    : `<p style="font-size:12px;color:#9ca3af;margin:16px 0 0;">No photos attached to this ResQ WO.</p>`;
+
+  return `
+  <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:640px;margin:0 auto;background:#fff;">
+    <div style="background:#1F4E79;padding:22px 28px;border-radius:8px 8px 0 0;">
+      <h1 style="color:#fff;font-size:19px;margin:0;">New ResQ Work Order — ${esc(wo.code)}${wo.isUrgent ? ' · ⚠ URGENT' : ''}</h1>
+      <p style="color:rgba(255,255,255,0.75);font-size:13px;margin:6px 0 0;">${esc(wo.facility || f.name || '')}</p>
+    </div>
+    <div style="padding:22px 28px;border:1px solid #e2e6ed;border-top:0;border-radius:0 0 8px 8px;">
+      <table style="width:100%;border-collapse:collapse;">
+        ${row('Work Order', `<span style="font-family:monospace;">${esc(wo.code)}</span>`)}
+        ${row('Location', `${esc(f.name || wo.facility || '—')}${addr ? `<br><span style="color:#6b7280;font-size:13px;">${esc(addr)}</span>` : ''}`)}
+        ${row('Asset', assetBits.length ? esc(assetBits.join(' / ')) : (wo.equipment ? esc(wo.equipment) : '—'))}
+        ${row('Service', wo.serviceCategory ? esc(wo.serviceCategory) : '')}
+        ${row('Priority', wo.isUrgent ? '<strong style="color:#991B1B;">URGENT</strong>' : 'Normal')}
+        ${row('Title', wo.title ? esc(wo.title) : '')}
+      </table>
+      ${wo.description ? `<p style="font-size:13px;font-weight:600;color:#1F4E79;margin:18px 0 6px;">WHAT'S WRONG</p>
+        <div style="background:#f4f6f9;border-radius:6px;padding:14px 16px;font-size:14px;white-space:pre-wrap;">${esc(wo.description)}</div>` : ''}
+      ${photoHtml}
+    </div>
+    <p style="text-align:center;font-size:11px;color:#9ca3af;margin:14px 0;">APBG · ResQ ↔ Service Fusion sync · automated job notification</p>
+  </div>`;
+}
+
+// Send the notification. Best-effort: returns { ok, error?, photos } and never
+// throws. `enrichment` may be passed in (from createSfJob) to skip a re-fetch.
+export async function notifyNewResqJob(session, wo, enrichment = null) {
+  try {
+    if (!enrichment) enrichment = await fetchWoEnrichment(session, wo.code);
+    const subject = `New ResQ WO ${wo.code}${wo.isUrgent ? ' (URGENT)' : ''} — ${wo.facility || enrichment.facility?.name || ''}`.trim();
+    const html = buildEmailHtml(wo, enrichment);
+    await sendEmail({ to: NOTIFY_TO, subject, html });
+    return { ok: true, photos: enrichment.photos.length, enrichment };
+  } catch (e) {
+    return { ok: false, error: String(e?.message || e).slice(0, 200) };
+  }
+}

--- a/netlify/functions/lib/resq-job-notify.mjs
+++ b/netlify/functions/lib/resq-job-notify.mjs
@@ -12,7 +12,10 @@
 import { resqGql } from '../resq-helpers.mjs';
 import { sendEmail } from '../email-helpers.mjs';
 
-const NOTIFY_TO = process.env.RESQ_JOB_NOTIFY_TO || 'skypace@brixbev.com';
+// Recipients for the new-job alert. Defaults to both ops owners; override with
+// a comma-separated RESQ_JOB_NOTIFY_TO env var.
+const NOTIFY_TO = (process.env.RESQ_JOB_NOTIFY_TO || 'skypace@brixbev.com,whitney@alamedasoda.com')
+  .split(',').map(s => s.trim()).filter(Boolean);
 
 // --- Schema introspection (cached per cold start) ---
 const _typeCache = new Map();

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -20,6 +20,7 @@ import { sfRequest } from './sf-helpers.mjs';
 import { requireAuth } from './lib/auth.mjs';
 import { loadSyncCustomers, classifySyncCustomer, allFacilityKeywords, sfNameFor, stemFor } from './lib/sync-customers.mjs';
 import { mapEntryToLinkRow, bulkUpsertLinks, bulkInsertEvents, eventFromResult } from './lib/resq-sf-links.mjs';
+import { fetchWoEnrichment, assetNotesBlock, notifyNewResqJob } from './lib/resq-job-notify.mjs';
 
 const BRIX_VENDOR_KEYWORDS = ['brix'];
 
@@ -179,7 +180,7 @@ export async function handler(event) {
             continue;
           }
 
-          const r = await withTimeout(processNewWO(wo, mapping, syncCustomers), 15000, `process ${wo.code}`);
+          const r = await withTimeout(processNewWO(wo, mapping, syncCustomers, session), 15000, `process ${wo.code}`);
           if (r.steps.length) log.steps.push(...r.steps);
           if (r.errors.length) log.errors.push(...r.errors);
           if (r.report?.length) dedupeReport.push(...r.report);
@@ -282,7 +283,7 @@ function withTimeout(promise, ms, label) {
 }
 
 // --- Process new unmapped WO ---
-async function processNewWO(wo, mapping, syncCustomers) {
+async function processNewWO(wo, mapping, syncCustomers, session = null) {
   const result = { steps: [], errors: [], created: 0, report: [] };
   const cust = classifySyncCustomer(wo.facility, syncCustomers);
   if (!cust) {
@@ -396,7 +397,14 @@ async function processNewWO(wo, mapping, syncCustomers) {
       result.report?.push({ resqCode: wo.code, reason: 'sf_customer_not_found', message: `No SF customer matches "${customerName}" (stem "${sfCustomerKey}").`, facility: wo.facility });
       return result;
     }
-    const sfJob = await createSfJob(wo, resolvedName);
+    // Pull ResQ asset/location/photo detail once — used for BOTH the SF job
+    // notes and the notification email. Best-effort; never blocks job creation.
+    let enrichment = null;
+    if (session) {
+      try { enrichment = await fetchWoEnrichment(session, wo.code); } catch { /* ignore */ }
+    }
+
+    const sfJob = await createSfJob(wo, resolvedName, enrichment);
 
     // Determine initial SF status based on ResQ status
     const resqStatus = (wo.status || '').toUpperCase();
@@ -412,6 +420,21 @@ async function processNewWO(wo, mapping, syncCustomers) {
     };
     result.created++;
     result.steps.push(`✓ Created SF #${sfJob.id} (${resqRef}) for ${wo.code} (${wo.facility})`);
+
+    // Notify: email the new-job details (location, asset, what's wrong, photos)
+    // via Resend through alamedapointbg.com. Idempotent — only fires here, on
+    // first creation, and the mapping persists so it won't re-send. Non-fatal.
+    if (session && !mapping[wo.id].notified) {
+      try {
+        const n = await notifyNewResqJob(session, wo, enrichment);
+        if (n.ok) {
+          mapping[wo.id].notified = true;
+          result.steps.push(`📧 New-job email sent for ${wo.code} (${n.photos} photo(s))`);
+        } else {
+          result.errors.push(`Notify ${wo.code}: ${n.error}`);
+        }
+      } catch (e) { result.errors.push(`Notify ${wo.code}: ${e.message.substring(0, 150)}`); }
+    }
   } catch (e) {
     result.errors.push(`Create SF job for ${wo.code}: ${e.message.substring(0, 300)}`);
   }
@@ -852,14 +875,22 @@ async function resolveSfCustomerName(configuredName, stem, sfCustomerId) {
 }
 
 // --- SF Helpers ---
-async function createSfJob(resqWO, customerName) {
+async function createSfJob(resqWO, customerName, enrichment = null) {
   const resqRef = resqWO.code.startsWith('R') ? resqWO.code : `R${resqWO.code}`;
+  // Asset/location detail pulled from ResQ (equipment make/model/serial,
+  // facility address, service category, photo count). Best-effort — empty
+  // string when ResQ exposes nothing extra.
+  let assetBlock = '';
+  if (enrichment) {
+    try { assetBlock = assetNotesBlock(resqWO, enrichment); } catch { /* ignore */ }
+  }
   const description = [
     `ResQ WO: ${resqRef}`,
     resqWO.title,
     resqWO.description,
     `Facility: ${resqWO.facility}`,
     resqWO.equipment ? `Equipment: ${resqWO.equipment}` : '',
+    assetBlock,
     resqWO.isUrgent ? 'URGENT' : '',
   ].filter(Boolean).join('\n');
 
@@ -1621,7 +1652,7 @@ export async function syncSingleByCode(resqCode) {
     } else {
       const st = (wo.status || '').toUpperCase();
       if (RESQ_NO_NEW_JOB_STATUSES.includes(st)) { out.steps.push(`${wo.code}: ${wo.status} — no new SF job created`); return out; }
-      r = await processNewWO(wo, mapping, syncCustomers);
+      r = await processNewWO(wo, mapping, syncCustomers, session);
       out.created += r.created || 0;
     }
     if (r.steps?.length) out.steps.push(...r.steps);


### PR DESCRIPTION
## Summary

When the sync first picks up a ResQ WO and creates the Service Fusion job, it now does two new things:

### 1. Asset/location detail → SF job notes
Pulls ResQ equipment detail (make/model/serial/asset-tag), facility address, service category, and photo count, and folds it into the SF job description alongside the existing fields.

### 2. Notification email per new ResQ job (via Resend, through alamedapointbg.com)
Sends a branded "here's what's wrong" email with:
- **Location** — facility name + address
- **Asset** — equipment name + make/model/serial
- **What's wrong** — title + description
- **Priority** — urgent flag highlighted
- **Photos** — any pictures attached to the ResQ WO (inline, with click-through links)

Sent from `alerts@alamedapointbg.com` (the verified Resend sender). Recipient defaults to `skypace@brixbev.com`, overridable via the `RESQ_JOB_NOTIFY_TO` env var.

## Why it's safe

ResQ's GraphQL schema for WO photos / equipment detail / facility address isn't known up front, and an unknown field fails the *whole* query. So `lib/resq-job-notify.mjs` **introspects** the `WorkOrder` / `Equipment` / `Facility` types once per cold start and builds the enrichment query from only the fields that actually exist. Everything is **best-effort**:
- If enrichment fails, the email still sends with the core fields we already have (facility, equipment name, title, description, urgency).
- Job creation is never blocked by enrichment or email failures.
- Fires **once per new WO** (idempotent via a `notified` flag). WOs linked to a pre-existing SF job don't email.

No `ops.*` writes, so the sync-manifest lint is unaffected.

## Verify after deploy

The photo field is the one part discovered at runtime — I'd like to confirm against the next live WO that photos populate (and the address/equipment-detail fields resolve to ResQ's actual schema). If a field name doesn't match, the email degrades gracefully and I tune the candidate list.

https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_