### PR TITLE
chore(sync): probe equipment/asset photo field (data-plate image)

### DIFF
--- a/netlify/functions/lib/resq-job-notify.mjs
+++ b/netlify/functions/lib/resq-job-notify.mjs
@@ -264,8 +264,15 @@ export async function probeResqJob(session, code) {
     }
   };
   out.fieldCheck = {};
-  for (const f of ['modelNo', 'model', 'warrantyExpiry', 'warrantyNotes']) {
-    out.fieldCheck[`equipment.${f}`] = await tryQ(`equipment { ${f} }`);
+  // Hunt the EQUIPMENT/asset photo field (the data-plate / serial photo lives on
+  // the asset, not the WO — R0994830's WO images were empty). 'ok' = field valid.
+  const photoSels = [
+    'images { url }', 'photos { url }', 'pictures { url }', 'attachments { url }',
+    'media { url }', 'image', 'imageUrl', 'photoUrl', 'photoUrls', 'imageUrls',
+    'thumbnailUrl', 'avatarUrl', 'attachments { edges { node { url } } }',
+  ];
+  for (const sel of photoSels) {
+    out.fieldCheck[`equipment{${sel}}`] = await tryQ(`equipment { ${sel} }`);
   }
   return out;
 }


### PR DESCRIPTION
## Why
R0994830 emailed with all the asset text but **no photos** — its WO-level `images` field is empty. The data-plate / serial photo the user needs lives on the **equipment/asset**, under a field we haven't identified.

## What
Repoints the slim probe's `fieldCheck` to test **equipment photo field** candidates: `equipment { images { url } }`, `photos`, `pictures`, `attachments`, `media`, plus scalar `imageUrl`/`photoUrl`/`thumbnailUrl` and a connection shape. `ok` = the field exists on the asset.

## Next
Probe a WO whose asset has a data-plate photo; whichever `equipment{…}` candidate returns `ok` is the field. Then I wire it into the scan + email so the asset photo arrives on the notifications.

https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_