### PR TITLE
perf(sync): single-WO-by-code enrichment (kill the 500-WO scan per sync)

### DIFF
--- a/netlify/functions/lib/resq-job-notify.mjs
+++ b/netlify/functions/lib/resq-job-notify.mjs
@@ -133,11 +133,12 @@ function discoverPlan(session) {
 //              warrantyNotes, photos { url } (asset data-plate images), image
 //   facility:  address (street), addressLine2, zipCode
 //   WO images: images { url }
-// We SCAN the recent WO list (no code filter — ResQ's code filter is unreliable
-// and returns empty even for visible WOs; that's why the old code-filter lookup
-// produced empty enrichment) and match the WO by code.
-const WO_ENRICH_SCAN = `{
-  workOrders(first: 500, orderBy: "-raised_on") {
+// Target the SINGLE WO by code (R prefix stripped — that's the form ResQ's
+// `code:` filter accepts; passing it with the "R" returns empty, which is why
+// an earlier version fell back to a 500-WO scan). first:8 is a tiny safety
+// margin in case the filter returns a few; we match the exact code below.
+const WO_ENRICH_BY_CODE = (codeStripped) => `{
+  workOrders(first: 8, code: "${codeStripped}") {
     edges { node {
       code
       equipment { id name manufacturer modelNo description serialNo code warrantyNotes image photos { url } }
@@ -153,8 +154,10 @@ export async function fetchWoEnrichment(session, code) {
   const out = { photos: [], assetPhotos: [], equipment: {}, facility: {} };
   const want = String(code).replace(/^R/i, '').trim();
   const run = async (sess) => {
-    const d = await resqGql(sess, WO_ENRICH_SCAN);
+    const d = await resqGql(sess, WO_ENRICH_BY_CODE(want));
     const edges = d.data?.workOrders?.edges || [];
+    // Strict code match only — never guess from edges[0], so we can't email the
+    // wrong WO's data if the filter returns neighbors.
     return edges.find(e => String(e.node.code || '').replace(/^R/i, '') === want)?.node || null;
   };
   let node = null;

--- a/netlify/functions/resq-sf-sync.mjs
+++ b/netlify/functions/resq-sf-sync.mjs
@@ -767,17 +767,16 @@ async function handleNotifyJob(code) {
     const { resqLogin, resqGql } = await import('./resq-helpers.mjs');
     const { notifyNewResqJob } = await import('./lib/resq-job-notify.mjs');
     const want = String(code).replace(/^R/i, '').trim(); // match R-insensitively
-    // Scan recent WOs (NO code filter — ResQ's code filter is unreliable, which
-    // is why the main sync scans). Pull the full asset/facility/image fields so
-    // we build the email straight from this node — no second flaky lookup.
-    const SCAN = `{ workOrders(first: 500, orderBy: "-raised_on") { edges { node {
+    // Target the SINGLE WO by code (R stripped — the form ResQ's filter accepts).
+    // No 500-WO scan: we only ever query the one WO you entered.
+    const ONE = `{ workOrders(first: 8, code: "${want}") { edges { node {
       code title description status isUrgent serviceCategory
       facility { id name address addressLine2 zipCode }
       equipment { id name manufacturer modelNo description serialNo code warrantyNotes image photos { url } }
       images { url }
     } } } }`;
     const findNode = async (sess) => {
-      const d = await resqGql(sess, SCAN);
+      const d = await resqGql(sess, ONE);
       const edges = d.data?.workOrders?.edges || [];
       return edges.find(e => String(e.node.code || '').replace(/^R/i, '') === want)?.node || null;
     };


### PR DESCRIPTION
## What
Removes the 500-work-order scan from the per-WO paths so syncing/emailing a single WO only ever queries **that one work order**.

- **Root cause of the scan:** the enrichment was passing the WO code *with* the "R" prefix to ResQ's `code:` filter, which returns empty — so it fell back to `workOrders(first: 500)`. ResQ's filter actually works when the "R" is stripped (exactly how "⚡ Sync this WO now" already targets one WO).
- **Fix:** `fetchWoEnrichment` and `handleNotifyJob` now query `workOrders(first: 8, code: "<stripped>")` with a **strict code match** (never guess from `edges[0]`, so we can't email the wrong WO's data).

## Effect
Enter a WO number → **"⚡ Sync this WO now"** (and the email) now hit ResQ for **only that one WO** — a couple of small calls instead of pulling 500. Traffic stays proportional to the single ticket being worked.

> Note: the "▶ Run Sync Now" button still triggers the full 500-WO reconcile (the legacy all-WOs path). Recommend retiring/hiding it so the only way to sync is per-WO — happy to do that next.

https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu

---
_Generated by [Claude Code](https://claude.ai/code/session_019y5rTgXwBsLZzz1RqWwGWu)_