### PR TITLE
chore(sync): manual-only ResQ sync (stop cron + auto-on-load)

### DIFF
--- a/public/sync.html
+++ b/public/sync.html
@@ -275,7 +275,10 @@ APBG.auth.requireSuperadmin().then(() => {
   document.getElementById('mainApp').style.display = 'block';
   loadStatus();
   loadSyncEvents();
-  autoSyncOnLoad();
+  // MANUAL-ONLY: do not auto-sync on page load. ResQ throttled us for too much
+  // automated traffic and asked for usage that matches our ticket volume
+  // (~10/wk). The sync now runs ONLY when someone clicks "Run Sync Now"
+  // (or "⚡ Sync this WO now"). autoSyncOnLoad is intentionally NOT called.
 });
 
 // Event-driven freshness: kick a background sync whenever someone opens the


### PR DESCRIPTION
## Why
ResQ throttled the integration for too much automated traffic and asked for usage that matches our ticket volume (~10/week). This makes the sync **manual-only** so ResQ only ever sees human-initiated, ticket-proportionate activity.

## Changes
- **pg_cron job #36 disabled** (the every-5-minute ResQ sync POST) — done via `cron.alter_job(36, active := false)`.
- **Removed the auto-sync-on-page-load** in `sync.html` — opening the dashboard no longer triggers a sync.
- Result: the only things that touch ResQ now are explicit clicks — **Run Sync Now** or **⚡ Sync this WO now** — i.e. once per ticket when the ResQ email comes in. No timer, no page-load trigger.

https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_