### PR TITLE
Add MCP Connectors section to Master Control (control.html)

### DIFF
--- a/public/control.html
+++ b/public/control.html
@@ -124,6 +124,18 @@ header .links a:hover{color:#fff}
     <div id="syncCustomersBox" style="background:#fff;border:1px solid #E2E6ED;border-radius:10px;padding:16px 20px;color:#1F2937">Loading…</div>
   </div>
 
+  <div class="keepalive-section" style="margin-top:24px">
+    <h2>🔌 MCP Connectors <span style="font-weight:400;font-size:0.75rem;color:#9CA3AF">— authorize QuickBooks, Zoho Books &amp; Service Fusion for the PACER MCP servers</span></h2>
+    <div style="background:#fff;border:1px solid #E2E6ED;border-radius:10px;padding:16px 20px;color:#1F2937;display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap">
+      <div style="font-size:0.85rem;color:#374151;max-width:560px">
+        Connect or reconnect the accounting / field-service systems the
+        <code>pacerfinance</code> MCP servers (QBO, Zoho, Service Fusion) authenticate against.
+        Tokens are stored server-side in Supabase and refresh automatically — reconnect only if a connection goes red.
+      </div>
+      <a href="/pacer/connect.html" style="flex:none;background:#1F4E79;color:#fff;text-decoration:none;font-weight:600;font-size:0.85rem;padding:10px 18px;border-radius:8px">Manage MCP Connections →</a>
+    </div>
+  </div>
+
   <div class="log-section">
     <h2>Activity Log</h2>
     <div class="log" id="log"></div>


### PR DESCRIPTION
## Adds an MCP Connectors entry point to Master Control

Per request: a place in the control center to authorize the MCP connectors. Adds a **🔌 MCP Connectors** section to `public/control.html` with a **Manage MCP Connections →** button linking to `/pacer/connect.html`, where QuickBooks, Zoho Books, and Service Fusion are authorized for the `pacerfinance` MCP servers.

Static HTML only — no functions, no `ops.*` writers, so the sync-manifest lint gate is unaffected.

Companion to skypace/pacerfinance (connect page) and skypace/apbg-gateway (`/pacer/*` proxy) on the same branch.

https://claude.ai/code/session_01AQV1fAndDsszL3CwCTzDKp

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQV1fAndDsszL3CwCTzDKp)_