### PR TITLE
qbo-reconcile: daily backstop cron + emailed report

### DIFF
--- a/architecture/sync-manifest.json
+++ b/architecture/sync-manifest.json
@@ -13,7 +13,7 @@
       "writes": ["ops.qbo_invoices", "ops.qbo_invoice_lines", "ops.qbo_token_cache", "ops.sync_log"],
       "multi_writer": true,
       "external_inputs": ["QuickBooks Online API (active invoice IDs by window)"],
-      "notes": "Source at supabase/functions/qbo-reconcile/. PRUNES mirror invoices QBO no longer returns (deleted in QBO) so they stop ghosting in brix-order. Guarded: dry-run by default (mode=prune to delete), requires INTERNAL_PAY_SECRET, per-type 0-result guard, and a global max_prune cap. Complements qbo-webhook's Delete-event branch for instant pruning.",
+      "notes": "Source at supabase/functions/qbo-reconcile/. PRUNES mirror invoices QBO no longer returns (deleted in QBO) so they stop ghosting in brix-order. Guarded: dry-run by default (mode=prune to delete), prune requires INTERNAL_PAY_SECRET OR a service-role bearer, per-type 0-result guard, global max_prune cap, paginated mirror read. Emails a Resend report (RECONCILE_REPORT_TO/_FROM) only when it prunes or aborts. Daily backstop cron 'qbo-reconcile-daily' (09:20 UTC, 150-day window) is created DISABLED until INTERNAL_PAY_SECRET is dropped into its header. Complements qbo-webhook's real-time Delete-event prune.",
       "last_verified": "2026-06-10"
     },
     {

--- a/supabase/functions/qbo-reconcile/index.ts
+++ b/supabase/functions/qbo-reconcile/index.ts
@@ -53,6 +53,22 @@ function sleep(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
 function reqId(): string { return crypto.randomUUID().replace(/-/g, "").slice(0, 32); }
 function pad(n: number) { return String(n).padStart(2, "0"); }
 
+// Email a report via Resend (only called "if needed" — on prune or abort).
+async function sendReport(subject: string, html: string) {
+  const key = Deno.env.get("RESEND_API_KEY") || "";
+  if (!key) return;
+  const to = (Deno.env.get("RECONCILE_REPORT_TO") || "skypace@brixbev.com").split(",").map((s) => s.trim()).filter(Boolean);
+  const from = Deno.env.get("RECONCILE_REPORT_FROM") || "Brix Alerts <alerts@alamedapointbg.com>";
+  try {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: { Authorization: "Bearer " + key, "Content-Type": "application/json" },
+      body: JSON.stringify({ from, to, subject, html }),
+    });
+    if (!res.ok) console.error("reconcile email " + res.status + ": " + (await res.text()).slice(0, 200));
+  } catch (e) { console.error("reconcile email failed: " + (e as Error).message); }
+}
+
 async function claimRefresh(sb: SupabaseClient): Promise<any> {
   const { data, error } = await sb.rpc("qbo_token_claim_refresh", {
     p_realm_id: getRealm(), p_min_ttl_seconds: REFRESH_MIN_REMAINING_SECONDS, p_lease_seconds: LEASE_SECONDS,
@@ -139,9 +155,10 @@ Deno.serve(async (req: Request) => {
     // Read-only dry-run is open; the destructive prune requires the secret.
     if (prune) {
       const secret = Deno.env.get("INTERNAL_PAY_SECRET") || "";
-      if (!secret || req.headers.get("x-internal-secret") !== secret) {
-        return jsonRes({ ok: false, error: "unauthorized (prune requires x-internal-secret)" }, 401);
-      }
+      const svc = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
+      const bearer = (req.headers.get("authorization") || "").replace(/^Bearer\s+/i, "");
+      const authed = (secret && req.headers.get("x-internal-secret") === secret) || (svc && bearer === svc);
+      if (!authed) return jsonRes({ ok: false, error: "unauthorized (prune requires x-internal-secret or service-role bearer)" }, 401);
     }
     const now = new Date();
     const defStart = new Date(now.getTime() - 120 * 24 * 3600 * 1000);
@@ -184,6 +201,14 @@ Deno.serve(async (req: Request) => {
     const totalGhosts = ghostBigintIds.length;
     // Global safety cap — a real delete batch is tiny; a huge count means a bug.
     if (totalGhosts > maxPrune) {
+      if (prune) {
+        await sendReport(
+          "⚠ Brix reconcile ABORTED — " + totalGhosts + " ghosts exceed cap (" + maxPrune + ")",
+          `<p>The mirror reconcile found <b>${totalGhosts}</b> invoices in the portal mirror that QBO no longer returns for ${start} → ${end}, exceeding the safety cap of ${maxPrune}.</p>` +
+          `<p><b>Nothing was pruned.</b> A batch this large usually means a QBO read problem, not real deletions — please investigate before pruning manually.</p>` +
+          `<p>Sample: ${ghostDocs.slice(0, 20).join(", ")}</p>`,
+        );
+      }
       return jsonRes({
         ok: false, aborted: true, reason: "ghost count " + totalGhosts + " exceeds max_prune " + maxPrune + " — not pruning",
         window: { start, end }, per_type: perType, sample: ghostDocs.slice(0, 20), duration_ms: Date.now() - startedAt,
@@ -200,6 +225,13 @@ Deno.serve(async (req: Request) => {
         source: "qbo", sync_type: "reconcile", status: "success", records_synced: pruned,
         completed_at: new Date().toISOString(), metadata: { window: { start, end }, per_type: perType, docs: ghostDocs.slice(0, 50) },
       });
+      // Report only when something was actually pruned ("if needed").
+      await sendReport(
+        "Brix mirror reconcile — pruned " + pruned + " ghost invoice(s)",
+        `<p>Removed <b>${pruned}</b> invoice(s) that were deleted in QuickBooks but still showed in the customer portal (window ${start} → ${end}).</p>` +
+        `<p>Per type: ${Object.entries(perType).map(([t, v]: any) => `${t} ${v.ghosts}/${v.mirror}`).join(", ")}</p>` +
+        `<ul>${ghostDocs.slice(0, 50).map((d) => "<li>" + d + "</li>").join("")}</ul>`,
+      );
     }
 
     return jsonRes({


### PR DESCRIPTION
## Daily reconcile cron + emailed report

Builds on the prune work (#217): adds the **daily backstop** and an **emailed report**.

### Changes (`qbo-reconcile` v4, deployed)
- **Emailed report (Resend) — "if needed" only.** Sends a report **only** when the reconcile actually **prunes** ghost invoices or **aborts** on the safety cap. No email on a clean (0-ghost) run, so no inbox noise. Recipients/sender via `RECONCILE_REPORT_TO` / `RECONCILE_REPORT_FROM` (defaults: `skypace@brixbev.com` / `alerts@alamedapointbg.com`).
- **Service-role auth for the cron.** `mode=prune` now authorizes via `x-internal-secret` **OR** a service-role bearer.
- **Daily cron `qbo-reconcile-daily`** — 09:20 UTC (just after `nightly-qbo-sync`), rolling 150-day window. Created in Supabase **DISABLED** with a placeholder secret.

### ⚠ One step to activate the cron (needs the secret I don't hold)
The prune is gated on `INTERNAL_PAY_SECRET`. Drop your value in + enable:
```sql
select cron.alter_job(
  (select jobid from cron.job where jobname='qbo-reconcile-daily'),
  command := replace(command, 'REPLACE_WITH_INTERNAL_PAY_SECRET', '<your INTERNAL_PAY_SECRET>'),
  active := true
);
```
(The real-time **webhook Delete branch** already prunes deletions instantly; this cron is the safety net for any missed event.)

### Verified
- Manifest lint clean (31 writers).
- Dry sweep over 2026 = 0 ghosts (mirror matches QBO); prune-auth path tested.

https://claude.ai/code/session_01LPcEaPXmUvR3qfqqSDRxCz

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPcEaPXmUvR3qfqqSDRxCz)_