### PR TITLE
Refractor: wire MUI theme to the universal light/dark switch

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -8,6 +8,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#06121F" />
     <title>BRIX Refractor</title>
+    <!-- Pre-paint: honor the universal APBG theme switch (gateway waffle writes
+         localStorage.apbg_theme) before React mounts, so there's no flash.
+         theme.css overrides + the MUI theme both key off data-apbg-theme. -->
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem('apbg_theme') === 'light' ? 'light' : 'dark';
+          document.documentElement.setAttribute('data-apbg-theme', t);
+          var m = document.querySelector('meta[name="theme-color"]');
+          if (m) m.setAttribute('content', t === 'light' ? '#EEF3F8' : '#06121F');
+        } catch (e) {}
+      })();
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/app/src/lib/muiTheme.ts
+++ b/app/src/lib/muiTheme.ts
@@ -1,7 +1,7 @@
-import { createTheme } from '@mui/material/styles';
+import { createTheme, type Theme } from '@mui/material/styles';
 
-// Brix Margin Control — MUI theme. Mirrors the CSS variable tokens in
-// theme.css against the actual Brix Beverage brand:
+// Brix Margin Control (Refractor) — MUI theme. Mirrors the CSS variable tokens
+// in theme.css against the actual Brix Beverage brand:
 //   --brix      #143966   navy (logo circle, primary chrome)
 //   --ac        #5BB5F0   bubble blue (accents, the "bubble" dots above brix wordmark)
 //   --amber     #F4B400   warm secondary
@@ -10,86 +10,113 @@ import { createTheme } from '@mui/material/styles';
 //   --sf        #0E2240   surface
 //   --tx        #E6EEF7   primary text
 //   --mt        #6B8499   muted text
+//
+// The app follows the universal APBG light/dark switch (gateway waffle writes
+// localStorage.apbg_theme). `makeBrixTheme(mode)` builds the matching MUI theme;
+// the CSS-variable half of the theme flips via theme.css on
+// html[data-apbg-theme="light"]. Refractor keeps its navy/bubble-blue brand in
+// both modes — the switch just lightens the canvas.
 
-export const brixTheme = createTheme({
-  palette: {
-    mode: 'dark',
-    primary:   { main: '#5BB5F0', dark: '#3A8FCC', light: '#7ACBF5', contrastText: '#06121F' },
-    secondary: { main: '#F4B400', contrastText: '#06121F' },
-    success:   { main: '#2EB872' },
-    error:     { main: '#FF5A5F' },
-    warning:   { main: '#F4B400' },
-    info:      { main: '#5BB5F0' },
-    background: {
-      default: '#06121F',
-      paper:   '#0E2240',
+export type ThemeMode = 'light' | 'dark';
+
+export function makeBrixTheme(mode: ThemeMode): Theme {
+  const dark = mode !== 'light';
+
+  // Accent reads as the bubble blue on dark; on the white canvas we deepen it so
+  // links/accents keep contrast. The brand navy + amber are shared.
+  const accent = dark ? '#5BB5F0' : '#1F76C2';
+  const accentDark = dark ? '#3A8FCC' : '#15568F';
+  const accentLight = dark ? '#7ACBF5' : '#2A7FBF';
+
+  const paper = dark ? '#0E2240' : '#FFFFFF';
+  const canvas = dark ? '#06121F' : '#EEF3F8';
+  const fieldBorder = dark ? 'rgba(255,255,255,0.10)' : 'rgba(15,23,42,0.16)';
+  const paperBorder = dark ? 'rgba(255,255,255,0.06)' : 'rgba(15,23,42,0.08)';
+
+  return createTheme({
+    palette: {
+      mode,
+      primary:   { main: accent, dark: accentDark, light: accentLight, contrastText: '#06121F' },
+      secondary: { main: '#F4B400', contrastText: '#06121F' },
+      success:   { main: '#2EB872' },
+      error:     { main: '#FF5A5F' },
+      warning:   { main: '#F4B400' },
+      info:      { main: accent },
+      background: {
+        default: canvas,
+        paper,
+      },
+      text: {
+        primary:   dark ? '#E6EEF7' : '#0E2447',
+        secondary: dark ? '#94A8BD' : '#436081',
+        disabled:  dark ? '#5A6F84' : '#8AA0B5',
+      },
+      divider: dark ? 'rgba(255,255,255,0.08)' : 'rgba(15,23,42,0.10)',
     },
-    text: {
-      primary:   '#E6EEF7',
-      secondary: '#94A8BD',
-      disabled:  '#5A6F84',
+    shape: { borderRadius: 12 },
+    typography: {
+      fontFamily:
+        '"Inter Tight", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
+      fontSize: 12,
+      htmlFontSize: 14,
+      button: { textTransform: 'none', fontWeight: 600, letterSpacing: 0 },
+      h1: { fontFamily: '"Bricolage Grotesque", "Inter Tight", sans-serif', fontWeight: 600 },
+      h2: { fontFamily: '"Bricolage Grotesque", "Inter Tight", sans-serif', fontWeight: 600 },
+      h3: { fontFamily: '"Bricolage Grotesque", "Inter Tight", sans-serif', fontWeight: 600 },
     },
-    divider: 'rgba(255,255,255,0.08)',
-  },
-  shape: { borderRadius: 12 },
-  typography: {
-    fontFamily:
-      '"Inter Tight", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
-    fontSize: 12,
-    htmlFontSize: 14,
-    button: { textTransform: 'none', fontWeight: 600, letterSpacing: 0 },
-    h1: { fontFamily: '"Bricolage Grotesque", "Inter Tight", sans-serif', fontWeight: 600 },
-    h2: { fontFamily: '"Bricolage Grotesque", "Inter Tight", sans-serif', fontWeight: 600 },
-    h3: { fontFamily: '"Bricolage Grotesque", "Inter Tight", sans-serif', fontWeight: 600 },
-  },
-  components: {
-    MuiPaper: {
-      styleOverrides: {
-        root: {
-          backgroundImage: 'none',
-          backgroundColor: '#0E2240',
-          border: '1px solid rgba(255,255,255,0.06)',
+    components: {
+      MuiPaper: {
+        styleOverrides: {
+          root: {
+            backgroundImage: 'none',
+            backgroundColor: paper,
+            border: `1px solid ${paperBorder}`,
+          },
+        },
+      },
+      MuiButton: {
+        styleOverrides: {
+          root: { borderRadius: 10, fontWeight: 600 },
+          containedPrimary: {
+            background: `linear-gradient(135deg, ${accent} 0%, ${accentDark} 100%)`,
+            color: dark ? '#06121F' : '#FFFFFF',
+          },
+        },
+      },
+      MuiOutlinedInput: {
+        styleOverrides: {
+          root: {
+            backgroundColor: paper,
+            '& fieldset': { borderColor: fieldBorder },
+            '&:hover fieldset': { borderColor: dark ? 'rgba(91,181,240,0.40)' : 'rgba(31,118,194,0.45)' },
+          },
+        },
+      },
+      MuiCheckbox: {
+        styleOverrides: { root: { color: dark ? '#94A8BD' : '#647D96', '&.Mui-checked': { color: accent } } },
+      },
+      MuiSwitch: {
+        styleOverrides: {
+          root: {
+            '& .MuiSwitch-track': { backgroundColor: dark ? '#1B3A5E' : '#C3D2E2' },
+            '& .Mui-checked + .MuiSwitch-track': { backgroundColor: `${accent} !important` },
+          },
+        },
+      },
+      MuiTooltip: {
+        styleOverrides: {
+          tooltip: {
+            backgroundColor: dark ? '#163052' : '#143052',
+            color: '#E6EEF7',
+            border: '1px solid rgba(255,255,255,0.08)',
+            fontSize: 11,
+          },
         },
       },
     },
-    MuiButton: {
-      styleOverrides: {
-        root: { borderRadius: 10, fontWeight: 600 },
-        containedPrimary: {
-          background: 'linear-gradient(135deg, #5BB5F0 0%, #3A8FCC 100%)',
-          color: '#06121F',
-        },
-      },
-    },
-    MuiOutlinedInput: {
-      styleOverrides: {
-        root: {
-          backgroundColor: '#0E2240',
-          '& fieldset': { borderColor: 'rgba(255,255,255,0.10)' },
-          '&:hover fieldset': { borderColor: 'rgba(91,181,240,0.40)' },
-        },
-      },
-    },
-    MuiCheckbox: {
-      styleOverrides: { root: { color: '#94A8BD', '&.Mui-checked': { color: '#5BB5F0' } } },
-    },
-    MuiSwitch: {
-      styleOverrides: {
-        root: {
-          '& .MuiSwitch-track': { backgroundColor: '#1B3A5E' },
-          '& .Mui-checked + .MuiSwitch-track': { backgroundColor: '#5BB5F0 !important' },
-        },
-      },
-    },
-    MuiTooltip: {
-      styleOverrides: {
-        tooltip: {
-          backgroundColor: '#163052',
-          color: '#E6EEF7',
-          border: '1px solid rgba(255,255,255,0.08)',
-          fontSize: 11,
-        },
-      },
-    },
-  },
-});
+  });
+}
+
+// Back-compat default export — the dark theme (the app's original look).
+export const brixTheme = makeBrixTheme('dark');
+export const brixThemeLight = makeBrixTheme('light');

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode } from 'react';
+import { StrictMode, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { ThemeProvider } from '@mui/material/styles';
 import { LicenseInfo } from '@mui/x-license';
@@ -8,7 +8,7 @@ import './styles/theme.css';
 import './styles/hero.css';
 import './styles/print.css';
 import { App } from './App';
-import { brixTheme } from './lib/muiTheme';
+import { makeBrixTheme, type ThemeMode } from './lib/muiTheme';
 import { ToastProvider } from './lib/toast';
 
 // MUI X Pro license — read VITE_MUI_LICENSE_KEY at build time.
@@ -17,14 +17,53 @@ LicenseInfo.setLicenseKey(import.meta.env.VITE_MUI_LICENSE_KEY ?? '');
 const rootEl = document.getElementById('root');
 if (!rootEl) throw new Error('root element missing from index.html');
 
-createRoot(rootEl).render(
-  <StrictMode>
-    <ThemeProvider theme={brixTheme}>
+// Refractor follows the universal APBG light/dark switch. The gateway waffle
+// launcher writes localStorage.apbg_theme and fires 'apbg:themechange'; other
+// tabs/apps surface as 'storage'. We swap both the MUI theme AND the
+// data-apbg-theme attribute (theme.css keys off it) so the navy-glass UI flips
+// to its light variant. The app keeps its brand in both modes.
+function readMode(): ThemeMode {
+  try { return localStorage.getItem('apbg_theme') === 'light' ? 'light' : 'dark'; } catch { return 'dark'; }
+}
+
+function Root() {
+  const [mode, setMode] = useState<ThemeMode>(readMode);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-apbg-theme', mode);
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) meta.setAttribute('content', mode === 'light' ? '#EEF3F8' : '#06121F');
+  }, [mode]);
+
+  useEffect(() => {
+    const onTheme = (e: Event) => {
+      const t = (e as CustomEvent).detail?.theme;
+      if (t === 'light' || t === 'dark') setMode(t);
+    };
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === 'apbg_theme') setMode(e.newValue === 'light' ? 'light' : 'dark');
+    };
+    window.addEventListener('apbg:themechange', onTheme as EventListener);
+    window.addEventListener('storage', onStorage);
+    return () => {
+      window.removeEventListener('apbg:themechange', onTheme as EventListener);
+      window.removeEventListener('storage', onStorage);
+    };
+  }, []);
+
+  return (
+    <ThemeProvider theme={makeBrixTheme(mode)}>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <ToastProvider>
           <App />
         </ToastProvider>
       </LocalizationProvider>
     </ThemeProvider>
+  );
+}
+
+createRoot(rootEl).render(
+  <StrictMode>
+    <Root />
   </StrictMode>,
 );

--- a/app/src/styles/theme.css
+++ b/app/src/styles/theme.css
@@ -1004,3 +1004,76 @@ td.mn, th.mn {
   outline: 2px solid var(--ac);
   outline-offset: 2px;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   Universal light mode — html[data-apbg-theme="light"]
+   Driven by the gateway waffle's shared switch (localStorage.apbg_theme).
+   Refractor keeps its navy / bubble-blue brand; the canvas lightens. Most
+   surfaces are token-driven, so overriding the tokens flips them; a few
+   literal navy/white rules are overridden directly below.
+   ═══════════════════════════════════════════════════════════════════ */
+
+html[data-apbg-theme="light"] {
+  --bg:  #EEF3F8;
+  --sf:  #FFFFFF;
+  --sf2: #F1F5FA;
+  --sf3: #E4ECF4;
+  --bd:  #D2DEEA;
+  --bd2: #B9CBDD;
+  --tx:  #0E2447;
+  --tx2: #436081;
+  --mt:  #647D96;
+  --ac:        #1F76C2;
+  --ac2:       #15568F;
+  --ac3:       #2A7FBF;
+  --brix:      #143966;
+  --brix-deep: #0E2447;
+  --amber:     #C9920C;
+  --alameda-red: #C8102E;
+  --success: #1E9E5F;
+  --warning: #C9920C;
+  --danger:  #E0454A;
+  --info:    #1F76C2;
+  /* Glass tokens → light frosted translucency */
+  --glass-bg-card:    linear-gradient(180deg, rgba(255,255,255,0.78) 0%, rgba(244,248,252,0.62) 100%);
+  --glass-bg-card-h:  linear-gradient(180deg, rgba(255,255,255,0.92) 0%, rgba(236,243,250,0.78) 100%);
+  --glass-bg-bar:     linear-gradient(180deg, rgba(255,255,255,0.82) 0%, rgba(241,245,250,0.70) 100%);
+  --glass-bg-side:    linear-gradient(180deg, rgba(255,255,255,0.92) 0%, rgba(238,243,248,0.96) 100%);
+  --glass-bord:       1px solid rgba(15,23,42,0.10);
+  --glass-bord-h:     1px solid rgba(31,118,194,0.35);
+  --glass-edge-line:  linear-gradient(90deg, transparent 0%, rgba(31,118,194,0.40) 50%, transparent 100%);
+  /* Shadows lighter */
+  --shadow:    0 4px 14px rgba(15,23,42,0.10);
+  --shadow-lg: 0 12px 40px rgba(15,23,42,0.16);
+  --shadow-glow: 0 0 0 1px rgba(31,118,194,0.16), 0 8px 24px rgba(31,118,194,0.10);
+  --shadow-bar:  0 4px 12px rgba(31,118,194,0.16);
+  /* Card/shine gradients to light */
+  --grad-card:   linear-gradient(180deg, rgba(31,118,194,0.05) 0%, rgba(31,118,194,0) 100%);
+  --grad-shine:  linear-gradient(90deg, transparent 0%, rgba(31,118,194,0.10) 50%, transparent 100%);
+}
+
+/* Ambient page glow — recolor for a light canvas (the navy radial muddies it). */
+html[data-apbg-theme="light"] body::before {
+  background:
+    radial-gradient(ellipse 90% 60% at 18% -10%, rgba(31, 118, 194, 0.10) 0%, transparent 60%),
+    radial-gradient(ellipse 80% 50% at 85% 0%,  rgba(244, 180, 0,  0.06) 0%, transparent 55%),
+    radial-gradient(circle at 50% 110%, rgba(210, 222, 234, 0.55) 0%, transparent 70%);
+}
+
+/* Tables — white-on-dark hairlines + navy header don't read on light. */
+html[data-apbg-theme="light"] th,
+html[data-apbg-theme="light"] td { border-bottom-color: rgba(15, 23, 42, 0.08); }
+html[data-apbg-theme="light"] th { background: rgba(231, 239, 247, 0.92); }
+html[data-apbg-theme="light"] tbody tr:hover { background: rgba(31, 118, 194, 0.06); }
+
+/* Accent buttons use color:var(--bg) as "ink on the blue gradient" — that ink
+   must stay light, not follow the now-light canvas. */
+html[data-apbg-theme="light"] .seg-btn--active,
+html[data-apbg-theme="light"] .tb-btn--primary,
+html[data-apbg-theme="light"] .tb-btn--primary:hover { color: #FFFFFF; }
+
+/* Misc literal-white fills that vanish on light. */
+html[data-apbg-theme="light"] .bg { background: rgba(15, 23, 42, 0.04); }
+html[data-apbg-theme="light"] .sign-out:hover { background: rgba(15, 23, 42, 0.03); }
+/* The date picker indicator was inverted for a dark field; reset on light. */
+html[data-apbg-theme="light"] .date-input::-webkit-calendar-picker-indicator { filter: none; }


### PR DESCRIPTION
## What

Brings BRIX Margin Control (Refractor) onto the universal APBG light/dark switch. It was dark-only.

- **`muiTheme.ts`** → `makeBrixTheme(mode)` factory producing matching light + dark MUI palettes (accent deepens to `#1F76C2` on the white canvas for contrast; navy/amber brand shared). Exports `brixTheme` (dark, back-compat) + `brixThemeLight`.
- **`main.tsx`** swaps the MUI theme **and** the `data-apbg-theme` attribute live, following the gateway waffle's shared `apbg_theme` via the `apbg:themechange` event + cross-tab `storage`.
- **`index.html`** applies the theme **pre-paint** (no flash) + updates `theme-color`.
- **`theme.css`** gains a light token override on `html[data-apbg-theme="light"]` (canvas/surfaces/text/borders/glass/shadows) plus targeted fixes for navy/white literals that don't auto-flip: table hairlines + header, accent-button ink (keeps white on the blue gradient), the ambient page glow, the `.bg` badge fill, and the date-picker indicator.

Refractor keeps its navy / bubble-blue brand in both modes — the switch just lightens the canvas. **Dark stays the default.**

## Verification

- `tsc -b` clean
- `vite build` succeeds (build output not committed — Netlify regenerates `public/sales-next/`)

## Note

First-pass light mode covers the token-driven chrome + the most visible literals. A few deep hairline borders that use literal `rgba(255,255,255,…)` go faint on white; easy to tighten incrementally if anything reads thin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpjenrU9hdJiWCd1BFL72r

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpjenrU9hdJiWCd1BFL72r)_