### PR TITLE
feat(sync): Email this WO button to re-send the new-job notification

### DIFF
--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -28,6 +28,7 @@ export async function handler(event) {
   if (qs.clearErrors) return handleClearErrors();
   if (qs.ignoreWo) return handleIgnoreWo(qs.ignoreWo, qs.ignore);
   if (qs.probeJob) return handleProbeJob(qs.probeJob);
+  if (qs.notifyJob) return handleNotifyJob(qs.notifyJob);
   if (qs.bulkCleanup !== undefined) return handleBulkCleanup();
   if (qs.syncOne) return handleSyncOne(qs.syncOne);
   if (event.httpMethod === 'GET') return handleGet();
@@ -755,6 +756,38 @@ async function handleProbeJob(code) {
     const session = await resqLogin();
     const result = await probeResqJob(session, String(code).replace(/^R/i, '').trim() || code);
     return json(result);
+  } catch (e) {
+    return json({ error: e.message }, 500);
+  }
+}
+
+// --- Send the new-job notification email for one WO on demand (re-send) ---
+async function handleNotifyJob(code) {
+  try {
+    const { resqLogin, resqGql } = await import('./resq-helpers.mjs');
+    const { notifyNewResqJob } = await import('./lib/resq-job-notify.mjs');
+    const c = String(code).replace(/^R/i, '').trim() || code;
+    // Pull the WO's base fields (vendor login; fall back to facility for
+    // WOs not assigned to Brix). Build the `wo` shape notifyNewResqJob expects.
+    const Q = `{ workOrders(first:1, code:"${c}") { edges { node {
+      code title description status isUrgent serviceCategory
+      facility { name } equipment { name }
+    } } } }`;
+    const grab = async (sess) => (await resqGql(sess, Q)).data?.workOrders?.edges?.[0]?.node || null;
+    const vendor = await resqLogin();
+    let node = await grab(vendor);
+    let session = vendor;
+    if (!node) {
+      try { const fac = await resqLogin({ facility: true }); const fnode = await grab(fac); if (fnode) { node = fnode; session = fac; } } catch {}
+    }
+    if (!node) return json({ error: `WO ${code} not found (vendor or facility login)` }, 404);
+    const wo = {
+      code: node.code, title: node.title || '', description: node.description || '',
+      status: node.status, isUrgent: !!node.isUrgent, serviceCategory: node.serviceCategory || '',
+      facility: node.facility?.name || '', equipment: node.equipment?.name || '',
+    };
+    const r = await notifyNewResqJob(session, wo);
+    return json(r, r.ok ? 200 : 500);
   } catch (e) {
     return json({ error: e.message }, 500);
   }

--- a/public/sync.html
+++ b/public/sync.html
@@ -197,6 +197,7 @@ td a:hover,.review-head .code a:hover,.review-job .meta a:hover{color:#2E75B6;bo
       <input id="syncOneCode" placeholder="ResQ WO code (e.g. R12345)" style="padding:10px 12px;border:1px solid #D1D5DB;border-radius:8px;font-size:0.9rem;min-width:220px">
       <button class="secondary" id="syncOneBtn" onclick="syncOneWO()">⚡ Sync this WO now</button>
       <button class="secondary" id="probeBtn" onclick="probeSchema()" title="Dump ResQ fields + send a test email for this WO">🔎 Probe schema</button>
+      <button class="secondary" id="emailWoBtn" onclick="emailWo()" title="Send the new-job notification email for this WO now">📧 Email this WO</button>
       <span id="syncOneResult" style="align-self:center;font-size:0.82rem;color:#6B7280"></span>
     </div>
     <textarea id="probeResult" readonly placeholder="Probe output appears here — click into it, select all, and copy." style="display:none;width:100%;height:220px;margin-top:8px;font-family:monospace;font-size:0.78rem;padding:10px;border:1px solid #D1D5DB;border-radius:8px"></textarea>
@@ -430,6 +431,23 @@ async function probeSchema() {
     out.textContent = `${code}: probe done — copy the box below and send it over. Email: ${data.emailResult || data.emailError || '?'}`;
   } catch (e) {
     out.textContent = `${code}: probe failed — ${e.message}`;
+  } finally { btn.disabled = false; }
+}
+
+// --- Email this WO: re-send the new-job notification email now ---
+async function emailWo() {
+  const code = (document.getElementById('syncOneCode').value || '').trim();
+  const out = document.getElementById('syncOneResult');
+  if (!code) { out.textContent = 'Enter a ResQ WO code first.'; return; }
+  const btn = document.getElementById('emailWoBtn');
+  btn.disabled = true; out.textContent = 'Emailing ' + code + '…';
+  try {
+    const res = await fetch(`${API_BASE}/resq-sf-sync?notifyJob=${encodeURIComponent(code)}`);
+    const data = await res.json();
+    if (!res.ok || !data.ok) throw new Error(data.error || `HTTP ${res.status}`);
+    out.textContent = `${code}: email sent (${data.photos || 0} photo(s))${data.emailId ? ' id=' + data.emailId : ''}`;
+  } catch (e) {
+    out.textContent = `${code}: email failed — ${e.message}`;
   } finally { btn.disabled = false; }
 }
 


### PR DESCRIPTION
## What
Adds a way to re-send the new-job notification email on demand, so you can see the full data plate now without waiting for a fresh WO.

- New authed endpoint `?notifyJob=<resqCode>` — pulls the WO base fields (vendor login, facility fallback) and fires the real `notifyNewResqJob` email.
- New **📧 Email this WO** dashboard button next to Probe — enter a WO code, click, and the email goes to skypace@brixbev.com + whitney@alamedasoda.com with Make / Model / Serial / Asset # / Warranty + street address + photos.

## Usage
Use a **real Brix WO** code (so the vendor login can see the asset data). The button shows the photo count + Resend id on success.

https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_