### PR TITLE
feat(sync): dashboard Ignore toggle + auto-heal cancelled-SF-job links

### DIFF
--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -147,6 +147,11 @@ export async function handler(event) {
 
       try {
         if (mapping[wo.id]) {
+          // User-flagged IGNORE (dashboard toggle) — skip entirely: no status
+          // sync, no photos, no invoice, no email. Cleared by un-ignoring.
+          if (mapping[wo.id].ignored) {
+            continue;
+          }
           // Skip deleted SF jobs — they 404 every time and bloat errors
           if (mapping[wo.id].sfDeleted) {
             continue;
@@ -1646,6 +1651,7 @@ export async function syncSingleByCode(resqCode) {
   try {
     let r;
     if (mapping[wo.id]) {
+      if (mapping[wo.id].ignored) { out.steps.push(`${wo.code}: ignored (dashboard toggle) — skipped`); return out; }
       if (mapping[wo.id].sfDeleted) { out.steps.push(`${wo.code}: linked SF job was deleted — skipped`); return out; }
       r = await syncBidirectional(session, wo, mapping[wo.id]);
       out.updated += r.updated || 0;

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -175,6 +175,19 @@ export async function handler(event) {
           log.updated += r.updated || 0;
           const ev = eventFromResult(wo, mapping[wo.id], r, 'sf->resq');
           if (ev) syncEvents.push(ev);
+
+          // Auto-heal: the WO's only SF job was Cancelled and no live one
+          // exists — drop the dead link and create a fresh SF job this pass.
+          if (mapping[wo.id]?.needsRecreate) {
+            delete mapping[wo.id];
+            const rc = await withTimeout(processNewWO(wo, mapping, syncCustomers, session), 15000, `recreate ${wo.code}`);
+            if (rc.steps.length) log.steps.push(...rc.steps);
+            if (rc.errors.length) log.errors.push(...rc.errors);
+            if (rc.report?.length) dedupeReport.push(...rc.report);
+            log.created += rc.created || 0;
+            const ev2 = eventFromResult(wo, mapping[wo.id], rc, 'resq->sf');
+            if (ev2) syncEvents.push(ev2);
+          }
         } else {
           // New WO — don't create an SF job if ResQ already considers it
           // completed/terminal (a fresh job would be a phantom; also keeps a
@@ -529,6 +542,39 @@ async function syncBidirectional(session, resqWO, mapEntry) {
     const resqStatus = (resqWO.status || '').toUpperCase();
     const prevSfStatus = (mapEntry.sfStatus || '').toLowerCase();
     const prevResqStatus = (mapEntry.resqStatus || '').toUpperCase();
+
+    // Auto-heal a Cancelled link. If the SF job we're mapped to reads Cancelled
+    // but the WO is still active in ResQ, the WO is stranded — the sync just
+    // no-ops on it forever (R1027590: SF job cancelled, then un-cancelled, but
+    // the mapping never re-evaluated and the board stayed stuck). Re-link to a
+    // live SF job for this PO if one exists (e.g. the one you un-cancelled, or a
+    // replacement). If none exists, flag for recreation — the main loop drops
+    // the dead link and processNewWO creates a fresh SF job next.
+    if (isSfCancelled(sfStatus) && !RESQ_DONE_STATUSES.includes(resqStatus)) {
+      const resqRef = resqWO.code.startsWith('R') ? resqWO.code : `R${resqWO.code}`;
+      let live = [];
+      try {
+        const all = await findSfJobsByPoNumber(resqRef);
+        live = all.filter(j => !isSfCancelled(j.status));
+      } catch (e) { result.errors.push(`Heal ${resqWO.code}: ${e.message.substring(0, 150)}`); }
+      if (live.length) {
+        const best = pickBestSfJob(live, null) || live[0];
+        result.steps.push(`♻ ${resqWO.code}: linked SF #${mapEntry.sfJobId} is Cancelled → re-linked to live SF #${best.id} (${best.status})`);
+        mapEntry.replacedSfJobId = mapEntry.sfJobId;
+        mapEntry.sfJobId = best.id;
+        mapEntry.sfJobNumber = best.number || best.job_number || best.id;
+        mapEntry.sfStatus = best.status;
+        mapEntry.lastSyncAt = new Date().toISOString();
+        result.updated++;
+        return result; // next pass syncs the freshly-linked job normally
+      }
+      // No live SF job for this PO — the only one is cancelled. Mark for
+      // recreation; the reconciler loop handles the actual re-create.
+      mapEntry.needsRecreate = true;
+      mapEntry.lastSyncAt = new Date().toISOString();
+      result.steps.push(`♻ ${resqWO.code}: only SF job is Cancelled — flagged for fresh SF job creation`);
+      return result;
+    }
 
     const sfChanged = sfStatus !== mapEntry.sfStatus;
     const resqChanged = resqStatus !== prevResqStatus;

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -26,6 +26,7 @@ export async function handler(event) {
   if (qs.relink) return handleRelink(qs.relink, qs.toSfJobId);
   if (qs.dismissIssue) return handleDismissIssue(qs.dismissIssue);
   if (qs.clearErrors) return handleClearErrors();
+  if (qs.ignoreWo) return handleIgnoreWo(qs.ignoreWo, qs.ignore);
   if (qs.bulkCleanup !== undefined) return handleBulkCleanup();
   if (qs.syncOne) return handleSyncOne(qs.syncOne);
   if (event.httpMethod === 'GET') return handleGet();
@@ -740,6 +741,33 @@ async function handleDismissIssue(resqCode) {
     } catch (e) { /* non-fatal */ }
 
     return json({ ok: true, dismissed: before - r.totalIssues });
+  } catch (e) {
+    return json({ error: e.message }, 500);
+  }
+}
+
+// --- Ignore toggle: flag a WO so the sync skips it entirely ---
+// ?ignoreWo=<resqCode>&ignore=true|false  (ignore defaults to true)
+// Sets/clears mapEntry.ignored in the blob. The reconciler + syncOne both
+// skip ignored WOs (no create, no status sync, no invoice, no email).
+async function handleIgnoreWo(code, ignoreParam) {
+  try {
+    const store = await getStore();
+    if (!store) return json({ error: 'Blob store not available' }, 500);
+    const raw = await store.get('wo-mapping');
+    const mapping = raw ? JSON.parse(raw) : {};
+    const ignore = !(ignoreParam === 'false' || ignoreParam === '0'); // default true
+    let found = false;
+    for (const [k, v] of Object.entries(mapping)) {
+      if (v.resqCode === code || k === code) {
+        if (ignore) v.ignored = true; else delete v.ignored;
+        v.lastSyncAt = new Date().toISOString();
+        found = true;
+      }
+    }
+    if (!found) return json({ deleted: false, code, message: 'Not found in mapping' }, 404);
+    await store.set('wo-mapping', JSON.stringify(mapping));
+    return json({ ok: true, code, ignored: ignore });
   } catch (e) {
     return json({ error: e.message }, 500);
   }

--- a/public/sync.html
+++ b/public/sync.html
@@ -543,6 +543,28 @@ async function clearMapping(code) {
   }
 }
 
+// --- Ignore toggle: flag a WO so the sync skips it (or resume it) ---
+async function toggleIgnore(code, ignore) {
+  if (!code) return;
+  const verb = ignore ? 'ignore' : 'resume syncing';
+  if (!confirm(`${ignore ? 'Ignore' : 'Resume'} ${code}? ${ignore ? 'The sync will skip this WO entirely (no status sync, no invoice, no email) until you un-ignore it.' : 'The sync will start processing this WO again.'}`)) return;
+  const btn = event?.target;
+  if (btn) { btn.disabled = true; btn.textContent = '...'; }
+  try {
+    const res = await fetch(`${API_BASE}/resq-sf-sync?ignoreWo=${encodeURIComponent(code)}&ignore=${ignore}`);
+    const data = await res.json();
+    if (!res.ok || !data.ok) {
+      alert(`Could not ${verb} ${code}: ${data.message || data.error || res.status}`);
+      if (btn) { btn.disabled = false; }
+      return;
+    }
+    await loadStatus();
+  } catch (e) {
+    alert(`Toggle failed: ${e.message}`);
+    if (btn) { btn.disabled = false; }
+  }
+}
+
 // --- Render Helpers ---
 function renderMappings(mappings) {
   const entries = Object.entries(mappings);
@@ -568,7 +590,7 @@ function renderMappings(mappings) {
   let html = `<table>
     <thead><tr>
       <th>ResQ Code</th><th>Title</th><th>Facility</th><th>SF Job #</th>
-      <th>ResQ Status</th><th>SF Status</th><th>Expenses</th><th>Last Synced</th><th>Clear</th>
+      <th>ResQ Status</th><th>SF Status</th><th>Expenses</th><th>Last Synced</th><th>Ignore</th><th>Clear</th>
     </tr></thead><tbody>`;
 
   for (const [resqId, m] of active) {
@@ -584,8 +606,13 @@ function renderMappings(mappings) {
 
     const resqLink = resqLinkHtml(resqId, m.resqCode);
     const sfLink = sfLinkHtml(m.sfJobId, m.sfJobNumber);
-    html += `<tr>
-      <td>${resqLink}</td>
+    const code = m.resqCode || resqId;
+    const ignored = !!m.ignored;
+    const ignoreBtn = ignored
+      ? `<button class="clear-btn" style="background:#059669;color:#fff;border-color:#059669" onclick="toggleIgnore('${code}', false)" title="Resume syncing this WO">↩ Unignore</button>`
+      : `<button class="clear-btn" onclick="toggleIgnore('${code}', true)" title="Skip this WO in the sync entirely">🚫 Ignore</button>`;
+    html += `<tr${ignored ? ' style="opacity:0.5"' : ''}>
+      <td>${resqLink}${ignored ? ' <span style="font-size:0.7rem;background:#6B7280;color:#fff;padding:1px 6px;border-radius:4px;">IGNORED</span>' : ''}</td>
       <td>${(m.title || '').substring(0, 50)}</td>
       <td>${m.facility || '—'}</td>
       <td>${sfLink}</td>
@@ -593,7 +620,8 @@ function renderMappings(mappings) {
       <td>${sfBadge}</td>
       <td>${expenseBtn}</td>
       <td>${synced}</td>
-      <td><button class="clear-btn" onclick="clearMapping('${m.resqCode || resqId}')">✕ Clear</button></td>
+      <td>${ignoreBtn}</td>
+      <td><button class="clear-btn" onclick="clearMapping('${code}')">✕ Clear</button></td>
     </tr>`;
   }
 


### PR DESCRIPTION
Two changes on this branch:

## 1. Dashboard Ignore toggle
Per-row **🚫 Ignore / ↩ Unignore** button on `sync.html`. Ignoring sets `mapEntry.ignored` in the blob; the reconciler and `syncSingleByCode` skip ignored WOs entirely (no status sync, no photos, no invoice, no email). Ignored rows render dimmed with an `IGNORED` badge. New authed endpoint `?ignoreWo=<code>&ignore=true|false`.

## 2. Auto-heal WOs stranded on a Cancelled SF job
A mapped WO whose linked SF job reads `Cancelled` (while still active in ResQ) was stuck — `syncBidirectional` saw "Cancelled", found nothing to change, and early-returned every pass, so the WO sat frozen on the board (R1027590: SF job cancelled, then un-cancelled, never came back).

Now, when the linked SF job is `Cancelled` and the WO isn't done in ResQ:
- **re-link** to a live (non-cancelled) SF job for the same PO if one exists (the one you un-cancelled, or a replacement); else
- flag `needsRecreate` and the reconciler drops the dead link + `processNewWO` creates a fresh SF job that same pass.

Either way the WO resumes syncing automatically.

https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu