### PR TITLE
Domain control + gateway SSO bootstrap (Refractor + Brixpense)

### DIFF
--- a/app-expense/src/lib/hooks.ts
+++ b/app-expense/src/lib/hooks.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from './supabase';
+import { supabase, adoptGatewaySession } from './supabase';
 import type { ExpenseSettings, CogsAccount } from '@/types/expense';
 import type { Session } from '@supabase/supabase-js';
 
@@ -9,7 +9,8 @@ export function useSession() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => {
+    // Adopt the apbg-gateway SSO session first, then read the session.
+    adoptGatewaySession().then(() => supabase.auth.getSession()).then(({ data }) => {
       setSession(data.session);
       setLoading(false);
     });

--- a/app-expense/src/lib/supabase.ts
+++ b/app-expense/src/lib/supabase.ts
@@ -16,6 +16,26 @@ export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   },
 });
 
+// ── SSO with apbg-gateway ──
+// The gateway (alamedapointbg.com) writes localStorage.apbg_session on login,
+// holding a Supabase access_token + refresh_token from THIS same project.
+// Adopt it so a user who signed in at the hub flows straight into Brixpense
+// without a second login. No-op if already signed in or no gateway session.
+export async function adoptGatewaySession(): Promise<void> {
+  try {
+    const { data } = await supabase.auth.getSession();
+    if (data.session) return;
+    const raw = localStorage.getItem('apbg_session');
+    if (!raw) return;
+    const s = JSON.parse(raw);
+    if (s?.token && s?.refreshToken) {
+      await supabase.auth.setSession({ access_token: s.token, refresh_token: s.refreshToken });
+    }
+  } catch {
+    /* ignore — fall back to the in-app LoginPage */
+  }
+}
+
 /** Get the current bearer token for Netlify function calls */
 export async function getAccessToken(): Promise<string | null> {
   const { data } = await supabase.auth.getSession();

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy, useEffect, useState } from 'react';
 import type { Session } from '@supabase/supabase-js';
-import { sbAuth } from './lib/supabase';
+import { sbAuth, adoptGatewaySession } from './lib/supabase';
 import { useRoute } from './lib/router';
 import { Layout } from './components/Layout';
 import { LoginPage } from './pages/LoginPage';
@@ -40,7 +40,8 @@ export function App() {
   const [route, navTo] = useRoute();
 
   useEffect(() => {
-    sbAuth.auth.getSession().then(({ data }) => setSession(data.session));
+    // Adopt the apbg-gateway SSO session first, then read the session.
+    adoptGatewaySession().then(() => sbAuth.auth.getSession()).then(({ data }) => setSession(data.session));
     const { data: sub } = sbAuth.auth.onAuthStateChange((_event, s) => {
       setSession(s);
     });

--- a/app/src/lib/supabase.ts
+++ b/app/src/lib/supabase.ts
@@ -12,6 +12,26 @@ export const sbAuth: SupabaseClient<Database> = createClient<Database>(
   { auth: { persistSession: true, autoRefreshToken: true } },
 );
 
+// ── SSO with apbg-gateway ──
+// The gateway (alamedapointbg.com) writes localStorage.apbg_session on login,
+// holding a Supabase access_token + refresh_token from THIS same project.
+// Adopt it so a user who signed in at the hub flows straight into Refractor
+// without a second login. No-op if already signed in or no gateway session.
+export async function adoptGatewaySession(): Promise<void> {
+  try {
+    const { data } = await sbAuth.auth.getSession();
+    if (data.session) return;
+    const raw = localStorage.getItem('apbg_session');
+    if (!raw) return;
+    const s = JSON.parse(raw);
+    if (s?.token && s?.refreshToken) {
+      await sbAuth.auth.setSession({ access_token: s.token, refresh_token: s.refreshToken });
+    }
+  } catch {
+    /* ignore — fall back to the in-app LoginPage */
+  }
+}
+
 // Returns the user's bearer token if signed in, otherwise the anon key.
 export async function _sbToken(): Promise<string> {
   try {

--- a/netlify/edge-functions/require-gateway.mjs
+++ b/netlify/edge-functions/require-gateway.mjs
@@ -1,0 +1,46 @@
+// ═══ Domain control — gateway-only access ═══
+// This site should only be reached through https://alamedapointbg.com (the
+// apbg-gateway proxy). The gateway stamps every proxied request with an
+// X-APBG-Proxy header; requests without it — i.e. direct hits on
+// apbg-billing.netlify.app — get a 301 to the branded URL.
+//
+// Activation: enforcement is OFF until the APBG_PROXY_SECRET env var is set
+// on this site (same value as the header in apbg-gateway/netlify.toml).
+// Merge + deploy order: gateway first (so the header is being stamped), then
+// this, then set the env var. Unset the env var to turn it back off.
+//
+// Always allowed regardless:
+//   - deploy previews + branch deploys (hosts containing "--")
+//   - /api/* and /.netlify/* — QBO/SF OAuth callbacks, Brixpense v2 function
+//     paths, gateway health probes (health-watchdog / pacer-health), and
+//     scheduled-function invocations all hit those paths directly and carry
+//     their own auth (secrets / JWTs).
+
+const GATEWAY = 'https://alamedapointbg.com';
+
+function mapPath(pathname) {
+  // Surfaces with their own branded prefixes on the gateway
+  if (pathname.startsWith('/expense/') || pathname === '/expense') return pathname;
+  if (pathname.startsWith('/sales-next/')) return pathname;          // /sales-next/* is proxied 1:1
+  if (pathname.startsWith('/docs/')) return '/margin' + pathname;    // → /margin/docs/*
+  if (pathname === '/control.html') return '/control';
+  if (pathname === '/' || pathname === '/index.html') return '/billing/';
+  if (pathname.startsWith('/billing/')) return pathname;
+  return '/billing' + pathname;                                      // AP tool pages (sync.html, setup.html, …)
+}
+
+export default async (request, context) => {
+  const secret = Netlify.env.get('APBG_PROXY_SECRET');
+  if (!secret) return context.next(); // fail open until configured
+  if (request.headers.get('x-apbg-proxy') === secret) return context.next();
+
+  const url = new URL(request.url);
+  if (url.hostname.includes('--') || url.hostname === 'localhost') return context.next();
+
+  return Response.redirect(GATEWAY + mapPath(url.pathname) + url.search, 301);
+};
+
+export const config = {
+  path: '/*',
+  excludedPath: ['/api/*', '/.netlify/*'],
+};


### PR DESCRIPTION
Part of the **one-domain rollout**: all APBG apps reachable only via `alamedapointbg.com`, never the raw `*.netlify.app` subdomains.

## How it works
`netlify/edge-functions/require-gateway.mjs` runs on every page request:
- ✅ allowed: requests carrying the `X-APBG-Proxy` header that the apbg-gateway proxy now stamps (skypace/apbg-gateway#4)
- ✅ allowed: `/api/*` (Brixpense v2 function paths) and `/.netlify/*` (QBO/SF OAuth callbacks, `health-watchdog`/`pacer-health` probes from the hub, scheduled functions) — these carry their own secrets/JWTs
- ✅ allowed: deploy previews + branch deploys (`--` hosts)
- ⛔ everything else → 301 to the branded path: `/expense/*` and `/sales-next/*` keep their paths, `/docs/*` → `/margin/docs/*`, `/control.html` → `/control`, AP-tool pages → `/billing/<path>`

## Safe activation (no merge-order risk)
The function is a **no-op until `APBG_PROXY_SECRET` is set** on the apbg-billing Netlify site. Rollout:
1. Merge the gateway PR (header stamping)
2. Merge this PR — still no behavior change
3. Set `APBG_PROXY_SECRET` on this site (value = the header in `apbg-gateway/netlify.toml`) → enforcement on
4. To roll back: delete the env var

⚠ Note: the daily-driver billing tool is untouched functionally — same pages, same functions — only direct `apbg-billing.netlify.app` page URLs redirect once activated.

https://claude.ai/code/session_01BpjenrU9hdJiWCd1BFL72r

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpjenrU9hdJiWCd1BFL72r)_