### PR TITLE
feat(sync): pull ResQ asset photos + reliable scan-based enrichment

### DIFF
--- a/netlify/functions/lib/resq-job-notify.mjs
+++ b/netlify/functions/lib/resq-job-notify.mjs
@@ -264,8 +264,15 @@ export async function probeResqJob(session, code) {
     }
   };
   out.fieldCheck = {};
-  for (const f of ['modelNo', 'model', 'warrantyExpiry', 'warrantyNotes']) {
-    out.fieldCheck[`equipment.${f}`] = await tryQ(`equipment { ${f} }`);
+  // Hunt the EQUIPMENT/asset photo field (the data-plate / serial photo lives on
+  // the asset, not the WO — R0994830's WO images were empty). 'ok' = field valid.
+  const photoSels = [
+    'images { url }', 'photos { url }', 'pictures { url }', 'attachments { url }',
+    'media { url }', 'image', 'imageUrl', 'photoUrl', 'photoUrls', 'imageUrls',
+    'thumbnailUrl', 'avatarUrl', 'attachments { edges { node { url } } }',
+  ];
+  for (const sel of photoSels) {
+    out.fieldCheck[`equipment{${sel}}`] = await tryQ(`equipment { ${sel} }`);
   }
   return out;
 }

--- a/netlify/functions/lib/resq-job-notify.mjs
+++ b/netlify/functions/lib/resq-job-notify.mjs
@@ -103,47 +103,52 @@ function discoverPlan(session) {
   return _planPromise;
 }
 
-// Build + run the enrichment query for one WO code, using only fields ResQ
-// confirmed it has. Returns { photos:[{url,label}], equipment:{}, facility:{} }.
-// Fields confirmed to exist by direct probing (ResQ introspection is disabled).
-// Equipment: name, manufacturer (= make), description, serialNo, code. Facility:
-// address (street), addressLine2, zipCode. Photos: images { url } (plain list).
-// Model lives in name/description (no discrete model field is exposed).
-const WO_ENRICH_QUERY = (code) => `{
-  workOrders(first: 1, code: "${code}") {
+// Enrichment fields confirmed by direct probing (ResQ introspection is off):
+//   equipment: name, manufacturer (=make), modelNo, description, serialNo, code,
+//              warrantyNotes, photos { url } (asset data-plate images), image
+//   facility:  address (street), addressLine2, zipCode
+//   WO images: images { url }
+// We SCAN the recent WO list (no code filter — ResQ's code filter is unreliable
+// and returns empty even for visible WOs; that's why the old code-filter lookup
+// produced empty enrichment) and match the WO by code.
+const WO_ENRICH_SCAN = `{
+  workOrders(first: 500, orderBy: "-raised_on") {
     edges { node {
-      equipment { id name manufacturer modelNo description serialNo code warrantyNotes }
+      code
+      equipment { id name manufacturer modelNo description serialNo code warrantyNotes image photos { url } }
       facility { id name address addressLine2 zipCode }
       images { url }
     } }
   }
 }`;
 
+const isHttpUrl = (u) => u && /^https?:\/\//i.test(String(u));
+
 export async function fetchWoEnrichment(session, code) {
-  const out = { photos: [], equipment: {}, facility: {} };
+  const out = { photos: [], assetPhotos: [], equipment: {}, facility: {} };
+  const want = String(code).replace(/^R/i, '').trim();
   const run = async (sess) => {
-    const d = await resqGql(sess, WO_ENRICH_QUERY(code));
-    return d.data?.workOrders?.edges?.[0]?.node || null;
+    const d = await resqGql(sess, WO_ENRICH_SCAN);
+    const edges = d.data?.workOrders?.edges || [];
+    return edges.find(e => String(e.node.code || '').replace(/^R/i, '') === want)?.node || null;
   };
   let node = null;
   try { node = await run(session); } catch { /* ignore */ }
-  // The WO/asset detail may not be visible to the Brix VENDOR login (WO not
-  // assigned to Brix, or asset specs are facility-private). Fall back to the
-  // FACILITY login, which can see the facility's assets.
-  const lacks = !node || (!node.equipment?.manufacturer && !node.equipment?.serialNo);
-  if (lacks) {
-    try {
-      const fac = await resqLogin({ facility: true });
-      const fnode = await run(fac);
-      if (fnode && (fnode.equipment?.manufacturer || fnode.equipment?.serialNo || !node)) node = fnode;
-    } catch { /* keep whatever the vendor login returned */ }
+  // Fall back to the FACILITY login if the vendor login can't see the WO/asset.
+  if (!node) {
+    try { const fac = await resqLogin({ facility: true }); node = await run(fac); } catch { /* keep null */ }
   }
   if (node) {
     out.equipment = node.equipment || {};
     out.facility = node.facility || {};
-    out.photos = (node.images || [])
-      .map(it => ({ url: it?.url, label: null }))
-      .filter(p => p.url && /^https?:\/\//i.test(String(p.url)));
+    // Asset/equipment photos (the data-plate / serial images) first, then any
+    // WO-level photos. `image` is a single primary thumbnail.
+    const asset = [];
+    if (isHttpUrl(node.equipment?.image)) asset.push({ url: node.equipment.image, label: 'Asset' });
+    for (const p of (node.equipment?.photos || [])) if (isHttpUrl(p?.url)) asset.push({ url: p.url, label: 'Asset' });
+    const woPhotos = (node.images || []).filter(p => isHttpUrl(p?.url)).map(p => ({ url: p.url, label: null }));
+    out.assetPhotos = asset;
+    out.photos = [...asset, ...woPhotos];
   }
   return out;
 }

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -773,7 +773,7 @@ async function handleNotifyJob(code) {
     const SCAN = `{ workOrders(first: 500, orderBy: "-raised_on") { edges { node {
       code title description status isUrgent serviceCategory
       facility { id name address addressLine2 zipCode }
-      equipment { id name manufacturer modelNo description serialNo code warrantyNotes }
+      equipment { id name manufacturer modelNo description serialNo code warrantyNotes image photos { url } }
       images { url }
     } } } }`;
     const findNode = async (sess) => {
@@ -793,12 +793,18 @@ async function handleNotifyJob(code) {
       status: node.status, isUrgent: !!node.isUrgent, serviceCategory: node.serviceCategory || '',
       facility: node.facility?.name || '', equipment: node.equipment?.name || '',
     };
-    // Build enrichment straight from the scanned node and pass it in (skips the
-    // code-filtered re-fetch inside notifyNewResqJob).
+    // Build enrichment straight from the scanned node — asset/equipment photos
+    // (data plate) first, then WO-level photos.
+    const isHttp = (u) => u && /^https?:\/\//i.test(String(u));
+    const asset = [];
+    if (isHttp(node.equipment?.image)) asset.push({ url: node.equipment.image, label: 'Asset' });
+    for (const p of (node.equipment?.photos || [])) if (isHttp(p?.url)) asset.push({ url: p.url, label: 'Asset' });
+    const woPhotos = (node.images || []).filter(p => isHttp(p?.url)).map(p => ({ url: p.url, label: null }));
     const enrichment = {
       equipment: node.equipment || {},
       facility: node.facility || {},
-      photos: (node.images || []).map(it => ({ url: it?.url, label: null })).filter(p => p.url && /^https?:\/\//i.test(String(p.url))),
+      assetPhotos: asset,
+      photos: [...asset, ...woPhotos],
     };
     const r = await notifyNewResqJob(session, wo, enrichment);
     return json(r, r.ok ? 200 : 500);


### PR DESCRIPTION
## What
The probe confirmed the asset data-plate photos live at **`equipment.photos { url }`** (a list), plus a single `equipment.image` thumbnail — not on the work order (the WO's own `images` is empty for jobs like R0994830).

Two fixes:

1. **Pull asset photos** — enrichment + email now include `equipment.photos` and `equipment.image`. Asset photos render first in the PHOTOS block, then any WO-level photos.

2. **Scan-based enrichment (fixes the empty-data bug)** — `fetchWoEnrichment` now SCANs the recent WO list and matches by code, instead of ResQ's `code` filter, which returns empty even for visible WOs. That filter is why `sampleValues` was blank and why the *automatic* new-job emails were coming through without asset data. Both the auto-email and the on-demand "Email this WO" now reliably pull make / model / serial / asset # / warranty + street address + asset photos.

## Verify
Click 📧 Email this WO on R0994830 (or any completed Brix WO whose asset has a data-plate photo) — the email should now include the asset photo(s).

https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_