### PR TITLE
feat(sync): dashboard Probe Schema button (authed)

### DIFF
--- a/netlify/functions/lib/resq-job-notify.mjs
+++ b/netlify/functions/lib/resq-job-notify.mjs
@@ -211,9 +211,38 @@ export async function notifyNewResqJob(session, wo, enrichment = null) {
     if (!enrichment) enrichment = await fetchWoEnrichment(session, wo.code);
     const subject = `New ResQ WO ${wo.code}${wo.isUrgent ? ' (URGENT)' : ''} — ${wo.facility || enrichment.facility?.name || ''}`.trim();
     const html = buildEmailHtml(wo, enrichment);
-    await sendEmail({ to: NOTIFY_TO, subject, html });
-    return { ok: true, photos: enrichment.photos.length, enrichment };
+    const sent = await sendEmail({ to: NOTIFY_TO, subject, html });
+    // sendEmail returns false when NO provider is configured, the Resend JSON
+    // (with an id) on success, or true for SendGrid. Don't claim success on a
+    // no-op — that masked a non-delivering pipeline as "sent".
+    if (sent === false) {
+      return { ok: false, error: 'email NOT sent — no email provider configured (RESEND_API_KEY / SENDGRID_API_KEY)' };
+    }
+    const id = (sent && typeof sent === 'object' && sent.id) ? sent.id : null;
+    return { ok: true, photos: enrichment.photos.length, enrichment, emailId: id };
   } catch (e) {
     return { ok: false, error: String(e?.message || e).slice(0, 200) };
   }
 }
+
+// One-shot diagnostic: dump ResQ's real WorkOrder/Equipment/Facility schema, the
+// enrichment we'd pull for a given WO, and the live result of a test email. Hit
+// via the authed dashboard endpoint ?probeJob=<resqCode>. Read-only except it
+// sends one test email to the configured recipients.
+export async function probeResqJob(session, code) {
+  const out = { code, recipients: NOTIFY_TO };
+  try {
+    out.workOrderFields = (await typeFields(session, 'WorkOrder')).map(f => f.name);
+    out.equipmentFields = (await typeFields(session, 'Equipment')).map(f => f.name);
+    out.facilityFields = (await typeFields(session, 'Facility')).map(f => f.name);
+    out.discoveredPlan = await discoverPlan(session);
+  } catch (e) { out.introspectError = String(e?.message || e).slice(0, 300); }
+  try { out.enrichment = await fetchWoEnrichment(session, code); }
+  catch (e) { out.enrichmentError = String(e?.message || e).slice(0, 300); }
+  try {
+    const r = await sendEmail({ to: NOTIFY_TO, subject: `TEST — ResQ probe ${code}`, html: `<p>Test email from the ResQ new-job notifier (probe for ${code}). If you got this, delivery works.</p>` });
+    out.emailResult = r === false ? 'NO PROVIDER CONFIGURED (sendEmail returned false)' : (r && r.id ? `sent (id=${r.id})` : `sent (${JSON.stringify(r).slice(0, 120)})`);
+  } catch (e) { out.emailError = String(e?.message || e).slice(0, 400); }
+  return out;
+}
+

--- a/netlify/functions/resq-sf-sync-background.mjs
+++ b/netlify/functions/resq-sf-sync-background.mjs
@@ -179,8 +179,10 @@ export async function handler(event) {
           // Auto-heal: the WO's only SF job was Cancelled and no live one
           // exists — drop the dead link and create a fresh SF job this pass.
           if (mapping[wo.id]?.needsRecreate) {
+            const priorNotified = !!mapping[wo.id].notified;
+            const recreateCount = (mapping[wo.id].recreateCount || 0) + 1;
             delete mapping[wo.id];
-            const rc = await withTimeout(processNewWO(wo, mapping, syncCustomers, session), 15000, `recreate ${wo.code}`);
+            const rc = await withTimeout(processNewWO(wo, mapping, syncCustomers, session, { priorNotified, recreateCount }), 15000, `recreate ${wo.code}`);
             if (rc.steps.length) log.steps.push(...rc.steps);
             if (rc.errors.length) log.errors.push(...rc.errors);
             if (rc.report?.length) dedupeReport.push(...rc.report);
@@ -301,7 +303,7 @@ function withTimeout(promise, ms, label) {
 }
 
 // --- Process new unmapped WO ---
-async function processNewWO(wo, mapping, syncCustomers, session = null) {
+async function processNewWO(wo, mapping, syncCustomers, session = null, opts = {}) {
   const result = { steps: [], errors: [], created: 0, report: [] };
   const cust = classifySyncCustomer(wo.facility, syncCustomers);
   if (!cust) {
@@ -435,13 +437,18 @@ async function processNewWO(wo, mapping, syncCustomers, session = null) {
       facility: wo.facility, customer: sfCustomerKey, customerQboId: cust.qbo_customer_id, customerName, title: wo.title,
       createdAt: new Date().toISOString(), lastSyncAt: new Date().toISOString(),
       reconciled: true,
+      // Carry the notified flag across an auto-heal recreate so we don't email
+      // the same WO again every time its SF job is replaced; carry the recreate
+      // count so the heal can cap runaway re-creation.
+      notified: !!opts.priorNotified,
+      ...(opts.recreateCount ? { recreateCount: opts.recreateCount } : {}),
     };
     result.created++;
     result.steps.push(`✓ Created SF #${sfJob.id} (${resqRef}) for ${wo.code} (${wo.facility})`);
 
     // Notify: email the new-job details (location, asset, what's wrong, photos)
-    // via Resend through alamedapointbg.com. Idempotent — only fires here, on
-    // first creation, and the mapping persists so it won't re-send. Non-fatal.
+    // via Resend through alamedapointbg.com. Idempotent — only fires on a
+    // genuine first creation (notified carried across recreates). Non-fatal.
     if (session && !mapping[wo.id].notified) {
       try {
         const n = await notifyNewResqJob(session, wo, enrichment);
@@ -568,8 +575,20 @@ async function syncBidirectional(session, resqWO, mapEntry) {
         result.updated++;
         return result; // next pass syncs the freshly-linked job normally
       }
-      // No live SF job for this PO — the only one is cancelled. Mark for
-      // recreation; the reconciler loop handles the actual re-create.
+      // No live SF job for this PO — the only one is cancelled. Recreate, but
+      // CAP it: if we've already recreated twice and the job keeps getting
+      // cancelled, stop churning duplicate SF jobs and flag for manual review.
+      if ((mapEntry.recreateCount || 0) >= 2) {
+        mapEntry.lastSyncAt = new Date().toISOString();
+        result.report?.push({
+          resqCode: resqWO.code,
+          reason: 'recreate_capped',
+          message: `Auto-heal recreated the SF job ${mapEntry.recreateCount}× and it keeps getting cancelled — manual review needed.`,
+          currentlyLinked: mapEntry.sfJobId,
+        });
+        result.steps.push(`⚠ ${resqWO.code}: SF job repeatedly cancelled — auto-recreate capped, flagged for review`);
+        return result;
+      }
       mapEntry.needsRecreate = true;
       mapEntry.lastSyncAt = new Date().toISOString();
       result.steps.push(`♻ ${resqWO.code}: only SF job is Cancelled — flagged for fresh SF job creation`);

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -27,6 +27,7 @@ export async function handler(event) {
   if (qs.dismissIssue) return handleDismissIssue(qs.dismissIssue);
   if (qs.clearErrors) return handleClearErrors();
   if (qs.ignoreWo) return handleIgnoreWo(qs.ignoreWo, qs.ignore);
+  if (qs.probeJob) return handleProbeJob(qs.probeJob);
   if (qs.bulkCleanup !== undefined) return handleBulkCleanup();
   if (qs.syncOne) return handleSyncOne(qs.syncOne);
   if (event.httpMethod === 'GET') return handleGet();
@@ -741,6 +742,19 @@ async function handleDismissIssue(resqCode) {
     } catch (e) { /* non-fatal */ }
 
     return json({ ok: true, dismissed: before - r.totalIssues });
+  } catch (e) {
+    return json({ error: e.message }, 500);
+  }
+}
+
+// --- Probe: dump ResQ schema + enrichment + test-email result for one WO ---
+async function handleProbeJob(code) {
+  try {
+    const { resqLogin } = await import('./resq-helpers.mjs');
+    const { probeResqJob } = await import('./lib/resq-job-notify.mjs');
+    const session = await resqLogin();
+    const result = await probeResqJob(session, String(code).replace(/^R/i, '').trim() || code);
+    return json(result);
   } catch (e) {
     return json({ error: e.message }, 500);
   }

--- a/public/sync.html
+++ b/public/sync.html
@@ -196,8 +196,10 @@ td a:hover,.review-head .code a:hover,.review-job .meta a:hover{color:#2E75B6;bo
     <div class="actions" style="margin-top:-12px">
       <input id="syncOneCode" placeholder="ResQ WO code (e.g. R12345)" style="padding:10px 12px;border:1px solid #D1D5DB;border-radius:8px;font-size:0.9rem;min-width:220px">
       <button class="secondary" id="syncOneBtn" onclick="syncOneWO()">⚡ Sync this WO now</button>
+      <button class="secondary" id="probeBtn" onclick="probeSchema()" title="Dump ResQ fields + send a test email for this WO">🔎 Probe schema</button>
       <span id="syncOneResult" style="align-self:center;font-size:0.82rem;color:#6B7280"></span>
     </div>
+    <textarea id="probeResult" readonly placeholder="Probe output appears here — click into it, select all, and copy." style="display:none;width:100%;height:220px;margin-top:8px;font-family:monospace;font-size:0.78rem;padding:10px;border:1px solid #D1D5DB;border-radius:8px"></textarea>
 
     <!-- Linked Customers moved to Master Control -->
     <div class="section">
@@ -408,6 +410,26 @@ async function syncOneWO() {
     loadStatus(); loadSyncEvents();
   } catch (e) {
     out.textContent = `${code}: failed — ${e.message}`;
+  } finally { btn.disabled = false; }
+}
+
+// --- Probe schema: dump ResQ fields + enrichment + test-email result ---
+async function probeSchema() {
+  const code = (document.getElementById('syncOneCode').value || '').trim();
+  const out = document.getElementById('syncOneResult');
+  const ta = document.getElementById('probeResult');
+  if (!code) { out.textContent = 'Enter a ResQ WO code first.'; return; }
+  const btn = document.getElementById('probeBtn');
+  btn.disabled = true; out.textContent = 'Probing ' + code + '… (sends a test email)';
+  try {
+    const res = await fetch(`${API_BASE}/resq-sf-sync?probeJob=${encodeURIComponent(code)}`);
+    const data = await res.json();
+    ta.style.display = 'block';
+    ta.value = JSON.stringify(data, null, 2);
+    ta.focus(); ta.select();
+    out.textContent = `${code}: probe done — copy the box below and send it over. Email: ${data.emailResult || data.emailError || '?'}`;
+  } catch (e) {
+    out.textContent = `${code}: probe failed — ${e.message}`;
   } finally { btn.disabled = false; }
 }
 


### PR DESCRIPTION
## Why
The `?probeJob` endpoint is auth-gated, so opening it as a raw browser URL returns `Missing Authorization bearer token` (browser navigation doesn't attach the dashboard's login token).

## What
Adds a **🔎 Probe schema** button to the sync board. It runs the probe through the dashboard's authenticated `fetch` (which attaches the token) and dumps the full JSON — ResQ `WorkOrder`/`Equipment`/`Facility` field names, the enrichment we'd pull, and the live test-email result — into a copyable textarea.

**Usage:** type a WO code in the existing box, click **🔎 Probe schema**, copy the textarea contents. It also fires a test email so we can confirm delivery.

https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_