### PR TITLE
feat(sync): re-host ResQ photos so they render inline in the email

### DIFF
--- a/netlify/functions/lib/resq-job-notify.mjs
+++ b/netlify/functions/lib/resq-job-notify.mjs
@@ -11,6 +11,31 @@
 
 import { resqGql, resqLogin } from '../resq-helpers.mjs';
 import { sendEmail } from '../email-helpers.mjs';
+import { uploadToRelay } from './sf-assets.mjs';
+
+// ResQ photo URLs are short-lived signed S3 links (temporary AWS token, fast
+// expiry) — so inline <img> often fails to render once the email is opened
+// (Gmail proxies images and the signed URL has expired). Re-host each photo in
+// our public Storage bucket at send time and embed the stable public URL.
+// Best-effort: on any failure, fall back to the original signed URL.
+async function relayPhotosForEmail(photos) {
+  const out = [];
+  for (const p of (photos || [])) {
+    let publicUrl = null;
+    try {
+      const res = await fetch(p.url);
+      if (res.ok) {
+        const ct = res.headers.get('content-type') || 'image/jpeg';
+        const buf = Buffer.from(await res.arrayBuffer());
+        const ext = (ct.split('/')[1] || 'jpg').replace('jpeg', 'jpg').replace(/[^a-z0-9]/gi, '') || 'jpg';
+        const token = Math.random().toString(36).slice(2, 10);
+        publicUrl = await uploadToRelay(`email/${token}.${ext}`, buf, ct);
+      }
+    } catch { /* keep original */ }
+    out.push({ url: publicUrl || p.url, label: p.label });
+  }
+  return out;
+}
 
 // Recipients for the new-job alert. Defaults to both ops owners; override with
 // a comma-separated RESQ_JOB_NOTIFY_TO env var.
@@ -190,8 +215,11 @@ function buildEmailHtml(wo, enrichment) {
 
   const photoHtml = photos.length
     ? `<p style="font-size:13px;font-weight:600;color:#1F4E79;margin:20px 0 8px;">PHOTOS (${photos.length})</p>
-       <div>${photos.map(p => `<a href="${esc(p.url)}" style="text-decoration:none;"><img src="${esc(p.url)}" alt="${esc(p.label || 'photo')}" style="max-width:260px;max-height:200px;border-radius:6px;border:1px solid #e2e6ed;margin:0 8px 8px 0;display:inline-block;"></a>`).join('')}</div>
-       <p style="font-size:11px;color:#9ca3af;">If images don't load, click one to open it in ResQ.</p>`
+       <div>${photos.map((p, i) => `<div style="display:inline-block;margin:0 10px 12px 0;vertical-align:top;text-align:center;">
+         <a href="${esc(p.url)}" style="text-decoration:none;"><img src="${esc(p.url)}" alt="${esc(p.label || 'photo')}" style="max-width:260px;max-height:200px;border-radius:6px;border:1px solid #e2e6ed;display:block;"></a>
+         <a href="${esc(p.url)}" style="font-size:11px;color:#1F4E79;">${esc(p.label || 'Photo')} ${i + 1} — open ↗</a>
+       </div>`).join('')}</div>
+       <p style="font-size:11px;color:#9ca3af;">If an image doesn't show, click the link beneath it to open the full photo.</p>`
     : `<p style="font-size:12px;color:#9ca3af;margin:16px 0 0;">No photos attached to this ResQ WO.</p>`;
 
   return `
@@ -228,6 +256,10 @@ function buildEmailHtml(wo, enrichment) {
 export async function notifyNewResqJob(session, wo, enrichment = null) {
   try {
     if (!enrichment) enrichment = await fetchWoEnrichment(session, wo.code);
+    // Re-host photos to stable public URLs so they render inline in the email.
+    if (enrichment.photos?.length) {
+      enrichment = { ...enrichment, photos: await relayPhotosForEmail(enrichment.photos) };
+    }
     const subject = `New ResQ WO ${wo.code}${wo.isUrgent ? ' (URGENT)' : ''} — ${wo.facility || enrichment.facility?.name || ''}`.trim();
     const html = buildEmailHtml(wo, enrichment);
     const sent = await sendEmail({ to: NOTIFY_TO, subject, html });

--- a/netlify/functions/lib/resq-job-notify.mjs
+++ b/netlify/functions/lib/resq-job-notify.mjs
@@ -264,8 +264,15 @@ export async function probeResqJob(session, code) {
     }
   };
   out.fieldCheck = {};
-  for (const f of ['modelNo', 'model', 'warrantyExpiry', 'warrantyNotes']) {
-    out.fieldCheck[`equipment.${f}`] = await tryQ(`equipment { ${f} }`);
+  // Hunt the EQUIPMENT/asset photo field (the data-plate / serial photo lives on
+  // the asset, not the WO — R0994830's WO images were empty). 'ok' = field valid.
+  const photoSels = [
+    'images { url }', 'photos { url }', 'pictures { url }', 'attachments { url }',
+    'media { url }', 'image', 'imageUrl', 'photoUrl', 'photoUrls', 'imageUrls',
+    'thumbnailUrl', 'avatarUrl', 'attachments { edges { node { url } } }',
+  ];
+  for (const sel of photoSels) {
+    out.fieldCheck[`equipment{${sel}}`] = await tryQ(`equipment { ${sel} }`);
   }
   return out;
 }

--- a/netlify/functions/lib/resq-job-notify.mjs
+++ b/netlify/functions/lib/resq-job-notify.mjs
@@ -103,47 +103,52 @@ function discoverPlan(session) {
   return _planPromise;
 }
 
-// Build + run the enrichment query for one WO code, using only fields ResQ
-// confirmed it has. Returns { photos:[{url,label}], equipment:{}, facility:{} }.
-// Fields confirmed to exist by direct probing (ResQ introspection is disabled).
-// Equipment: name, manufacturer (= make), description, serialNo, code. Facility:
-// address (street), addressLine2, zipCode. Photos: images { url } (plain list).
-// Model lives in name/description (no discrete model field is exposed).
-const WO_ENRICH_QUERY = (code) => `{
-  workOrders(first: 1, code: "${code}") {
+// Enrichment fields confirmed by direct probing (ResQ introspection is off):
+//   equipment: name, manufacturer (=make), modelNo, description, serialNo, code,
+//              warrantyNotes, photos { url } (asset data-plate images), image
+//   facility:  address (street), addressLine2, zipCode
+//   WO images: images { url }
+// We SCAN the recent WO list (no code filter — ResQ's code filter is unreliable
+// and returns empty even for visible WOs; that's why the old code-filter lookup
+// produced empty enrichment) and match the WO by code.
+const WO_ENRICH_SCAN = `{
+  workOrders(first: 500, orderBy: "-raised_on") {
     edges { node {
-      equipment { id name manufacturer modelNo description serialNo code warrantyNotes }
+      code
+      equipment { id name manufacturer modelNo description serialNo code warrantyNotes image photos { url } }
       facility { id name address addressLine2 zipCode }
       images { url }
     } }
   }
 }`;
 
+const isHttpUrl = (u) => u && /^https?:\/\//i.test(String(u));
+
 export async function fetchWoEnrichment(session, code) {
-  const out = { photos: [], equipment: {}, facility: {} };
+  const out = { photos: [], assetPhotos: [], equipment: {}, facility: {} };
+  const want = String(code).replace(/^R/i, '').trim();
   const run = async (sess) => {
-    const d = await resqGql(sess, WO_ENRICH_QUERY(code));
-    return d.data?.workOrders?.edges?.[0]?.node || null;
+    const d = await resqGql(sess, WO_ENRICH_SCAN);
+    const edges = d.data?.workOrders?.edges || [];
+    return edges.find(e => String(e.node.code || '').replace(/^R/i, '') === want)?.node || null;
   };
   let node = null;
   try { node = await run(session); } catch { /* ignore */ }
-  // The WO/asset detail may not be visible to the Brix VENDOR login (WO not
-  // assigned to Brix, or asset specs are facility-private). Fall back to the
-  // FACILITY login, which can see the facility's assets.
-  const lacks = !node || (!node.equipment?.manufacturer && !node.equipment?.serialNo);
-  if (lacks) {
-    try {
-      const fac = await resqLogin({ facility: true });
-      const fnode = await run(fac);
-      if (fnode && (fnode.equipment?.manufacturer || fnode.equipment?.serialNo || !node)) node = fnode;
-    } catch { /* keep whatever the vendor login returned */ }
+  // Fall back to the FACILITY login if the vendor login can't see the WO/asset.
+  if (!node) {
+    try { const fac = await resqLogin({ facility: true }); node = await run(fac); } catch { /* keep null */ }
   }
   if (node) {
     out.equipment = node.equipment || {};
     out.facility = node.facility || {};
-    out.photos = (node.images || [])
-      .map(it => ({ url: it?.url, label: null }))
-      .filter(p => p.url && /^https?:\/\//i.test(String(p.url)));
+    // Asset/equipment photos (the data-plate / serial images) first, then any
+    // WO-level photos. `image` is a single primary thumbnail.
+    const asset = [];
+    if (isHttpUrl(node.equipment?.image)) asset.push({ url: node.equipment.image, label: 'Asset' });
+    for (const p of (node.equipment?.photos || [])) if (isHttpUrl(p?.url)) asset.push({ url: p.url, label: 'Asset' });
+    const woPhotos = (node.images || []).filter(p => isHttpUrl(p?.url)).map(p => ({ url: p.url, label: null }));
+    out.assetPhotos = asset;
+    out.photos = [...asset, ...woPhotos];
   }
   return out;
 }

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -773,7 +773,7 @@ async function handleNotifyJob(code) {
     const SCAN = `{ workOrders(first: 500, orderBy: "-raised_on") { edges { node {
       code title description status isUrgent serviceCategory
       facility { id name address addressLine2 zipCode }
-      equipment { id name manufacturer modelNo description serialNo code warrantyNotes }
+      equipment { id name manufacturer modelNo description serialNo code warrantyNotes image photos { url } }
       images { url }
     } } } }`;
     const findNode = async (sess) => {
@@ -793,12 +793,18 @@ async function handleNotifyJob(code) {
       status: node.status, isUrgent: !!node.isUrgent, serviceCategory: node.serviceCategory || '',
       facility: node.facility?.name || '', equipment: node.equipment?.name || '',
     };
-    // Build enrichment straight from the scanned node and pass it in (skips the
-    // code-filtered re-fetch inside notifyNewResqJob).
+    // Build enrichment straight from the scanned node — asset/equipment photos
+    // (data plate) first, then WO-level photos.
+    const isHttp = (u) => u && /^https?:\/\//i.test(String(u));
+    const asset = [];
+    if (isHttp(node.equipment?.image)) asset.push({ url: node.equipment.image, label: 'Asset' });
+    for (const p of (node.equipment?.photos || [])) if (isHttp(p?.url)) asset.push({ url: p.url, label: 'Asset' });
+    const woPhotos = (node.images || []).filter(p => isHttp(p?.url)).map(p => ({ url: p.url, label: null }));
     const enrichment = {
       equipment: node.equipment || {},
       facility: node.facility || {},
-      photos: (node.images || []).map(it => ({ url: it?.url, label: null })).filter(p => p.url && /^https?:\/\//i.test(String(p.url))),
+      assetPhotos: asset,
+      photos: [...asset, ...woPhotos],
     };
     const r = await notifyNewResqJob(session, wo, enrichment);
     return json(r, r.ok ? 200 : 500);


### PR DESCRIPTION
## Why
The email shows a **link** to the photo but the **inline image doesn't render**. Cause: ResQ's photo URLs are short-lived **signed S3 links** (temporary AWS token, fast expiry). By the time the email is opened — especially through Gmail's image proxy — the signature has expired, so `<img>` can't load; only an immediate click worked.

## Fix
At send time, **fetch each photo's bytes and re-host them in our public `resq-photo-relay` bucket** (the same relay used SF→ResQ), then embed the **stable public URL**. It doesn't expire, so the image renders inline reliably. Each photo now shows **inline AND** has an explicit "open ↗" link beneath it. Best-effort — falls back to the original signed URL if the re-host fails.

## Verify
📧 Email this WO on a WO with asset photos — the images should now display inline in the email body, with a link under each.

https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_