### PR TITLE
chore(sync): declutter sync page + stop health checks auto-logging into ResQ

### DIFF
--- a/netlify/functions/health-watchdog.mjs
+++ b/netlify/functions/health-watchdog.mjs
@@ -557,19 +557,30 @@ export default async function handler(req, context) {
   const timestamp = new Date().toISOString();
   console.log(`[health-watchdog] Starting checks at ${timestamp}`);
 
+  // ResQ asked us to keep usage at ticket volume — so health checks must NOT
+  // auto-login to ResQ (the control panel auto-refreshes every 60s and the
+  // gateway probes on load; that was a ResQ login every minute, and a FAILED
+  // one while the account is deactivated). Skip ResQ unless explicitly asked
+  // with ?resq=1.
+  let includeResq = false;
+  try { includeResq = new URL(req.url).searchParams.get('resq') === '1'; } catch { /* default off */ }
+  const resqSkipped = { status: 'skipped', detail: 'ResQ health check disabled to avoid auto-login (append ?resq=1 to run it)', session: null };
+
   // Run all checks concurrently (ResQ schema depends on ResQ login)
   const [qbo, sf, resq, syncFreshness, opsSyncFreshness, cacheTableFreshness, pgNetFailures] = await Promise.all([
     checkQBO(),
     checkSF(),
-    checkResQ(),
+    includeResq ? checkResQ() : Promise.resolve(resqSkipped),
     checkSyncFreshness(),
     checkOpsSyncFreshness(),
     checkCacheTableFreshness(),
     checkPgNetFailures(),
   ]);
 
-  // Schema check uses the ResQ session from the login check
-  const resqSchema = await checkResqSchema(resq.session || null);
+  // Schema check uses the ResQ session from the login check (skipped unless asked)
+  const resqSchema = includeResq
+    ? await checkResqSchema(resq.session || null)
+    : { status: 'skipped', detail: 'skipped (ResQ check disabled)' };
 
   // Strip session from result before storing
   const { session: _, ...resqClean } = resq;

--- a/public/sync.html
+++ b/public/sync.html
@@ -275,7 +275,10 @@ APBG.auth.requireSuperadmin().then(() => {
   document.getElementById('mainApp').style.display = 'block';
   loadStatus();
   loadSyncEvents();
-  autoSyncOnLoad();
+  // MANUAL-ONLY: do not auto-sync on page load. ResQ throttled us for too much
+  // automated traffic and asked for usage that matches our ticket volume
+  // (~10/wk). The sync now runs ONLY when someone clicks "Run Sync Now"
+  // (or "⚡ Sync this WO now"). autoSyncOnLoad is intentionally NOT called.
 });
 
 // Event-driven freshness: kick a background sync whenever someone opens the

--- a/public/sync.html
+++ b/public/sync.html
@@ -155,7 +155,6 @@ td a:hover,.review-head .code a:hover,.review-job .meta a:hover{color:#2E75B6;bo
   <header>
     <h1>🔄 ResQ ↔ Service Fusion Sync</h1>
     <div class="links">
-      <a href="/billing/setup.html">Setup</a>
       <a href="/billing/">Billing Loader</a>
     </div>
   </header>
@@ -235,13 +234,7 @@ td a:hover,.review-head .code a:hover,.review-job .meta a:hover{color:#2E75B6;bo
       <div id="syncEventsBox" style="padding:12px 20px"><div class="empty">Loading…</div></div>
     </div>
 
-    <!-- Health Status -->
-    <div class="section">
-      <h2>🩺 Integration Health <span id="healthAge" style="font-weight:400;font-size:0.75rem;color:#9CA3AF"></span></h2>
-      <div id="healthGrid" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;padding:16px 20px">
-        <div style="color:#9CA3AF;font-size:0.85rem">Loading health checks...</div>
-      </div>
-    </div>
+    <!-- Integration Health moved to Master Control (/control) -->
   </div>
 </div>
 
@@ -363,8 +356,7 @@ async function loadStatus() {
     // Needs Manual Review
     renderReview(data.dedupeReport || { items: [] });
 
-    // Health checks (async, non-blocking)
-    loadHealth();
+    // Integration Health moved to Master Control (/control) — not loaded here.
 
     // Connection status (simple: if we got data, both are probably ok)
     document.getElementById('resqStatus').textContent = '✓';
@@ -642,9 +634,11 @@ function renderMappings(mappings) {
     const synced = m.lastSyncAt ? timeAgo(new Date(m.lastSyncAt)) : '—';
     const sfJob = m.sfJobId || '';
     const sfInvoiced = (m.sfStatus || '').toLowerCase().includes('invoic');
-    const expenseBtn = sfJob
-      ? `<button class="expense-btn" onclick="openExpense('${sfJob}','${m.resqCode || ''}')">💰 Bill</button>`
-        + (sfInvoiced ? '' : ` <button class="clear-btn" onclick="closeSfJob('${sfJob}','${m.resqCode || ''}')" title="Set SF job to Invoiced (closes it out)">🔒 Close</button>`)
+    // 💰 Bill moved off the sync page (lives in the control panel). Only the
+    // 🔒 Close action remains here — it sets SF to Invoiced, which the next
+    // manual sync turns into the ResQ vendor invoice.
+    const expenseBtn = (sfJob && !sfInvoiced)
+      ? `<button class="clear-btn" onclick="closeSfJob('${sfJob}','${m.resqCode || ''}')" title="Set SF job to Invoiced (closes it out)">🔒 Close</button>`
       : '—';
 
     const resqLink = resqLinkHtml(resqId, m.resqCode);


### PR DESCRIPTION
## What
Declutters the sync page per request and stops health checks from auto-logging into ResQ (critical while the account is deactivated).

### Sync page (`public/sync.html`)
- **Removed 💰 Bill** button from each WO row (kept **🔒 Close**, which still drives the invoice). Billing belongs in the control panel.
- **Removed the Setup ("settings") header link** — it already exists in Master Control.
- **Removed the 🩺 Integration Health** section and its `loadHealth()` call. Health already exists in Master Control. *Bonus:* that loader hit `health-watchdog` on every page load, which logs into ResQ.

> Settings + Integration Health already live in the Master Control panel (`/control`), so nothing had to be re-built there — they just needed to come off the sync page.

### `health-watchdog`
ResQ asked us to keep usage at ticket volume. The control panel auto-refreshes health every 60s and the gateway probes on load — each was a **ResQ login every minute** (a *failed* one while the account is deactivated, i.e. looks like brute force). The ResQ login + schema check are now **skipped unless `?resq=1`** is passed. No automated health check touches ResQ anymore.

## Net ResQ-traffic posture
Combined with disabling cron #36 and the sync page's auto-on-load, **nothing hits ResQ automatically now** — only an explicit "Run Sync" / "Sync this WO" click, or an explicit `?resq=1` health probe.

https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_